### PR TITLE
Improve Source tab: fix UTF-8 panics, add clipboard/diff/XML support

### DIFF
--- a/src/tui/app_impl_constructors.rs
+++ b/src/tui/app_impl_constructors.rs
@@ -104,6 +104,7 @@ impl App {
 
         let mut app = Self::base(AppMode::Diff, components_len, vulns_len);
         app.tabs.source = SourceDiffState::new(old_raw, new_raw);
+        app.tabs.source.populate_annotations(&diff_result);
         app.data.diff_result = Some(diff_result);
         app.data.old_sbom = Some(old_sbom);
         app.data.new_sbom = Some(new_sbom);

--- a/src/tui/events/mod.rs
+++ b/src/tui/events/mod.rs
@@ -449,6 +449,37 @@ pub fn get_yank_text(app: &super::App) -> Option<String> {
                 .get(app.tabs.diff_compliance.selected_violation)
                 .map(|v| v.message.clone())
         }
+        super::TabKind::Source => {
+            let panel = match app.tabs.source.active_side {
+                crate::tui::app_states::SourceSide::Old => &app.tabs.source.old_panel,
+                crate::tui::app_states::SourceSide::New => &app.tabs.source.new_panel,
+            };
+            match panel.view_mode {
+                super::app_states::SourceViewMode::Tree => {
+                    // Cache is already warm from rendering
+                    panel
+                        .cached_flat_items
+                        .get(panel.selected)
+                        .map(|item| {
+                            if !item.value_preview.is_empty() {
+                                // Strip surrounding quotes for string values
+                                let v = &item.value_preview;
+                                if v.starts_with('"') && v.ends_with('"') && v.len() >= 2 {
+                                    v[1..v.len() - 1].to_string()
+                                } else {
+                                    v.clone()
+                                }
+                            } else {
+                                item.node_id.clone()
+                            }
+                        })
+                }
+                super::app_states::SourceViewMode::Raw => panel
+                    .raw_lines
+                    .get(panel.selected)
+                    .map(|line| line.trim().to_string()),
+            }
+        }
         _ => None,
     }
 }

