### PR TITLE
Fix 78 false positive vulnerabilities in Scorecard

### DIFF
--- a/tests/fixtures/cyclonedx/osv-scanner.toml
+++ b/tests/fixtures/cyclonedx/osv-scanner.toml
@@ -1,0 +1,37 @@
+# These are SBOM test fixtures, not actual dependencies.
+# Ignore all non-Rust ecosystem packages found by osv-scanner.
+
+[[PackageOverrides]]
+ecosystem = "npm"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "PyPI"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "Maven"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "RubyGems"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "Packagist"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "Go"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "NuGet"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"

--- a/tests/fixtures/osv-scanner.toml
+++ b/tests/fixtures/osv-scanner.toml
@@ -1,0 +1,37 @@
+# These are SBOM test fixtures, not actual dependencies.
+# Ignore all non-Rust ecosystem packages found by osv-scanner.
+
+[[PackageOverrides]]
+ecosystem = "npm"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "PyPI"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "Maven"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "RubyGems"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "Packagist"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "Go"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "NuGet"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"

--- a/tests/fixtures/spdx/osv-scanner.toml
+++ b/tests/fixtures/spdx/osv-scanner.toml
@@ -1,0 +1,37 @@
+# These are SBOM test fixtures, not actual dependencies.
+# Ignore all non-Rust ecosystem packages found by osv-scanner.
+
+[[PackageOverrides]]
+ecosystem = "npm"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "PyPI"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "Maven"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "RubyGems"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "Packagist"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "Go"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"
+
+[[PackageOverrides]]
+ecosystem = "NuGet"
+ignore = true
+reason = "SBOM test fixture data, not actual dependencies"


### PR DESCRIPTION
## Summary
- Add `osv-scanner.toml` config files to `tests/fixtures/`, `tests/fixtures/cyclonedx/`, and `tests/fixtures/spdx/`
- osv-scanner config [does not propagate to child directories](https://google.github.io/osv-scanner/configuration/), so the existing root-level config was ineffective for fixture files
- All 53 non-Rust packages (npm, PyPI, Maven, RubyGems, Packagist, Go, NuGet) in SBOM test fixtures are now filtered out

## Test plan
- [x] `osv-scanner scan --recursive .` reports 0 vulnerabilities (was 78)
- [x] `cargo test --locked --all-features` passes
- [ ] Scorecard Vulnerabilities check should improve from 0/10 after next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)