### PR TITLE
Fix vulnerability score inflating quality rating when no data exists

### DIFF
--- a/src/cli/quality.rs
+++ b/src/cli/quality.rs
@@ -242,10 +242,10 @@ fn format_quality_report(report: &QualityReport, config: &QualityConfig) -> Stri
         "  Licenses:        {:.1}/100",
         report.license_score
     ));
-    lines.push(format!(
-        "  Vulnerabilities: {:.1}/100",
-        report.vulnerability_score
-    ));
+    lines.push(match report.vulnerability_score {
+        Some(score) => format!("  Vulnerabilities: {score:.1}/100"),
+        None => "  Vulnerabilities: N/A".to_string(),
+    });
     lines.push(format!(
         "  Dependencies:    {:.1}/100",
         report.dependency_score

--- a/src/quality/scorer.rs
+++ b/src/quality/scorer.rs
@@ -292,8 +292,8 @@ pub struct QualityReport {
     pub identifier_score: f32,
     /// License quality score
     pub license_score: f32,
-    /// Vulnerability documentation score
-    pub vulnerability_score: f32,
+    /// Vulnerability documentation score (`None` if no vulnerability data)
+    pub vulnerability_score: Option<f32>,
     /// Dependency graph quality score
     pub dependency_score: f32,
     /// Hash/integrity quality score
@@ -385,12 +385,13 @@ impl QualityScorer {
         let lifecycle_score = lifecycle_metrics.quality_score();
 
         // Determine which categories are available
+        let vuln_available = vulnerability_score.is_some();
         let lifecycle_available = lifecycle_score.is_some();
         let available = [
             true,                // completeness
             true,                // identifiers
             true,                // licenses
-            true,                // vulnerabilities
+            vuln_available,      // vulnerabilities
             true,                // dependencies
             true,                // integrity
             true,                // provenance
@@ -404,7 +405,7 @@ impl QualityScorer {
             completeness_score,
             identifier_score,
             license_score,
-            vulnerability_score,
+            vulnerability_score.unwrap_or(0.0),
             dependency_score,
             integrity_score,
             provenance_score,

--- a/src/tui/views/quality.rs
+++ b/src/tui/views/quality.rs
@@ -173,8 +173,18 @@ fn render_metrics_panel_with_explanation(
         ]),
         ratatui::widgets::Row::new(vec![
             "Vulnerabilities".to_string(),
-            format!("{:.0}%", report.vulnerability_score),
-            format!("×{:.0}%", weights.3 * 100.0),
+            match report.vulnerability_score {
+                Some(score) => format!("{score:.0}%"),
+                None => "N/A".to_string(),
+            },
+            format!(
+                "×{:.0}%",
+                if report.vulnerability_score.is_some() {
+                    weights.3 * 100.0
+                } else {
+                    0.0
+                }
+            ),
             shared::explain_vulnerability_score(report),
         ]),
         ratatui::widgets::Row::new(vec![


### PR DESCRIPTION
## Summary
- `VulnerabilityMetrics::documentation_score()` returned 100/100 when an SBOM had zero vulnerability data (e.g. empty `vulnerabilities: []`), inflating the overall quality score
- Changed `documentation_score()` to return `Option<f32>`, returning `None` when no vulnerability data exists
- The scorer now treats the vulnerability category as N/A and renormalizes weights across remaining categories, matching the existing `lifecycle_score` pattern

**Before:** reporter's SBOM scored 25.6/100 with Vulnerabilities: 100.0/100
**After:** reporter's SBOM scores 18.6/100 with Vulnerabilities: N/A

## Test plan
- [x] All 711 tests pass
- [x] Zero clippy warnings
- [x] Verified with reporter's SBOM (`sbom1.json`): vulnerability score shows N/A
- [x] Verified SBOM with actual mapped vulnerabilities (`with-vulnerabilities.cdx.json`): scores 85.0/100 correctly
- [x] TUI bar chart, breakdown table, and strongest/weakest analysis all handle N/A correctly

Fixes #18