--- a/src/tui/events/source.rs
+++ b/src/tui/events/source.rs
@@ -61,22 +61,36 @@ pub fn handle_source_keys(app: &mut App, key: KeyEvent) {
             }
         }
         KeyCode::Left | KeyCode::Char('h') => {
-            // Collapse: only if expanded
-            let node_id = get_active_expandable_node(&mut app.tabs.source, Some(true));
-            if let Some(id) = node_id {
-                app.tabs.source.active_panel_mut().toggle_expand(&id);
+            if app.tabs.source.active_panel_mut().view_mode == SourceViewMode::Raw {
+                app.tabs.source.active_panel_mut().scroll_left();
                 if app.tabs.source.is_synced() {
-                    sync_expand_to_inactive(&mut app.tabs.source, &id);
+                    app.tabs.source.inactive_panel_mut().scroll_left();
+                }
+            } else {
+                // Collapse: only if expanded
+                let node_id = get_active_expandable_node(&mut app.tabs.source, Some(true));
+                if let Some(id) = node_id {
+                    app.tabs.source.active_panel_mut().toggle_expand(&id);
+                    if app.tabs.source.is_synced() {
+                        sync_expand_to_inactive(&mut app.tabs.source, &id);
+                    }
                 }
             }
         }
         KeyCode::Right | KeyCode::Char('l') => {
-            // Expand: only if collapsed
-            let node_id = get_active_expandable_node(&mut app.tabs.source, Some(false));
-            if let Some(id) = node_id {
-                app.tabs.source.active_panel_mut().toggle_expand(&id);
+            if app.tabs.source.active_panel_mut().view_mode == SourceViewMode::Raw {
+                app.tabs.source.active_panel_mut().scroll_right();
                 if app.tabs.source.is_synced() {
-                    sync_expand_to_inactive(&mut app.tabs.source, &id);
+                    app.tabs.source.inactive_panel_mut().scroll_right();
+                }
+            } else {
+                // Expand: only if collapsed
+                let node_id = get_active_expandable_node(&mut app.tabs.source, Some(false));
+                if let Some(id) = node_id {
+                    app.tabs.source.active_panel_mut().toggle_expand(&id);
+                    if app.tabs.source.is_synced() {
+                        sync_expand_to_inactive(&mut app.tabs.source, &id);
+                    }
                 }
             }
         }
@@ -90,6 +104,25 @@ pub fn handle_source_keys(app: &mut App, key: KeyEvent) {
             app.tabs.source.active_panel_mut().expand_all();
             if app.tabs.source.is_synced() {
                 app.tabs.source.inactive_panel_mut().expand_all();
+            }
+        }
+        // Fold depth presets: Shift+1/2/3
+        KeyCode::Char('!') => {
+            app.tabs.source.active_panel_mut().expand_to_depth(1);
+            if app.tabs.source.is_synced() {
+                app.tabs.source.inactive_panel_mut().expand_to_depth(1);
+            }
+        }
+        KeyCode::Char('@') => {
+            app.tabs.source.active_panel_mut().expand_to_depth(2);
+            if app.tabs.source.is_synced() {
+                app.tabs.source.inactive_panel_mut().expand_to_depth(2);
+            }
+        }
+        KeyCode::Char('#') => {
+            app.tabs.source.active_panel_mut().expand_to_depth(3);
+            if app.tabs.source.is_synced() {
+                app.tabs.source.inactive_panel_mut().expand_to_depth(3);
             }
         }
         _ => {}

--- a/src/tui/views/source.rs
+++ b/src/tui/views/source.rs
@@ -2,8 +2,10 @@
 
 use crate::tui::app::App;
 use crate::tui::app_states::SourceSide;
+use crate::tui::app_states::source::SourceDiffState;
 use crate::tui::shared::source::render_source_panel;
 use ratatui::prelude::*;
+use std::fmt::Write;
 
 /// Render the source tab with side-by-side old/new SBOM panels.
 pub fn render_source(frame: &mut Frame, area: Rect, app: &mut App) {
@@ -16,8 +18,14 @@ pub fn render_source(frame: &mut Frame, area: Rect, app: &mut App) {
     let active = source.active_side;
     let sync_label = if source.is_synced() { " [sync]" } else { "" };
 
-    let old_title = format!("Old SBOM{sync_label}");
-    let new_title = format!("New SBOM{sync_label}");
+    let (old_a, old_r, old_m) = SourceDiffState::annotation_counts(&source.old_panel);
+    let (new_a, new_r, new_m) = SourceDiffState::annotation_counts(&source.new_panel);
+
+    let old_badge = format_change_badge(old_a, old_r, old_m);
+    let new_badge = format_change_badge(new_a, new_r, new_m);
+
+    let old_title = format!("Old SBOM{sync_label}{old_badge}");
+    let new_title = format!("New SBOM{sync_label}{new_badge}");
 
     render_source_panel(
         frame,
@@ -33,4 +41,22 @@ pub fn render_source(frame: &mut Frame, area: Rect, app: &mut App) {
         &new_title,
         active == SourceSide::New,
     );
+}
+
+/// Format a compact badge string showing change counts.
+fn format_change_badge(added: usize, removed: usize, modified: usize) -> String {
+    if added == 0 && removed == 0 && modified == 0 {
+        return String::new();
+    }
+    let mut badge = String::new();
+    if added > 0 {
+        let _ = write!(badge, " +{added}");
+    }
+    if removed > 0 {
+        let _ = write!(badge, " -{removed}");
+    }
+    if modified > 0 {
+        let _ = write!(badge, " ~{modified}");
+    }
+    badge
 }


### PR DESCRIPTION
## Summary
- Fix 7 unsafe byte-slice truncations that could panic on emoji/CJK content
- Add clipboard support, diff change highlighting, horizontal scroll, XML tree parsing, and fold depth presets to the Source tab
- Enrich vulnerability context in SBOM Map panel with CVE details, severity, and KEV status

## Test plan
- [ ] `cargo build --all-features` — 0 warnings
- [ ] `cargo clippy --all-features -- -D warnings` — clean
- [ ] `cargo test --all-features` — 762 tests pass
- [ ] Manual: view mode source tab (tree/raw, search, clipboard, fold depth)
- [ ] Manual: diff mode source tab (highlighting, sync, panel switching)
- [ ] Manual: horizontal scroll in raw mode with Left/Right arrows