### PR TITLE
CBOM quality scoring engine, metrics enrichment, and TUI polish

### DIFF
--- a/src/cli/quality.rs
+++ b/src/cli/quality.rs
@@ -98,9 +98,10 @@ fn parse_scoring_profile(profile_name: &str) -> Result<ScoringProfile> {
         "license-compliance" | "license" => Ok(ScoringProfile::LicenseCompliance),
         "cra" | "cyber-resilience" => Ok(ScoringProfile::Cra),
         "comprehensive" | "full" => Ok(ScoringProfile::Comprehensive),
+        "cbom" | "cryptographic" => Ok(ScoringProfile::Cbom),
         _ => {
             bail!(
-                "Unknown scoring profile: {profile_name}. Valid options: minimal, standard, security, license-compliance, cra, comprehensive"
+                "Unknown scoring profile: {profile_name}. Valid options: minimal, standard, security, license-compliance, cra, comprehensive, cbom"
             );
         }
     }

--- a/src/quality/metrics.rs
+++ b/src/quality/metrics.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use crate::model::{
     CompletenessDeclaration, ComponentType, CreatorType, CryptoAssetType, CryptoMaterialState,
-    EolStatus, ExternalRefType, HashAlgorithm, NormalizedSbom, StalenessLevel,
+    CryptoPrimitive, EolStatus, ExternalRefType, HashAlgorithm, NormalizedSbom, StalenessLevel,
 };
 use serde::{Deserialize, Serialize};
 
