### PR TITLE
Add CODEOWNERS and enable codeowners review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# Default reviewers for all files
+* @matrosov @yeggor
+
+# CI/CD and security-sensitive files require explicit review
+.github/ @matrosov
+deny.toml @matrosov
+Cargo.toml @matrosov


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with `@matrosov` and `@yeggor` as default reviewers
- CI/security files (`workflows/`, `deny.toml`, `Cargo.toml`) require `@matrosov` review
- Branch protection ruleset updated: requires 1 approval + codeowners review
- Improves OpenSSF Scorecard Branch-Protection and Code-Review checks