### PR TITLE
Fix OSV scanner false positives from SBOM test fixtures

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,42 @@
+# OSV-Scanner configuration for sbom-tools
+#
+# This project contains SBOM test fixtures with intentionally old/vulnerable
+# package versions (npm, pypi, maven, gem, composer) for testing the diff
+# and analysis features. These are NOT actual dependencies — they are data
+# files parsed by the tool. Only Rust (Cargo.lock) dependencies are real.
+
+# Ignore all non-Rust ecosystem packages found in test fixtures
+[[PackageOverrides]]
+ecosystem = "npm"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "PyPI"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "Maven"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "RubyGems"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "Packagist"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "Go"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "NuGet"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"


### PR DESCRIPTION
## Summary
- Add `osv-scanner.toml` to ignore non-Rust ecosystem packages (npm, PyPI, Maven, RubyGems, Packagist, Go, NuGet) found in SBOM test fixtures
- These are data files parsed by the tool, not actual dependencies — only Cargo.lock dependencies are real
- Also updated branch protection ruleset to require review thread resolution

Addresses OpenSSF Scorecard Vulnerabilities check (78 false positives from test fixture PURLs).

## Test plan
- [ ] `cargo test --all-features` still passes (no fixture changes)
- [ ] OSV scanner respects the config and stops flagging fixture packages
- [ ] Scorecard Vulnerabilities check improves on next rescan

🤖 Generated with [Claude Code](https://claude.com/claude-code)