### PR TITLE
Add community and governance docs for OpenSSF Silver badge

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,100 @@
+# Architecture
+
+High-level overview of the sbom-tools codebase (~85K LOC, ~200 Rust files).
+
+## Module Structure
+
+```
+src/
+  cli/          Command handlers (clap-based)
+  config/       YAML/JSON configuration, presets, validation
+  model/        Canonical SBOM representation
+  parsers/      Format detection + parsing
+  matching/     Multi-tier fuzzy component matching
+  diff/         Semantic diffing engine
+  enrichment/   OSV/KEV vulnerability data, EOL detection, VEX
+  quality/      Quality scoring engine + compliance standards
+  pipeline/     Orchestration: parse -> enrich -> diff -> report
+  reports/      Output format generators
+  tui/          Interactive terminal UI (ratatui)
+  watch/        Continuous SBOM monitoring
+```
+
+## Data Flow
+
+```
+Input SBOMs (CycloneDX/SPDX)
+    |
+    v
+  Parsers ──> NormalizedSbom (canonical model)
+    |
+    v
+  Enrichment (OSV, KEV, EOL)  [optional, feature-gated]
+    |
+    v
+  Matching Engine ──> Component pairs
+    |
+    v
+  Diff Engine ──> ChangeSet (added/removed/modified)
+    |
+    v
+  Reports / TUI
+```
+
+## Key Design Decisions
+
+### Canonical Model (`model/`)
+All SBOM formats are normalized into `NormalizedSbom` with `Component`, `Vulnerability`, and `Dependency` types. This allows format-agnostic diffing and analysis.
+
+### Multi-Tier Matching (`matching/`)
+Components are matched across SBOMs using a tiered strategy:
+1. Exact PURL match
+2. Alias lookup (known package renames)
+3. Ecosystem-specific normalization
+4. String similarity with adaptive thresholds
+5. LSH indexing for large SBOMs
+
+### Quality Scoring (`quality/`)
+8-category scoring engine (v2.0) with 6 profiles. N/A-aware weight renormalization handles missing data gracefully. Hard caps enforce minimum standards (e.g., EOL components cap grade at D).
+
+### Compliance (`quality/`)
+9 standards: NTIA, CRA Phase 1/2, FDA, NIST SSDF, EO 14028, plus Minimum and Comprehensive. Each standard defines required fields and produces SARIF-compatible findings.
+
+### TUI (`tui/`)
+Built on ratatui with crossterm backend. Two parallel systems exist:
+- Legacy `App` struct for diff mode (tabs: Summary, Components, Vulnerabilities, Dependencies, Compliance, Source)
+- `ViewState` trait for view mode (only Quality tab migrated so far)
+
+### Streaming Parser (`parsers/`)
+SBOMs larger than 512MB are parsed with a streaming strategy to avoid memory exhaustion.
+
+### Pipeline (`pipeline/`)
+`PipelineError` provides structured errors across stages. `build_enrichment_config()` centralizes feature-gated enrichment setup.
+
+## Error Handling
+
+- `thiserror` for library error types
+- `anyhow` for CLI error propagation
+- `PipelineError` for pipeline stage errors
+- Zero `unwrap()` in production; ~22 `expect()` calls, all safe-by-construction
+
+## Feature Flags
+
+- `enrichment` (default) — enables OSV/KEV vulnerability enrichment and EOL detection
+- `vex` — enables OpenVEX integration
+
+## Testing
+
+- 762+ tests (unit + integration)
+- Property-based testing via `proptest`
+- Fuzz targets for all parser formats (`cargo-fuzz`)
+- Golden fixture tests for format compatibility
+- Integration tests in `tests/` covering pipeline, CLI, CRA, query, VEX, watch, and graph
+
+## CI/CD
+
+- 10 CI jobs: lint, MSRV, 4 platform tests, 2 cargo-deny, security audit, gate
+- CodeQL for static analysis
+- OpenSSF Scorecard for security posture
+- Trusted Publishing (OIDC) for crates.io releases
+- SLSA Build Level 3 provenance for releases

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+## Our Pledge
+
+We are committed to making participation in this project a welcoming experience for everyone, regardless of background or identity.
+
+## Our Standards
+
+Positive behaviors include using inclusive language, respecting differing viewpoints, accepting constructive feedback gracefully, and focusing on what is best for the community.
+
+Unacceptable behaviors include trolling, personal attacks, publishing others' private information without permission, and any conduct that would be considered inappropriate in a professional setting.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported via [GitHub Private Reporting](https://github.com/sbom-tool/sbom-tools/security/advisories/new) or by contacting the maintainers listed in `Cargo.toml`.
+
+The project team will review all complaints and respond appropriately. Maintainers who do not follow or enforce this Code of Conduct may face consequences as determined by project leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to sbom-tools
+
+Thank you for your interest in contributing!
+
+## Getting Started
+
+1. Fork the repository
+2. Create a feature branch from `main`
+3. Make your changes
+4. Run the checks: `cargo fmt --check && cargo clippy --all-features -- -D warnings && cargo test --all-features`
+5. Open a pull request
+
+## Development Requirements
+
+- Rust 1.88+ (see `rust-toolchain.toml`)
+- All PRs must pass CI (lint, test, cargo-deny, CodeQL)
+- All PRs require at least one approving review
+
+## Code Style
+
+- Run `cargo fmt` before committing
+- Zero clippy warnings (`cargo clippy --all-features -- -D warnings`)
+- No `unwrap()` in production code; use `expect()` only when safe-by-construction
+- Prefer `&str` over `&String`, `&[T]` over `&Vec<T>`
+- Use `thiserror` for library errors, `anyhow` for CLI
+
+## Developer Certificate of Origin (DCO)
+
+By contributing to this project, you certify that your contribution was created in whole or in part by you and you have the right to submit it under the MIT license. This is the [Developer Certificate of Origin](https://developercertificate.org/).
+
+You do not need to sign off each commit, but by submitting a pull request you agree to the DCO.
+
+## Reporting Issues
+
+- **Bugs:** Open a [GitHub Issue](https://github.com/sbom-tool/sbom-tools/issues)
+- **Security vulnerabilities:** See [SECURITY.md](SECURITY.md) (do NOT open a public issue)
+
+## Pull Request Guidelines
+
+- Keep PRs focused on a single change
+- Include tests for new functionality
+- Update documentation if behavior changes
+- PRs are squash-merged by default

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,53 @@
+# Governance
+
+## Project Model
+
+sbom-tools follows a Benevolent Dictator For Life (BDFL) governance model, common for single-maintainer open source projects at this stage.
+
+## Roles
+
+### Maintainer (BDFL)
+
+- **Alex Matrosov** ([@matrosov](https://github.com/matrosov))
+- Final authority on project direction, releases, and code review
+- Responsible for security response (see [SECURITY.md](SECURITY.md))
+
+### Contributors
+
+Anyone who submits a pull request, opens an issue, or participates in discussions. All contributions are welcome and reviewed by the maintainer.
+
+### Code Owners
+
+The `CODEOWNERS` file defines review assignment. All changes require maintainer approval.
+
+## Decision Making
+
+- **Day-to-day decisions** (bug fixes, minor features): Maintainer discretion
+- **Significant changes** (new commands, architecture, breaking changes): Discussed in a GitHub Issue or PR before implementation
+- **Standards and compliance** (new compliance profiles, scoring changes): Documented in the PR with rationale
+
+## Releases
+
+- Versioned with [Semantic Versioning](https://semver.org/)
+- Published to [crates.io](https://crates.io/crates/sbom-tools) via automated CI
+- Release notes follow the [template](https://github.com/sbom-tool/sbom-tools/releases)
+
+## Access Continuity
+
+- Repository is owned by the `sbom-tool` GitHub organization
+- Organization admin access is separate from personal accounts
+- If the maintainer becomes unavailable, organization admins can grant access to new maintainers
+- All CI/CD uses OIDC tokens (no long-lived secrets that would expire)
+
+## Evolving Governance
+
+As the project grows, this governance model will evolve. Potential future steps:
+
+- Add co-maintainers with commit access
+- Establish a core team for shared decision making
+- Adopt a consensus-based model if multiple active maintainers emerge
+
+## Contact
+
+- GitHub Issues for public discussion
+- Security reports via [SECURITY.md](SECURITY.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,8 @@ If you discover a security vulnerability in sbom-tools, please report it respons
   - **Critical/High:** Patch release within 7 days
   - **Medium:** Patch in the next scheduled release
   - **Low:** Fix queued for a future release
-- You will be credited in the release notes (unless you prefer anonymity)
+- You will be credited in the release notes and GitHub Security Advisory (unless you prefer anonymity)
+- We follow [coordinated vulnerability disclosure](https://en.wikipedia.org/wiki/Coordinated_vulnerability_disclosure)
 
 ### Scope
 


### PR DESCRIPTION
## Summary
- Add `CODE_OF_CONDUCT.md` — Contributor Covenant v2.1
- Add `CONTRIBUTING.md` — development guide with DCO requirement
- Add `GOVERNANCE.md` — BDFL model, roles, access continuity plan
- Add `ARCHITECTURE.md` — high-level codebase overview
- Update `SECURITY.md` — explicit reporter credit and coordinated disclosure

These files satisfy prerequisites for the OpenSSF Best Practices Silver badge (CII-Best-Practices scorecard check, currently 5/10 → target 7/10).

## Test plan
- [ ] Verify all links in the new docs resolve correctly
- [ ] Complete Silver badge questionnaire at bestpractices.dev after merge
- [ ] Confirm CII-Best-Practices score improves on next Scorecard rescan

🤖 Generated with [Claude Code](https://claude.com/claude-code)