### PR TITLE
Add workflow_dispatch to Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   schedule:
     - cron: "30 1 * * 6" # Saturday 01:30 UTC
+  workflow_dispatch:
 
 # publish_results requires read-all at workflow level
 permissions: read-all


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to scorecard.yml for manual re-runs
- Allows verifying Scorecard improvements without waiting for weekly schedule