@@ -1449,6 +1449,36 @@ pub struct CryptographyMetrics {
     pub inadequate_key_sizes: usize,
     /// Names of weak/broken algorithms found
     pub weak_algorithm_names: Vec<String>,
+
+    // --- Algorithm completeness (slot 1: Crpt) ---
+    /// Algorithms with an OID identifier
+    pub algorithms_with_oid: usize,
+    /// Algorithms with `algorithm_family` set
+    pub algorithms_with_family: usize,
+    /// Algorithms with a recognized primitive (not `Other`)
+    pub algorithms_with_primitive: usize,
+    /// Algorithms with classical or quantum security level set
+    pub algorithms_with_security_level: usize,
+
+    // --- Cross-reference resolution (slot 4: Refs) ---
+    /// Certificates with `signature_algorithm_ref` set
+    pub certs_with_signature_algo_ref: usize,
+    /// Keys with `algorithm_ref` set
+    pub keys_with_algorithm_ref: usize,
+    /// Protocols with at least one cipher suite
+    pub protocols_with_cipher_suites: usize,
+
+    // --- Key lifecycle (slot 5: Life) ---
+    /// Keys with `state` tracked
+    pub keys_with_state: usize,
+    /// Keys with `secured_by` protection
+    pub keys_with_protection: usize,
+    /// Keys with `creation_date` or `activation_date`
+    pub keys_with_lifecycle_dates: usize,
+
+    // --- Certificate health (slot 5: Life) ---
+    /// Certificates with both `not_valid_before` and `not_valid_after`
+    pub certs_with_validity_dates: usize,
 }
 
 impl CryptographyMetrics {
@@ -1470,7 +1500,21 @@ impl CryptographyMetrics {
             match cp.asset_type {
                 CryptoAssetType::Algorithm => {
                     m.algorithms_count += 1;
+                    if cp.oid.is_some() {
+                        m.algorithms_with_oid += 1;
+                    }
                     if let Some(algo) = &cp.algorithm_properties {
+                        if algo.algorithm_family.is_some() {
+                            m.algorithms_with_family += 1;
+                        }
+                        if !matches!(algo.primitive, CryptoPrimitive::Other(_)) {
+                            m.algorithms_with_primitive += 1;
+                        }
+                        if algo.classical_security_level.is_some()
+                            || algo.nist_quantum_security_level.is_some()
+                        {
+                            m.algorithms_with_security_level += 1;
+                        }
                         if algo.is_quantum_safe() {
                             m.quantum_safe_count += 1;
                         } else if algo.nist_quantum_security_level == Some(0) {
@@ -1488,6 +1532,12 @@ impl CryptographyMetrics {
                 CryptoAssetType::Certificate => {
                     m.certificates_count += 1;
                     if let Some(cert) = &cp.certificate_properties {
+                        if cert.not_valid_before.is_some() && cert.not_valid_after.is_some() {
+                            m.certs_with_validity_dates += 1;
+                        }
+                        if cert.signature_algorithm_ref.is_some() {
+                            m.certs_with_signature_algo_ref += 1;
+                        }
                         if cert.is_expired() {
                             m.expired_certificates += 1;
                         } else if cert.is_expiring_soon(90) {
@@ -1498,6 +1548,18 @@ impl CryptographyMetrics {
                 CryptoAssetType::RelatedCryptoMaterial => {
                     m.keys_count += 1;
                     if let Some(mat) = &cp.related_crypto_material_properties {
+                        if mat.state.is_some() {
+                            m.keys_with_state += 1;
+                        }
+                        if mat.secured_by.is_some() {
+                            m.keys_with_protection += 1;
+                        }
+                        if mat.creation_date.is_some() || mat.activation_date.is_some() {
+                            m.keys_with_lifecycle_dates += 1;
+                        }
+                        if mat.algorithm_ref.is_some() {
+                            m.keys_with_algorithm_ref += 1;
+                        }
                         if mat.state == Some(CryptoMaterialState::Compromised) {
                             m.compromised_keys += 1;
                         }
@@ -1516,6 +1578,11 @@ impl CryptographyMetrics {
                 }
                 CryptoAssetType::Protocol => {
                     m.protocols_count += 1;
+                    if let Some(proto) = &cp.protocol_properties
+                        && !proto.cipher_suites.is_empty()
+                    {
+                        m.protocols_with_cipher_suites += 1;
+                    }
                 }
                 _ => {}
             }
@@ -1565,6 +1632,122 @@ impl CryptographyMetrics {
         score += (self.hybrid_pqc_count as f32 * 2.0).min(10.0);
 
         Some(score.clamp(0.0, 100.0))
+    }
+
+    // ----- Per-category scores for CBOM ScoringProfile -----
+
+    /// Crypto completeness: how fully documented are the crypto assets?
+    #[must_use]
+    pub fn crypto_completeness_score(&self) -> f32 {
+        if self.algorithms_count == 0 {
+            return 100.0;
+        }
+        let family_pct = self.algorithms_with_family as f32 / self.algorithms_count as f32;
+        let primitive_pct = self.algorithms_with_primitive as f32 / self.algorithms_count as f32;
+        let level_pct = self.algorithms_with_security_level as f32 / self.algorithms_count as f32;
+        (family_pct * 40.0 + primitive_pct * 30.0 + level_pct * 30.0).clamp(0.0, 100.0)
+    }
+
+    /// Crypto identifier quality: OID coverage.
+    #[must_use]
+    pub fn crypto_identifier_score(&self) -> f32 {
+        if self.algorithms_count == 0 {
+            return 100.0;
+        }
+        let oid_pct = self.algorithms_with_oid as f32 / self.algorithms_count as f32;
+        (oid_pct * 100.0).clamp(0.0, 100.0)
+    }
+
+    /// Algorithm strength: penalizes broken/weak/quantum-vulnerable algorithms.
+    #[must_use]
+    pub fn algorithm_strength_score(&self) -> f32 {
+        if self.algorithms_count == 0 {
+            return 100.0;
+        }
+        let mut score = 100.0_f32;
+        score -= (self.weak_algorithm_count as f32 * 15.0).min(60.0);
+        score -= (self.inadequate_key_sizes as f32 * 8.0).min(30.0);
+        if self.algorithms_count > 0 {
+            let vuln_pct = self.quantum_vulnerable_count as f32 / self.algorithms_count as f32;
+            score -= vuln_pct * 30.0;
+        }
+        score.clamp(0.0, 100.0)
+    }
+
+    /// Crypto dependency references: how well are cert/key/protocol -> algorithm refs resolved?
+    #[must_use]
+    pub fn crypto_dependency_score(&self) -> f32 {
+        let linkable = self.certificates_count + self.keys_count + self.protocols_count;
+        if linkable == 0 {
+            return 100.0;
+        }
+        let resolved = self.certs_with_signature_algo_ref
+            + self.keys_with_algorithm_ref
+            + self.protocols_with_cipher_suites;
+        let pct = resolved as f32 / linkable as f32;
+        (pct * 100.0).clamp(0.0, 100.0)
+    }
+
+    /// Crypto lifecycle: merged key management + certificate health.
+    #[must_use]
+    pub fn crypto_lifecycle_score(&self) -> f32 {
+        let mut score = 100.0_f32;
+
+        if self.keys_count > 0 {
+            let state_pct = self.keys_with_state as f32 / self.keys_count as f32;
+            let protection_pct = self.keys_with_protection as f32 / self.keys_count as f32;
+            let lifecycle_pct = self.keys_with_lifecycle_dates as f32 / self.keys_count as f32;
+            let key_completeness =
+                (state_pct * 0.4 + protection_pct * 0.3 + lifecycle_pct * 0.3) * 100.0;
+            score = score * 0.5 + key_completeness * 0.5;
+            score -= (self.compromised_keys as f32 * 20.0).min(40.0);
+            score -= (self.inadequate_key_sizes as f32 * 5.0).min(20.0);
+        }
+
+        if self.certificates_count > 0 {
+            let validity_pct =
+                self.certs_with_validity_dates as f32 / self.certificates_count as f32;
+            score -= (1.0 - validity_pct) * 15.0;
+            score -= (self.expired_certificates as f32 * 15.0).min(45.0);
+            score -= (self.expiring_soon_certificates as f32 * 5.0).min(20.0);
+        }
+
+        score.clamp(0.0, 100.0)
+    }
+
+    /// PQC readiness: quantum migration preparedness.
+    #[must_use]
+    pub fn pqc_readiness_score(&self) -> f32 {
+        if self.algorithms_count == 0 {
+            return 100.0;
+        }
+        let mut score = 0.0_f32;
+        let qs_pct = self.quantum_safe_count as f32 / self.algorithms_count as f32;
+        score += qs_pct * 60.0;
+        if self.hybrid_pqc_count > 0 {
+            score += 15.0;
+        }
+        if self.weak_algorithm_count == 0 {
+            score += 25.0;
+        } else {
+            score += (25.0 - self.weak_algorithm_count as f32 * 5.0).max(0.0);
+        }
+        score.clamp(0.0, 100.0)
+    }
+
+    /// Percentage of algorithms that are quantum-safe (for overview display).
+    #[must_use]
+    pub fn quantum_readiness_pct(&self) -> f32 {
+        if self.algorithms_count == 0 {
+            return 0.0;
+        }
+        (self.quantum_safe_count as f32 / self.algorithms_count as f32) * 100.0
+    }
+
+    /// Category labels for CBOM quality chart.
+    #[must_use]
+    pub const fn cbom_category_labels() -> [&'static str; 8] {
+        ["Crpt", "OIDs", "Algo", "Refs", "Life", "PQC", "Prov", "Lic"]
     }
 }
 
@@ -1962,5 +2145,185 @@ mod tests {
             "incomplete (first-party only)"
         );
         assert_eq!(CompletenessDeclaration::Unknown.to_string(), "unknown");
+    }
+
+    // ── CryptographyMetrics scoring tests ──
+
+    #[test]
+    fn crypto_completeness_all_documented() {
+        let m = CryptographyMetrics {
+            algorithms_count: 4,
+            algorithms_with_family: 4,
+            algorithms_with_primitive: 4,
+            algorithms_with_security_level: 4,
+            ..Default::default()
+        };
+        let score = m.crypto_completeness_score();
+        assert!(
+            (score - 100.0).abs() < 0.1,
+            "fully documented → 100, got {score}"
+        );
+    }
+
+    #[test]
+    fn crypto_completeness_partial() {
+        let m = CryptographyMetrics {
+            algorithms_count: 4,
+            algorithms_with_family: 2,         // 50%
+            algorithms_with_primitive: 4,      // 100%
+            algorithms_with_security_level: 0, // 0%
+            ..Default::default()
+        };
+        // 0.5*40 + 1.0*30 + 0.0*30 = 20+30+0 = 50
+        let score = m.crypto_completeness_score();
+        assert!((score - 50.0).abs() < 0.1, "partial → 50, got {score}");
+    }
+
+    #[test]
+    fn crypto_identifier_full_oid_coverage() {
+        let m = CryptographyMetrics {
+            algorithms_count: 5,
+            algorithms_with_oid: 5,
+            ..Default::default()
+        };
+        assert!((m.crypto_identifier_score() - 100.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn crypto_identifier_no_oids() {
+        let m = CryptographyMetrics {
+            algorithms_count: 5,
+            algorithms_with_oid: 0,
+            ..Default::default()
+        };
+        assert!((m.crypto_identifier_score() - 0.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn algorithm_strength_weak_penalty() {
+        let m = CryptographyMetrics {
+            algorithms_count: 5,
+            weak_algorithm_count: 2,
+            ..Default::default()
+        };
+        // 100 - 2*15 = 70
+        let score = m.algorithm_strength_score();
+        assert!((score - 70.0).abs() < 0.1, "2 weak → 70, got {score}");
+    }
+
+    #[test]
+    fn algorithm_strength_quantum_vulnerable() {
+        let m = CryptographyMetrics {
+            algorithms_count: 10,
+            quantum_vulnerable_count: 10,
+            ..Default::default()
+        };
+        // 100 - (10/10)*30 = 70
+        let score = m.algorithm_strength_score();
+        assert!(
+            (score - 70.0).abs() < 0.1,
+            "all quantum vuln → 70, got {score}"
+        );
+    }
+
+    #[test]
+    fn crypto_lifecycle_compromised_keys() {
+        let m = CryptographyMetrics {
+            keys_count: 3,
+            keys_with_state: 3,
+            keys_with_protection: 3,
+            keys_with_lifecycle_dates: 3,
+            compromised_keys: 1,
+            ..Default::default()
+        };
+        let score = m.crypto_lifecycle_score();
+        // With full key completeness: 100*0.5 + 100*0.5 = 100, then -20 penalty
+        assert!(score < 85.0);
+        assert!(score > 50.0);
+    }
+
+    #[test]
+    fn crypto_lifecycle_expired_certs() {
+        let m = CryptographyMetrics {
+            certificates_count: 4,
+            certs_with_validity_dates: 4,
+            expired_certificates: 2,
+            expiring_soon_certificates: 1,
+            ..Default::default()
+        };
+        let score = m.crypto_lifecycle_score();
+        // 100 - 2*15 - 1*5 = 100 - 30 - 5 = 65
+        assert!(score < 70.0);
+    }
+
+    #[test]
+    fn pqc_readiness_all_quantum_safe() {
+        let m = CryptographyMetrics {
+            algorithms_count: 5,
+            quantum_safe_count: 5,
+            hybrid_pqc_count: 2,
+            weak_algorithm_count: 0,
+            ..Default::default()
+        };
+        // (5/5)*60 + 15 + 25 = 100
+        let score = m.pqc_readiness_score();
+        assert!(
+            (score - 100.0).abs() < 0.1,
+            "all safe + hybrid → 100, got {score}"
+        );
+    }
+
+    #[test]
+    fn pqc_readiness_no_quantum_safe() {
+        let m = CryptographyMetrics {
+            algorithms_count: 5,
+            quantum_safe_count: 0,
+            hybrid_pqc_count: 0,
+            weak_algorithm_count: 0,
+            ..Default::default()
+        };
+        // 0*60 + 0 + 25 = 25
+        let score = m.pqc_readiness_score();
+        assert!(
+            (score - 25.0).abs() < 0.1,
+            "no safe, no weak → 25, got {score}"
+        );
+    }
+
+    #[test]
+    fn crypto_dependency_all_resolved() {
+        let m = CryptographyMetrics {
+            certificates_count: 2,
+            keys_count: 3,
+            protocols_count: 1,
+            certs_with_signature_algo_ref: 2,
+            keys_with_algorithm_ref: 3,
+            protocols_with_cipher_suites: 1,
+            ..Default::default()
+        };
+        assert!((m.crypto_dependency_score() - 100.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn crypto_dependency_none_resolved() {
+        let m = CryptographyMetrics {
+            certificates_count: 2,
+            keys_count: 3,
+            protocols_count: 1,
+            ..Default::default()
+        };
+        assert!((m.crypto_dependency_score() - 0.0).abs() < 0.1);
+    }
+
+    #[test]
+    fn quality_score_none_when_no_crypto() {
+        let m = CryptographyMetrics::default();
+        assert!(m.quality_score().is_none());
+    }
+
+    #[test]
+    fn quantum_readiness_pct_zero_algorithms() {
+        let m = CryptographyMetrics::default();
+        assert!((m.quantum_readiness_pct() - 0.0).abs() < 0.01);
     }
 }

--- a/src/quality/scorer.rs
+++ b/src/quality/scorer.rs
@@ -32,6 +32,8 @@ pub enum ScoringProfile {
     Cra,
     /// Comprehensive - all aspects equally weighted
     Comprehensive,
+    /// CBOM - cryptographic BOM focus (algorithm strength, PQC readiness, key/cert lifecycle)
+    Cbom,
 }
 
 impl ScoringProfile {
@@ -44,6 +46,7 @@ impl ScoringProfile {
             Self::Security => ComplianceLevel::NtiaMinimum,
             Self::Cra => ComplianceLevel::CraPhase2,
             Self::Comprehensive => ComplianceLevel::Comprehensive,
+            Self::Cbom => ComplianceLevel::Comprehensive,
         }
     }
 
@@ -112,6 +115,20 @@ impl ScoringProfile {
                 integrity: 0.12,
                 provenance: 0.13,
                 lifecycle: 0.12,
+            },
+            // CBOM slots are reinterpreted:
+            // completeness->CryptoCompl, identifiers->OIDs, licenses->AlgoStrength,
+            // vulnerabilities->CryptoRefs, dependencies->CryptoLifecycle,
+            // integrity->PQCReadiness, provenance->Provenance(std), lifecycle->Licenses(std)
+            Self::Cbom => ScoringWeights {
+                completeness: 0.15,
+                identifiers: 0.15,
+                licenses: 0.22,
+                vulnerabilities: 0.10,
+                dependencies: 0.13,
+                integrity: 0.15,
+                provenance: 0.08,
+                lifecycle: 0.02,
             },
         }
     }
@@ -398,33 +415,54 @@ impl QualityScorer {
         let lifecycle_score = lifecycle_metrics.quality_score();
         let cryptography_score = cryptography_metrics.quality_score();
 
-        // Determine which categories are available
-        let vuln_available = vulnerability_score.is_some();
-        let lifecycle_available = lifecycle_score.is_some();
-        let available = [
-            true,                // completeness
-            true,                // identifiers
-            true,                // licenses
-            vuln_available,      // vulnerabilities
-            true,                // dependencies
-            true,                // integrity
-            true,                // provenance
-            lifecycle_available, // lifecycle
-        ];
+        // For CBOM profile, substitute crypto-specific scores into the 8 slots
+        let is_cbom = self.profile == ScoringProfile::Cbom;
+        let (available, scores) = if is_cbom && cryptography_metrics.has_data() {
+            let cm = &cryptography_metrics;
+            (
+                [true; 8], // all categories available for CBOM
+                [
+                    cm.crypto_completeness_score(), // slot 1: Crpt
+                    cm.crypto_identifier_score(),   // slot 2: OIDs
+                    cm.algorithm_strength_score(),  // slot 3: Algo
+                    cm.crypto_dependency_score(),   // slot 4: Refs
+                    cm.crypto_lifecycle_score(),    // slot 5: Life
+                    cm.pqc_readiness_score(),       // slot 6: PQC
+                    provenance_score,               // slot 7: Prov (standard)
+                    license_score,                  // slot 8: Lic  (standard)
+                ],
+            )
+        } else {
+            // Standard SBOM scoring
+            let vuln_available = vulnerability_score.is_some();
+            let lifecycle_available = lifecycle_score.is_some();
+            (
+                [
+                    true,                // completeness
+                    true,                // identifiers
+                    true,                // licenses
+                    vuln_available,      // vulnerabilities
+                    true,                // dependencies
+                    true,                // integrity
+                    true,                // provenance
+                    lifecycle_available, // lifecycle
+                ],
+                [
+                    completeness_score,
+                    identifier_score,
+                    license_score,
+                    vulnerability_score.unwrap_or(0.0),
+                    dependency_score,
+                    integrity_score,
+                    provenance_score,
+                    lifecycle_score.unwrap_or(0.0),
+                ],
+            )
+        };
 
         // Calculate weighted overall score with N/A renormalization
         let weights = self.profile.weights();
         let norm = weights.renormalize(&available);
-        let scores = [
-            completeness_score,
-            identifier_score,
-            license_score,
-            vulnerability_score.unwrap_or(0.0),
-            dependency_score,
-            integrity_score,
-            provenance_score,
-            lifecycle_score.unwrap_or(0.0),
-        ];
 
         let mut overall_score: f32 = scores.iter().zip(norm.iter()).map(|(s, w)| s * w).sum();
         overall_score = overall_score.min(100.0);
@@ -435,6 +473,7 @@ impl QualityScorer {
             &lifecycle_metrics,
             &dependency_metrics,
             &hash_quality_metrics,
+            &cryptography_metrics,
             total_components,
         );
 
@@ -491,6 +530,7 @@ impl QualityScorer {
         lifecycle: &LifecycleMetrics,
         deps: &DependencyMetrics,
         hashes: &HashQualityMetrics,
+        crypto: &CryptographyMetrics,
         total_components: usize,
     ) -> f32 {
         let is_security_profile =
@@ -525,6 +565,19 @@ impl QualityScorer {
             && hashes.components_with_strong_hash == 0
         {
             score = score.min(89.0);
+        }
+
+        // CBOM-specific hard caps
+        if self.profile == ScoringProfile::Cbom && crypto.has_data() {
+            if crypto.weak_algorithm_count > 0 {
+                score = score.min(69.0);
+            }
+            if crypto.compromised_keys > 0 {
+                score = score.min(79.0);
+            }
+            if crypto.quantum_safe_count == 0 && crypto.algorithms_count > 0 {
+                score = score.min(79.0);
+            }
         }
 
         score
@@ -890,6 +943,7 @@ mod tests {
             ScoringProfile::LicenseCompliance,
             ScoringProfile::Cra,
             ScoringProfile::Comprehensive,
+            ScoringProfile::Cbom,
         ];
         for profile in &profiles {
             let w = profile.weights();
@@ -924,5 +978,36 @@ mod tests {
     #[test]
     fn test_scoring_engine_version() {
         assert_eq!(SCORING_ENGINE_VERSION, "2.0");
+    }
+
+    #[test]
+    fn cbom_hard_cap_weak_algorithms() {
+        use crate::model::{
+            AlgorithmProperties, CanonicalId, Component, ComponentType, CryptoAssetType,
+            CryptoPrimitive, CryptoProperties, NormalizedSbom,
+        };
+
+        let mut sbom = NormalizedSbom::default();
+        // Add a weak crypto component (MD5 algorithm)
+        let mut comp = Component::new("MD5".to_string(), "md5-ref".to_string());
+        comp.component_type = ComponentType::Cryptographic;
+        comp.crypto_properties = Some(
+            CryptoProperties::new(CryptoAssetType::Algorithm).with_algorithm_properties(
+                AlgorithmProperties::new(CryptoPrimitive::Hash)
+                    .with_algorithm_family("MD5".to_string())
+                    .with_nist_quantum_security_level(0),
+            ),
+        );
+        sbom.components
+            .insert(CanonicalId::from_name_version("md5", None), comp);
+
+        let scorer = QualityScorer::new(ScoringProfile::Cbom);
+        let report = scorer.score(&sbom);
+        // Weak algorithm → D max (69)
+        assert!(
+            report.overall_score <= 69.0,
+            "weak algo should cap at D, got {}",
+            report.overall_score
+        );
     }
 }

--- a/src/tui/app_impl_constructors.rs
+++ b/src/tui/app_impl_constructors.rs
@@ -79,10 +79,20 @@ impl App {
         old_raw: &str,
         new_raw: &str,
     ) -> Self {
-        // Calculate quality reports for both SBOMs
-        let scorer = QualityScorer::new(ScoringProfile::Standard);
-        let old_quality = Some(scorer.score(&old_sbom));
-        let new_quality = Some(scorer.score(&new_sbom));
+        // Calculate quality reports for both SBOMs using profile-aware scoring
+        let old_profile = match crate::model::BomProfile::detect(&old_sbom) {
+            crate::model::BomProfile::Cbom => ScoringProfile::Cbom,
+            crate::model::BomProfile::Sbom => ScoringProfile::Standard,
+        };
+        let old_scorer = QualityScorer::new(old_profile);
+        let old_quality = Some(old_scorer.score(&old_sbom));
+
+        let new_profile = match crate::model::BomProfile::detect(&new_sbom) {
+            crate::model::BomProfile::Cbom => ScoringProfile::Cbom,
+            crate::model::BomProfile::Sbom => ScoringProfile::Standard,
+        };
+        let new_scorer = QualityScorer::new(new_profile);
+        let new_quality = Some(new_scorer.score(&new_sbom));
 
         // Compute only CRA Phase2 for the summary card; full compliance is lazy
         let old_cra_compliance =

--- a/src/tui/shared/quality.rs
+++ b/src/tui/shared/quality.rs
@@ -4,8 +4,8 @@
 //! and have no dependency on App or `ViewApp` state.
 
 use crate::quality::{
-    ComplexityLevel, DependencyMetrics, QualityGrade, QualityReport, RecommendationCategory,
-    SCORING_ENGINE_VERSION, ScoringProfile,
+    ComplexityLevel, CryptographyMetrics, DependencyMetrics, QualityGrade, QualityReport,
+    RecommendationCategory, SCORING_ENGINE_VERSION, ScoringProfile,
 };
 use crate::tui::theme::colors;
 use ratatui::{
@@ -31,6 +31,7 @@ pub const fn get_profile_weights(
         ScoringProfile::LicenseCompliance => (0.15, 0.12, 0.35, 0.05, 0.10, 0.05, 0.10, 0.08),
         ScoringProfile::Cra => (0.12, 0.18, 0.08, 0.15, 0.12, 0.12, 0.15, 0.08),
         ScoringProfile::Comprehensive => (0.15, 0.13, 0.13, 0.10, 0.12, 0.12, 0.13, 0.12),
+        ScoringProfile::Cbom => (0.15, 0.15, 0.22, 0.10, 0.13, 0.15, 0.08, 0.02),
     }
 }
 
@@ -527,101 +528,104 @@ pub fn render_quality_summary(
         .constraints([Constraint::Percentage(55), Constraint::Percentage(45)])
         .split(chunks[2]);
 
-    // Bar chart with 8 category scores
+    // Bar chart with 8 category scores (CBOM-aware)
     // Use max(1) so even 0% bars have a stub for the text_value to render on
-    let vuln_val = report.vulnerability_score.unwrap_or(0.0);
-    let vuln_is_na = report.vulnerability_score.is_none();
-    let lifecycle_val = report.lifecycle_score.unwrap_or(0.0);
-    let lifecycle_is_na = report.lifecycle_score.is_none();
+    let is_cbom = report.profile == ScoringProfile::Cbom;
+    let bars: Vec<Bar> = if is_cbom {
+        let cm = &report.cryptography_metrics;
+        let labels = CryptographyMetrics::cbom_category_labels();
+        let scores = [
+            cm.crypto_completeness_score(),
+            cm.crypto_identifier_score(),
+            cm.algorithm_strength_score(),
+            cm.crypto_dependency_score(),
+            cm.crypto_lifecycle_score(),
+            cm.pqc_readiness_score(),
+            report.provenance_score,
+            report.license_score,
+        ];
+        labels
+            .iter()
+            .zip(scores.iter())
+            .map(|(label, &score)| {
+                Bar::default()
+                    .value((score as u64).max(1))
+                    .label(Line::from(*label))
+                    .style(bar_grade_style(score))
+                    .text_value(format!("{}", score as u64))
+            })
+            .collect()
+    } else {
+        let vuln_val = report.vulnerability_score.unwrap_or(0.0);
+        let vuln_is_na = report.vulnerability_score.is_none();
+        let lifecycle_val = report.lifecycle_score.unwrap_or(0.0);
+        let lifecycle_is_na = report.lifecycle_score.is_none();
+        let sbom_labels = ["Cmpl", "IDs", "Lic", "VDoc", "Deps", "Hash", "Prov", "Life"];
+        let sbom_scores = [
+            report.completeness_score,
+            report.identifier_score,
+            report.license_score,
+            vuln_val,
+            report.dependency_score,
+            report.integrity_score,
+            report.provenance_score,
+            lifecycle_val,
+        ];
+        let na_flags = [
+            false,
+            false,
+            false,
+            vuln_is_na,
+            false,
+            false,
+            false,
+            lifecycle_is_na,
+        ];
+        sbom_labels
+            .iter()
+            .zip(sbom_scores.iter())
+            .zip(na_flags.iter())
+            .map(|((label, &score), &is_na)| {
+                if is_na {
+                    Bar::default()
+                        .value(1)
+                        .label(Line::styled(*label, Style::default().fg(scheme.muted)))
+                        .style(Style::default().fg(scheme.muted))
+                        .text_value("N/A".to_string())
+                } else {
+                    Bar::default()
+                        .value((score as u64).max(1))
+                        .label(Line::from(*label))
+                        .style(bar_grade_style(score))
+                        .text_value(format!("{}", score as u64))
+                }
+            })
+            .collect()
+    };
+
+    let chart_title = if is_cbom {
+        " CBOM Category Scores (passing: 70) "
+    } else {
+        " Category Scores (passing: 70) "
+    };
     let bar_chart = BarChart::default()
         .block(
             Block::default()
-                .title(" Category Scores (passing: 70) ")
+                .title(chart_title)
                 .borders(Borders::ALL)
                 .border_style(Style::default().fg(scheme.muted)),
         )
         .bar_width(6)
         .bar_gap(1)
         .value_style(Style::default().fg(Color::White).bold())
-        .data(
-            BarGroup::default().bars(&[
-                Bar::default()
-                    .value((report.completeness_score as u64).max(1))
-                    .label(Line::from("Cmpl"))
-                    .style(bar_grade_style(report.completeness_score))
-                    .text_value(format!("{}", report.completeness_score as u64)),
-                Bar::default()
-                    .value((report.identifier_score as u64).max(1))
-                    .label(Line::from("IDs"))
-                    .style(bar_grade_style(report.identifier_score))
-                    .text_value(format!("{}", report.identifier_score as u64)),
-                Bar::default()
-                    .value((report.license_score as u64).max(1))
-                    .label(Line::from("Lic"))
-                    .style(bar_grade_style(report.license_score))
-                    .text_value(format!("{}", report.license_score as u64)),
-                Bar::default()
-                    .value(if vuln_is_na {
-                        1
-                    } else {
-                        (vuln_val as u64).max(1)
-                    })
-                    .label(if vuln_is_na {
-                        Line::styled("VDoc", Style::default().fg(scheme.muted))
-                    } else {
-                        Line::from("VDoc")
-                    })
-                    .style(if vuln_is_na {
-                        Style::default().fg(scheme.muted)
-                    } else {
-                        bar_grade_style(vuln_val)
-                    })
-                    .text_value(if vuln_is_na {
-                        "N/A".to_string()
-                    } else {
-                        format!("{}", vuln_val as u64)
-                    }),
-                Bar::default()
-                    .value((report.dependency_score as u64).max(1))
-                    .label(Line::from("Deps"))
-                    .style(bar_grade_style(report.dependency_score))
-                    .text_value(format!("{}", report.dependency_score as u64)),
-                Bar::default()
-                    .value((report.integrity_score as u64).max(1))
-                    .label(Line::from("Hash"))
-                    .style(bar_grade_style(report.integrity_score))
-                    .text_value(format!("{}", report.integrity_score as u64)),
-                Bar::default()
-                    .value((report.provenance_score as u64).max(1))
-                    .label(Line::from("Prov"))
-                    .style(bar_grade_style(report.provenance_score))
-                    .text_value(format!("{}", report.provenance_score as u64)),
-                Bar::default()
-                    .value(if lifecycle_is_na {
-                        1
-                    } else {
-                        (lifecycle_val as u64).max(1)
-                    })
-                    .label(if lifecycle_is_na {
-                        Line::styled("Life", Style::default().fg(scheme.muted))
-                    } else {
-                        Line::from("Life")
-                    })
-                    .style(if lifecycle_is_na {
-                        Style::default().fg(scheme.muted)
-                    } else {
-                        bar_grade_style(lifecycle_val)
-                    })
-                    .text_value(if lifecycle_is_na {
-                        "N/A".to_string()
-                    } else {
-                        format!("{}", lifecycle_val as u64)
-                    }),
-            ]),
-        );
+        .data(BarGroup::default().bars(&bars));
     frame.render_widget(bar_chart, mid_chunks[0]);
 
-    render_completeness_checklist(frame, mid_chunks[1], report);
+    if is_cbom {
+        render_crypto_inventory(frame, mid_chunks[1], report);
+    } else {
+        render_completeness_checklist(frame, mid_chunks[1], report);
+    }
 
     // Bottom row: full-width recommendations
     render_top_recommendations(frame, chunks[3], report, selected_rec);
@@ -641,20 +645,36 @@ fn render_compact_header(frame: &mut Frame, area: Rect, report: &QualityReport) 
     let bar_str: String = "\u{2588}".repeat(filled) + &"\u{2591}".repeat(empty);
 
     // Identify strongest and weakest across all 8 categories
-    let mut scores = vec![
-        ("Completeness", report.completeness_score),
-        ("Identifiers", report.identifier_score),
-        ("Licenses", report.license_score),
-        ("Dependencies", report.dependency_score),
-        ("Integrity", report.integrity_score),
-        ("Provenance", report.provenance_score),
-    ];
-    if let Some(vs) = report.vulnerability_score {
-        scores.push(("Vuln Docs", vs));
-    }
-    if let Some(lc) = report.lifecycle_score {
-        scores.push(("Lifecycle", lc));
-    }
+    let is_cbom = report.profile == ScoringProfile::Cbom;
+    let scores: Vec<(&str, f32)> = if is_cbom {
+        let cm = &report.cryptography_metrics;
+        vec![
+            ("Crypto Compl", cm.crypto_completeness_score()),
+            ("OIDs", cm.crypto_identifier_score()),
+            ("Algo Strength", cm.algorithm_strength_score()),
+            ("Crypto Refs", cm.crypto_dependency_score()),
+            ("Crypto Life", cm.crypto_lifecycle_score()),
+            ("PQC Readiness", cm.pqc_readiness_score()),
+            ("Provenance", report.provenance_score),
+            ("Licenses", report.license_score),
+        ]
+    } else {
+        let mut s = vec![
+            ("Completeness", report.completeness_score),
+            ("Identifiers", report.identifier_score),
+            ("Licenses", report.license_score),
+            ("Dependencies", report.dependency_score),
+            ("Integrity", report.integrity_score),
+            ("Provenance", report.provenance_score),
+        ];
+        if let Some(vs) = report.vulnerability_score {
+            s.push(("Vuln Docs", vs));
+        }
+        if let Some(lc) = report.lifecycle_score {
+            s.push(("Lifecycle", lc));
+        }
+        s
+    };
     let strongest = scores
         .iter()
         .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap_or(std::cmp::Ordering::Equal))
@@ -707,9 +727,14 @@ fn render_compact_header(frame: &mut Frame, area: Rect, report: &QualityReport) 
     }
     let line2 = Line::from(line2_spans);
 
+    let header_title = if is_cbom {
+        " CBOM Quality Score "
+    } else {
+        " SBOM Quality Score "
+    };
     let widget = Paragraph::new(vec![line1, line2]).block(
         Block::default()
-            .title(" SBOM Quality Score ")
+            .title(header_title)
             .title_style(Style::default().bold().fg(scheme.text))
             .borders(Borders::ALL)
             .border_style(Style::default().fg(gauge_color)),
@@ -886,6 +911,99 @@ fn render_insights_panel(frame: &mut Frame, area: Rect, report: &QualityReport) 
             .title(" Insights ")
             .borders(Borders::ALL)
             .border_style(Style::default().fg(scheme.info)),
+    );
+    frame.render_widget(widget, area);
+}
+
+/// Render a crypto asset inventory panel for CBOM mode.
+fn render_crypto_inventory(frame: &mut Frame, area: Rect, report: &QualityReport) {
+    let scheme = colors();
+    let cm = &report.cryptography_metrics;
+
+    let mut lines = vec![];
+
+    // Asset counts
+    lines.push(Line::from(vec![
+        Span::styled("  Algorithms:    ", Style::default().fg(scheme.text_muted)),
+        Span::styled(
+            format!("{}", cm.algorithms_count),
+            Style::default().fg(scheme.text).bold(),
+        ),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("  Certificates:  ", Style::default().fg(scheme.text_muted)),
+        Span::styled(
+            format!("{}", cm.certificates_count),
+            Style::default().fg(scheme.text).bold(),
+        ),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("  Keys:          ", Style::default().fg(scheme.text_muted)),
+        Span::styled(
+            format!("{}", cm.keys_count),
+            Style::default().fg(scheme.text).bold(),
+        ),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("  Protocols:     ", Style::default().fg(scheme.text_muted)),
+        Span::styled(
+            format!("{}", cm.protocols_count),
+            Style::default().fg(scheme.text).bold(),
+        ),
+    ]));
+    lines.push(Line::from(""));
+
+    // PQC readiness percentage
+    let pqc_pct = cm.quantum_readiness_pct();
+    let pqc_color = if pqc_pct >= 80.0 {
+        scheme.success
+    } else if pqc_pct >= 40.0 {
+        scheme.warning
+    } else {
+        scheme.error
+    };
+    lines.push(Line::from(vec![
+        Span::styled("  PQC Ready:     ", Style::default().fg(scheme.text_muted)),
+        Span::styled(
+            format!("{pqc_pct:.0}%"),
+            Style::default().fg(pqc_color).bold(),
+        ),
+    ]));
+
+    // Warnings
+    if cm.weak_algorithm_count > 0 {
+        lines.push(Line::from(vec![
+            Span::styled("  \u{26a0} ", Style::default().fg(scheme.warning)),
+            Span::styled(
+                format!("{} weak algorithm(s)", cm.weak_algorithm_count),
+                Style::default().fg(scheme.warning),
+            ),
+        ]));
+    }
+    if cm.expired_certificates > 0 {
+        lines.push(Line::from(vec![
+            Span::styled("  \u{26a0} ", Style::default().fg(scheme.error)),
+            Span::styled(
+                format!("{} expired cert(s)", cm.expired_certificates),
+                Style::default().fg(scheme.error),
+            ),
+        ]));
+    }
+    if cm.compromised_keys > 0 {
+        lines.push(Line::from(vec![
+            Span::styled("  \u{26a0} ", Style::default().fg(scheme.error)),
+            Span::styled(
+                format!("{} compromised key(s)", cm.compromised_keys),
+                Style::default().fg(scheme.error),
+            ),
+        ]));
+    }
+
+    let widget = Paragraph::new(lines).block(
+        Block::default()
+            .title(" Crypto Inventory ")
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(scheme.accent)),
     );
     frame.render_widget(widget, area);
 }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -893,8 +893,9 @@ impl FooterHints {
                 hints.insert(3, ("Enter", "select"));
             }
             "algorithms" => {
-                hints.insert(0, ("↑↓", "select"));
-                hints.insert(1, ("Enter", "detail"));
+                hints.insert(0, ("s", "sort"));
+                hints.insert(1, ("↑↓", "select"));
+                hints.insert(2, ("Enter", "detail"));
             }
             "certificates" => {
                 hints.insert(0, ("↑↓", "select"));

--- a/src/tui/view/app.rs
+++ b/src/tui/view/app.rs
@@ -123,6 +123,9 @@ pub struct ViewApp {
     /// CBOM Protocols tab: selected index
     pub(crate) protocols_selected: usize,
 
+    /// CBOM Algorithms tab: sort order
+    pub(crate) algorithm_sort_by: AlgorithmSortBy,
+
     /// Bookmarked component canonical IDs (in-memory, no persistence)
     pub(crate) bookmarked: HashSet<String>,
 
@@ -141,7 +144,11 @@ impl ViewApp {
         let stats = SbomStats::from_sbom(&sbom);
 
         // Calculate quality score
-        let scorer = QualityScorer::new(ScoringProfile::Standard);
+        let scoring_profile = match bom_profile {
+            crate::model::BomProfile::Cbom => ScoringProfile::Cbom,
+            crate::model::BomProfile::Sbom => ScoringProfile::Standard,
+        };
+        let scorer = QualityScorer::new(scoring_profile);
         let quality_report = scorer.score(&sbom);
         let quality_state = QualityViewState::new(quality_report.recommendations.len());
 
@@ -207,6 +214,7 @@ impl ViewApp {
             certificates_selected: 0,
             keys_selected: 0,
             protocols_selected: 0,
+            algorithm_sort_by: AlgorithmSortBy::default(),
             bookmarked: HashSet::new(),
             export_template: None,
         };
@@ -2470,6 +2478,36 @@ impl VulnSortBy {
             Self::Cvss => "CVSS",
             Self::CveId => "CVE ID",
             Self::Component => "Component",
+        }
+    }
+}
+
+/// Sort order for the Algorithms tab.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) enum AlgorithmSortBy {
+    #[default]
+    Name,
+    Family,
+    QuantumLevel,
+    Strength,
+}
+
+impl AlgorithmSortBy {
+    pub const fn next(self) -> Self {
+        match self {
+            Self::Name => Self::Family,
+            Self::Family => Self::QuantumLevel,
+            Self::QuantumLevel => Self::Strength,
+            Self::Strength => Self::Name,
+        }
+    }
+
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Name => "Name",
+            Self::Family => "Family",
+            Self::QuantumLevel => "Quantum",
+            Self::Strength => "Strength",
         }
     }
 }

--- a/src/tui/view/events.rs
+++ b/src/tui/view/events.rs
@@ -378,6 +378,21 @@ pub fn handle_key_event(app: &mut ViewApp, key: KeyEvent) {
             prefs.theme = theme_name.parse().unwrap_or_default();
             let _ = prefs.save();
         }
+        KeyCode::Char('P') => {
+            // Toggle BOM profile (SBOM <-> CBOM) and re-score
+            app.bom_profile = match app.bom_profile {
+                crate::model::BomProfile::Sbom => crate::model::BomProfile::Cbom,
+                crate::model::BomProfile::Cbom => crate::model::BomProfile::Sbom,
+            };
+            let scoring_profile = match app.bom_profile {
+                crate::model::BomProfile::Cbom => crate::quality::ScoringProfile::Cbom,
+                crate::model::BomProfile::Sbom => crate::quality::ScoringProfile::Standard,
+            };
+            let scorer = crate::quality::QualityScorer::new(scoring_profile);
+            app.quality_report = scorer.score(&app.sbom);
+            app.active_tab = ViewTab::Overview;
+            app.status_message = Some(format!("Switched to {} mode", app.bom_profile.label()));
+        }
         KeyCode::Char('b') | KeyCode::Backspace => {
             // Navigate back using breadcrumb history
             if app.navigation_ctx.has_history() {
@@ -615,11 +630,13 @@ fn handle_view_key(app: &mut ViewApp, key: KeyEvent) {
             }
             _ => {}
         },
-        KeyCode::Char('s') => {
-            if app.active_tab == ViewTab::Vulnerabilities {
-                app.vuln_state.toggle_sort();
+        KeyCode::Char('s') => match app.active_tab {
+            ViewTab::Vulnerabilities => app.vuln_state.toggle_sort(),
+            ViewTab::Algorithms => {
+                app.algorithm_sort_by = app.algorithm_sort_by.next();
             }
-        }
+            _ => {}
+        },
         KeyCode::Char('d') => {
             if app.active_tab == ViewTab::Vulnerabilities {
                 app.vuln_state.toggle_deduplicate();

--- a/src/tui/view/views/algorithms.rs
+++ b/src/tui/view/views/algorithms.rs
@@ -4,7 +4,7 @@
 //! security levels, and FIPS/CNSA compliance status.
 
 use crate::model::{ComponentType, CryptoAssetType};
-use crate::tui::view::app::ViewApp;
+use crate::tui::view::app::{AlgorithmSortBy, ViewApp};
 use ratatui::Frame;
 use ratatui::layout::{Constraint, Direction, Layout, Rect};
 use ratatui::style::{Color, Modifier, Style};
@@ -24,6 +24,59 @@ pub fn render_algorithms(frame: &mut Frame, area: Rect, app: &ViewApp) {
                     .is_some_and(|cp| cp.asset_type == CryptoAssetType::Algorithm)
         })
         .collect();
+
+    let mut algorithms = algorithms;
+    algorithms.sort_by(|a, b| match app.algorithm_sort_by {
+        AlgorithmSortBy::Name => a.name.cmp(&b.name),
+        AlgorithmSortBy::Family => {
+            let af = a
+                .crypto_properties
+                .as_ref()
+                .and_then(|cp| cp.algorithm_properties.as_ref())
+                .and_then(|algo| algo.algorithm_family.as_deref())
+                .unwrap_or("");
+            let bf = b
+                .crypto_properties
+                .as_ref()
+                .and_then(|cp| cp.algorithm_properties.as_ref())
+                .and_then(|algo| algo.algorithm_family.as_deref())
+                .unwrap_or("");
+            af.cmp(bf)
+        }
+        AlgorithmSortBy::QuantumLevel => {
+            let al = a
+                .crypto_properties
+                .as_ref()
+                .and_then(|cp| cp.algorithm_properties.as_ref())
+                .and_then(|algo| algo.nist_quantum_security_level)
+                .unwrap_or(0);
+            let bl = b
+                .crypto_properties
+                .as_ref()
+                .and_then(|cp| cp.algorithm_properties.as_ref())
+                .and_then(|algo| algo.nist_quantum_security_level)
+                .unwrap_or(0);
+            bl.cmp(&al) // descending: highest quantum level first
+        }
+        AlgorithmSortBy::Strength => {
+            let strength = |c: &&crate::model::Component| -> u8 {
+                let Some(cp) = &c.crypto_properties else {
+                    return 1;
+                };
+                let Some(algo) = &cp.algorithm_properties else {
+                    return 1;
+                };
+                if algo.is_weak_by_name(&c.name) {
+                    return 0;
+                }
+                if algo.nist_quantum_security_level == Some(0) {
+                    return 1;
+                }
+                2
+            };
+            strength(a).cmp(&strength(b))
+        }
+    });
 
     if algorithms.is_empty() {
         let msg = Paragraph::new("No algorithms found in this CBOM.")
@@ -88,16 +141,16 @@ pub fn render_algorithms(frame: &mut Frame, area: Rect, app: &ViewApp) {
         })
         .collect();
 
-    let list = List::new(items).block(
-        Block::default()
-            .borders(Borders::ALL)
-            .title(format!(" Algorithms ({}) ", algorithms.len())),
-    );
+    let list = List::new(items).block(Block::default().borders(Borders::ALL).title(format!(
+        " Algorithms ({}) [{}] ",
+        algorithms.len(),
+        app.algorithm_sort_by.label()
+    )));
     frame.render_widget(list, panels[0]);
 
     // ── Right: detail panel ──
     let selected = app
-        .crypto_list_selected
+        .active_crypto_selected()
         .min(algorithms.len().saturating_sub(1));
     let Some(comp) = algorithms.get(selected) else {
         frame.render_widget(
@@ -188,6 +241,15 @@ pub fn render_algorithms(frame: &mut Frame, area: Rect, app: &ViewApp) {
                     .map(|c| c.to_string())
                     .collect();
                 lines.push(Line::from(format!("Certified: {}", certs.join(", "))));
+            }
+            if let Some(p) = &algo.padding {
+                lines.push(Line::from(format!("Padding:   {p}")));
+            }
+            if let Some(env) = &algo.execution_environment {
+                lines.push(Line::from(format!("Exec Env:  {env}")));
+            }
+            if let Some(platform) = &algo.implementation_platform {
+                lines.push(Line::from(format!("Platform:  {platform}")));
             }
         }
     }

--- a/src/tui/view/views/certificates.rs
+++ b/src/tui/view/views/certificates.rs
@@ -24,6 +24,18 @@ pub fn render_certificates(frame: &mut Frame, area: Rect, app: &ViewApp) {
         })
         .collect();
 
+    let mut certs = certs;
+    certs.sort_by(|a, b| {
+        let days_remaining = |c: &&crate::model::Component| -> i64 {
+            c.crypto_properties
+                .as_ref()
+                .and_then(|cp| cp.certificate_properties.as_ref())
+                .and_then(|cert| cert.validity_days())
+                .unwrap_or(i64::MAX)
+        };
+        days_remaining(a).cmp(&days_remaining(b)) // most urgent first
+    });
+
     if certs.is_empty() {
         let msg = Paragraph::new("No certificates found in this CBOM.")
             .block(
@@ -93,7 +105,9 @@ pub fn render_certificates(frame: &mut Frame, area: Rect, app: &ViewApp) {
     frame.render_widget(list, panels[0]);
 
     // ── Right: detail panel ──
-    let selected = app.crypto_list_selected.min(certs.len().saturating_sub(1));
+    let selected = app
+        .active_crypto_selected()
+        .min(certs.len().saturating_sub(1));
     let Some(comp) = certs.get(selected) else {
         frame.render_widget(
             Paragraph::new("No selection")

--- a/src/tui/view/views/keys.rs
+++ b/src/tui/view/views/keys.rs
@@ -88,7 +88,9 @@ pub fn render_keys(frame: &mut Frame, area: Rect, app: &ViewApp) {
     frame.render_widget(list, panels[0]);
 
     // ── Right: detail panel ──
-    let selected = app.crypto_list_selected.min(keys.len().saturating_sub(1));
+    let selected = app
+        .active_crypto_selected()
+        .min(keys.len().saturating_sub(1));
     let Some(comp) = keys.get(selected) else {
         frame.render_widget(
             Paragraph::new("No selection")

--- a/src/tui/view/views/protocols.rs
+++ b/src/tui/view/views/protocols.rs
@@ -78,7 +78,9 @@ pub fn render_protocols(frame: &mut Frame, area: Rect, app: &ViewApp) {
     frame.render_widget(list, panels[0]);
 
     // ── Right: detail panel ──
-    let selected = app.crypto_list_selected.min(protos.len().saturating_sub(1));
+    let selected = app
+        .active_crypto_selected()
+        .min(protos.len().saturating_sub(1));
     let Some(comp) = protos.get(selected) else {
         frame.render_widget(
             Paragraph::new("No selection")


### PR DESCRIPTION
## Summary

- **CBOM Quality Scoring Engine**: New `ScoringProfile::Cbom` with 8 crypto-tuned categories — Algorithm Strength (0.22), PQC Readiness (0.15), Crypto Completeness (0.15), OID Coverage (0.15), Crypto Lifecycle (0.13), Cross-References (0.10), Provenance (0.08), Licenses (0.02)
- **12 enriched CryptographyMetrics fields**: Real field coverage for completeness, cross-references, key lifecycle, and certificate health — replaces proxy-based scoring
- **Hard caps**: Broken algorithms → D max, compromised keys → C max, zero quantum-safe → C max
- **TUI polish**: Dynamic CBOM chart labels, Crypto Inventory panel, `P` key profile toggle with re-scoring, algorithm sorting (`s` key), certificate expiry sort, selection index bug fix
- **CLI**: `quality --profile cbom` command, diff mode auto-detects BomProfile
- **15 new tests**: Scoring methods, hard caps, edge cases

## Test plan

- [x] `cargo clippy --lib -- -W clippy::all` — 0 warnings
- [x] `cargo build --release` — clean
- [x] `cargo test --all-targets` — 997 tests passing
- [x] 34 dedicated CBOM tests (21 unit + 13 integration)
- [ ] `sbom-tools view cbom-1.7.cdx.json` → auto-detects CBOM, crypto tabs work
- [ ] `sbom-tools quality --profile cbom cbom-weak-crypto.cdx.json` → grade D
- [ ] `P` key toggles SBOM↔CBOM with re-scoring
- [ ] `s` key cycles algorithm sort order

🤖 Generated with [Claude Code](https://claude.com/claude-code)