### PR TITLE
Fix dependabot security alerts: bump rand and rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,7 +1812,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2034,9 +2034,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -2411,9 +2411,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1682,7 +1682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -1851,9 +1851,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]
@@ -2219,9 +2219,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- Bump `rand` 0.8.5 → 0.8.6 ([GHSA-cq8v-f236-94qc](https://github.com/advisories/GHSA-cq8v-f236-94qc), low) in `Cargo.lock` + `fuzz/Cargo.lock`
- Bump `rustls-webpki` 0.103.12 → 0.103.13 ([GHSA-82j2-j2ch-gfr8](https://github.com/advisories/GHSA-82j2-j2ch-gfr8), high) in `Cargo.lock` + `fuzz/Cargo.lock`
- Resolves Dependabot alerts #21, #22, #24, #25

Both are patch-version bumps to transitive deps — `cargo update` only, no `Cargo.toml` changes.

## Dismissed alert (#23)
The remaining alert (`rustls-webpki` 0.101.7 in `dagger/rust-sdk/Cargo.lock`) was dismissed as **tolerable_risk**:

- Transitive: `dagger-sdk@0.20.x → reqwest@0.11 → rustls@0.21 → rustls-webpki@0.101.7`
- The fix only landed in `rustls-webpki` 0.103.13; there is no backport to the 0.101.x or 0.102.x lines
- Latest `dagger-sdk@0.20.6` still pins `reqwest@^0.11.23`, which transitively requires `rustls@0.21.x` (no path to upgrade rustls-webpki within the dagger-sdk 0.20.x line)
- `dagger/rust-sdk` is dev-only CI tooling (excluded from the main workspace; only used by `bindings.yml` to orchestrate FFI binding tests in ephemeral Docker containers)
- The vulnerable code path (panic on malformed CRL BIT STRING) is not exercised by the dagger pipeline, which connects only to dagger.io and crates.io

This alert will be revisited when `dagger-sdk` releases a version using `reqwest 0.12+`.

## Test plan
- [x] `cargo check --workspace --all-targets --locked` passes
- [x] `cargo build --workspace --locked` passes
- [x] `cargo test --workspace --locked` — 1020 passed, 0 failed, 28 ignored (FFI tests behind feature flag)
- [x] `cd fuzz && cargo check --locked` passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)