### PR TITLE
Fix publish workflow ancestor check

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -58,7 +58,7 @@ jobs:
             exit 1
           fi
 
-          git fetch --no-tags --depth=1 origin main
+          git fetch --no-tags origin main
           if ! git merge-base --is-ancestor "${GITHUB_SHA}" "origin/main"; then
             echo "::error::Tagged commit ${GITHUB_SHA} is not on origin/main."
             exit 1


### PR DESCRIPTION
## Summary
- Remove `--depth=1` from `git fetch origin main` in the publish workflow's tag verification step

## Problem
The shallow fetch only gets the tip commit of main, so `merge-base --is-ancestor` fails when the tagged commit is even 1 commit behind HEAD of main (e.g., when a post-release PR is merged before the publish workflow runs).

## Fix
Use full fetch since the checkout already uses `fetch-depth: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)