### PR TITLE
Source tab v2: 12 new features

### DIFF
--- a/src/tui/export.rs
+++ b/src/tui/export.rs
@@ -513,6 +513,32 @@ th { background: #313244; color: #89b4fa; font-weight: 600; }
     html
 }
 
+/// Export raw source content to a file.
+///
+/// Detects XML vs JSON from content prefix and writes to `sbom-source-{label}.{ext}`.
+pub fn export_source_content(content: &str, label: &str) -> ExportResult {
+    let ext = if content.trim_start().starts_with('<') {
+        "xml"
+    } else {
+        "json"
+    };
+    let filename = format!("sbom-source-{label}.{ext}");
+    let path = PathBuf::from(&filename);
+
+    match write_to_file(&path, content) {
+        Ok(actual_path) => ExportResult {
+            message: format!("Source exported to {}", display_path(&actual_path)),
+            path: actual_path,
+            success: true,
+        },
+        Err(e) => ExportResult {
+            path,
+            success: false,
+            message: format!("Failed to write: {e}"),
+        },
+    }
+}
+
 /// Escape a value for CSV: double any embedded quotes.
 fn csv_escape(s: &str) -> String {
     s.replace('"', "\"\"")

--- a/src/tui/view/app.rs
+++ b/src/tui/view/app.rs
@@ -883,6 +883,7 @@ impl ViewApp {
                         &mut items,
                         true,
                         &[],
+                        self.source_state.sort_mode,
                     );
                     if let Some(item) = items.get(self.source_state.selected)
                         && item.is_expandable
@@ -938,6 +939,7 @@ impl ViewApp {
                     &mut items,
                     true,
                     &[],
+                    self.source_state.sort_mode,
                 );
                 if let Some(idx) = items.iter().position(|item| item.node_id == target_id) {
                     self.source_state.selected = idx;
@@ -982,6 +984,7 @@ impl ViewApp {
             &mut items,
             true,
             &[],
+            self.source_state.sort_mode,
         );
         let item = items.get(self.source_state.selected)?;
         let parts: Vec<&str> = item.node_id.split('.').collect();

--- a/src/tui/views/source.rs
+++ b/src/tui/views/source.rs
@@ -3,18 +3,37 @@
 use crate::tui::app::App;
 use crate::tui::app_states::SourceSide;
 use crate::tui::app_states::source::SourceDiffState;
-use crate::tui::shared::source::render_source_panel;
+use crate::tui::shared::source::{render_source_panel, render_str};
+use crate::tui::theme::colors;
 use ratatui::prelude::*;
+use ratatui::widgets::{Block, Borders, Scrollbar, ScrollbarOrientation, ScrollbarState};
 use std::fmt::Write;
 
 /// Render the source tab with side-by-side old/new SBOM panels.
 pub fn render_source(frame: &mut Frame, area: Rect, app: &mut App) {
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(area);
-
     let source = &mut app.tabs.source;
+    let show_detail = source.show_detail;
+
+    // When detail panel is visible: 38% / 38% / 24%
+    let main_area = if show_detail {
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Percentage(38),
+                Constraint::Percentage(38),
+                Constraint::Percentage(24),
+            ])
+            .split(area);
+        render_detail_panel(frame, chunks[2], source);
+        (chunks[0], chunks[1])
+    } else {
+        let chunks = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(area);
+        (chunks[0], chunks[1])
+    };
+
     let active = source.active_side;
     let sync_label = if source.is_synced() { " [sync]" } else { "" };
 
@@ -29,18 +48,73 @@ pub fn render_source(frame: &mut Frame, area: Rect, app: &mut App) {
 
     render_source_panel(
         frame,
-        chunks[0],
+        main_area.0,
         &mut source.old_panel,
         &old_title,
         active == SourceSide::Old,
     );
     render_source_panel(
         frame,
-        chunks[1],
+        main_area.1,
         &mut source.new_panel,
         &new_title,
         active == SourceSide::New,
     );
+}
+
+/// Render the detail panel showing info about the selected item.
+fn render_detail_panel(frame: &mut Frame, area: Rect, source: &mut SourceDiffState) {
+    let scheme = colors();
+
+    let detail_text = source.get_selected_detail().unwrap_or_default();
+    let lines: Vec<&str> = detail_text.lines().collect();
+    let total_lines = lines.len();
+
+    let block = Block::default()
+        .title(" Detail ")
+        .title_style(Style::default().fg(scheme.accent).bold())
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(scheme.accent));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.width < 2 || inner.height < 1 {
+        return;
+    }
+
+    let visible_height = inner.height as usize;
+    // Clamp scroll
+    if source.detail_scroll > total_lines.saturating_sub(visible_height) {
+        source.detail_scroll = total_lines.saturating_sub(visible_height);
+    }
+
+    for (i, line) in lines
+        .iter()
+        .skip(source.detail_scroll)
+        .take(visible_height)
+        .enumerate()
+    {
+        let y = inner.y + i as u16;
+        // Word-wrap: just truncate for now (detail values are typically short)
+        render_str(
+            frame.buffer_mut(),
+            inner.x,
+            y,
+            line,
+            inner.width,
+            Style::default().fg(scheme.text),
+        );
+    }
+
+    // Scrollbar
+    if total_lines > visible_height {
+        let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            .thumb_style(Style::default().fg(scheme.accent))
+            .track_style(Style::default().fg(scheme.muted));
+        let mut sb_state = ScrollbarState::new(total_lines).position(source.detail_scroll);
+        frame.render_stateful_widget(scrollbar, inner, &mut sb_state);
+    }
 }
 
 /// Format a compact badge string showing change counts.


### PR DESCRIPTION
## Summary
- Add mouse click/scroll support for Source tab in both diff and view modes
- Add XML syntax highlighting, line numbers toggle, word wrap, and status bar
- Add change navigation (`n`/`N`), JSON path copy (`c`), source export (`E`)
- Add regex search (`Ctrl+R`), bookmarks (`m`/`'`), detail panel (`d`)
- Add tree filter by value type (`f`) and sort by key (`S`)

## Test plan
- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all-features -- -D warnings`
- [ ] `cargo test --all-features`
- [ ] Manual: `cargo run -- view tests/fixtures/cyclonedx/cdx-1.6-full.json` — verify all Source tab features
- [ ] Manual: `cargo run -- diff tests/fixtures/demo-old.cdx.json tests/fixtures/demo-new.cdx.json` — verify diff features + detail panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)