### PR TITLE
CRA compliance overhaul: full plan (P1–P5) — 11 commits, 1170 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -827,6 +827,9 @@ cargo bench
 
 - [Architecture overview](docs/ARCHITECTURE.md)
 - [Pipeline diagrams](docs/pipeline-diagrams.md)
+- [CRA compliance reverse-mapping](docs/CRA_COMPLIANCE.md) — every
+  CRA / BSI / prEN check sbom-tools surfaces, mapped to its
+  regulation, harmonised standard, sidecar field, and canonical URL
 - [Releases and changelog](https://github.com/sbom-tool/sbom-tools/releases)
 
 ## Contributing

--- a/docs/CRA_COMPLIANCE.md
+++ b/docs/CRA_COMPLIANCE.md
@@ -1,0 +1,253 @@
+# CRA Compliance — Standards Reverse Map
+
+This document maps every compliance check sbom-tools surfaces under
+`--standard cra` (and the related Article 24 / BSI / Annex III/IV
+profiles) to the underlying regulation, harmonised standard, and
+ENISA / industry guidance. Use it to:
+
+- **Auditors / notified bodies**: locate the regulatory text behind each
+  finding by Article number or Annex reference.
+- **Engineers**: see which sidecar field (`CraSidecarMetadata`) or SBOM
+  field clears each violation.
+- **GRC / dashboards**: cross-reference SARIF `properties.standardIds`
+  and `properties.standardHelpUris` to produce control-mapping reports.
+
+> Generated and maintained alongside the sbom-tools source tree.
+> If a check or article moves, send a PR — the reverse map is the
+> single source of truth for both human readers and the
+> `Violation::derive_standard_refs()` lookup table.
+
+## CRA timeline anchors
+
+| Date          | Event                                                         |
+|---------------|---------------------------------------------------------------|
+| 2024-12-10    | CRA enters into force (Regulation (EU) 2024/2847)             |
+| 2026-09-11    | Article 14 reporting obligations apply                        |
+| 2027-12-11    | Phase 1 deadline (`ComplianceLevel::CraPhase1`)               |
+| 2029-12-11    | Phase 2 deadline (`ComplianceLevel::CraPhase2`)               |
+
+## Compliance levels
+
+| `ComplianceLevel`           | sbom-tools `--standard` alias                                                                       | Scope                                                                                                            |
+|-----------------------------|-----------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| `CraPhase1`                 | `cra` (defaults to Phase 2; pin Phase 1 via the `Cra` profile)                                      | CRA Phase 1 reporting obligations (deadline 2027-12-11)                                                          |
+| `CraPhase2`                 | `cra`                                                                                               | Full CRA compliance (deadline 2029-12-11)                                                                        |
+| `CraOssSteward`             | `oss-steward`, `cra-oss-steward`, `cra-oss`, `cra-art24`, `art24`                                   | Article 24 lighter profile for open-source software stewards                                                     |
+| `BsiTr03183_2`              | `bsi`, `tr-03183`, `tr03183`, `bsi-tr-03183-2`                                                      | BSI TR-03183-2 (German national CRA-aligned baseline)                                                            |
+| `Cnsa2`                     | `cnsa2`, `cnsa-2`, `cnsa_2`, `cnsa2.0`                                                              | NSA CNSA 2.0 (post-quantum mandate for US national-security systems)                                             |
+| `NistPqc`                   | `pqc`, `nist-pqc`, `nist_pqc`                                                                       | NIST IR 8547 + FIPS 203/204/205 (PQC migration)                                                                  |
+
+The `--cra-product-class` flag (or sidecar `productClass`) drives the
+[CRA-P3.2 calibration table](#cra-p32-product-class-severity-calibration)
+that scales severity for vendor-hash, EOL, cycles, DoC, EUCC, PSIRT,
+and module-attestation checks.
+
+## Reverse map
+
+Each row maps a sbom-tools `Violation::requirement` string to its
+regulatory anchor, the harmonised-standard requirement ID
+(prEN 40000-1-3 where known), the BSI section, and the canonical URL
+that ends up in SARIF `properties.standardHelpUris`.
+
+### CRA Article 13 (essential requirements & SBOM-related obligations)
+
+| Requirement string                                              | CRA Article    | prEN 40000-1-3      | BSI TR-03183-2 § | sidecar field that clears it                              |
+|-----------------------------------------------------------------|----------------|---------------------|------------------|-----------------------------------------------------------|
+| `CRA Art. 13(2): Documented risk assessment`                    | Art. 13(2)     | —                   | §4.1             | `riskAssessmentUrl` + `riskAssessmentMethodology`         |
+| `CRA Art. 13(3): SBOM freshness`                                | Art. 13(3)     | PRE-7-RQ-04         | §5.1             | regenerate SBOM on each release                           |
+| `CRA Art. 13(4): SBOM machine-readable format`                  | Art. 13(4)     | PRE-7-RQ-04         | §5.2             | parse-time check (CycloneDX 1.4+ / SPDX 2.3+)             |
+| `CRA Art. 13(5): Licensed component tracking`                   | Art. 13(5)     | PRE-7-RQ-05         | §5.4 (reco.)     | populate component `license` fields                       |
+| `CRA Art. 13(6): Vulnerability disclosure contact`              | Art. 13(6)     | RLS-2-RQ-01         | §5.5 (reco.)     | `securityContact` / `vulnerabilityDisclosureUrl`          |
+| `CRA Art. 13(7): Coordinated vulnerability disclosure policy`   | Art. 13(7)     | RLS-2-RQ-02         | —                | `coordinatedDisclosurePolicyUrl`                          |
+| `CRA Art. 13(8): Support period / lifecycle management`         | Art. 13(8)     | PRE-7-RQ-06         | §5.5             | `supportEndDate` + EOL enrichment                         |
+| `CRA Art. 13(9): Known vulnerabilities statement`               | Art. 13(9)     | RLS-2-RQ-04         | §5.5             | OSV / KEV / VEX enrichment                                |
+| `CRA Art. 13(11): Component lifecycle monitoring`               | Art. 13(11)    | PRE-7-RQ-06         | §5.5             | EOL enrichment + transitive supplier coverage             |
+| `CRA Art. 13(12): Product name and version identification`      | Art. 13(12)    | PRE-7-RQ-06         | §5.3             | SBOM `metadata.component.name` + `version` + sidecar      |
+| `CRA Art. 13(15): Manufacturer identification`                  | Art. 13(15)    | —                   | §5.3             | `manufacturerName` + `manufacturerEmail`                  |
+
+### CRA Article 14 (reporting obligations, applicable from 2026-09-11)
+
+| Requirement string                                          | CRA Article    | prEN 40000-1-3      | sidecar field                         |
+|-------------------------------------------------------------|----------------|---------------------|---------------------------------------|
+| `CRA Art. 14: PSIRT contact for external vulnerability reports` | Art. 14    | RLS-2-RQ-03         | `psirtUrl`                            |
+| `CRA Art. 14(1): 24-hour early-warning channel`             | Art. 14(1)     | RLS-2-RQ-03         | `earlyWarningContact`                 |
+| `CRA Art. 14(2): 72-hour incident-report channel`           | Art. 14(2)     | RLS-2-RQ-03         | `incidentReportContact`               |
+| `CRA Art. 14(7): ENISA single reporting platform`           | Art. 14(7)     | RLS-2-RQ-03-RE      | `enisaReportingPlatformId`            |
+
+Pre-deadline (`Utc::now() < 2026-09-11`) findings are emitted as `Info`;
+post-deadline they become `Warning` (or `Error` at
+`ImportantClass2`/`Critical` per the
+[product-class calibration](#cra-p32-product-class-severity-calibration)).
+
+### CRA Annexes
+
+| Requirement string                                          | CRA Annex                | prEN 40000-1-3      | What clears it                                          |
+|-------------------------------------------------------------|--------------------------|---------------------|---------------------------------------------------------|
+| `CRA Annex I Part II / prEN 40000-1-3 [PRE-7-RQ-07-RE]: Vendor hash carry-through` | Annex I Part II | PRE-7-RQ-07-RE | strong (SHA-256+) hash on vendor-supplied components |
+| `CRA Annex I Part II 1: Component identifier`               | Annex I Part II 1        | PRE-7-RQ-07         | PURL / CPE / SWID / SWHID on each component             |
+| `CRA Annex I Part III: Supply chain transparency`           | Annex I Part III         | PRE-7-RQ-01,03      | supplier on direct + transitive deps                    |
+| `CRA Annex III: Document signature/integrity`               | Annex III                | —                   | serial number / digital signature / attestation hash    |
+| `CRA Annex IV: EUCC reference (Common Criteria certificate)`| Annex IV                 | —                   | `Certification` external ref with `eucc`/`common-criteria` URL |
+| `CRA Annex V: Technical documentation`                      | Annex V                  | —                   | run `sbom-tools cra-docs <sbom> --output dossier/`     |
+| `CRA Annex VII: EU Declaration of Conformity reference`     | Annex VII                | —                   | `Attestation`/`Certification` external ref OR `ceMarkingReference` |
+| `CRA Annex VIII: <Module> attestation reference`            | Annex VIII (Module B+C/H/EUCC) | —             | Module-specific `Attestation`/`Certification` external ref |
+| `CRA prEN 40000-1-3 [PRE-8-RQ-02]: Hardware component inventory` | Annex I Part II   | PRE-8-RQ-02         | producer + identifier + firmware version on hardware    |
+
+### Article 24 — open-source software steward floor
+
+| Requirement string                                          | CRA reference  | Cleared by                                            |
+|-------------------------------------------------------------|----------------|-------------------------------------------------------|
+| `CRA Art. 24: Vulnerability-handling process (steward floor)` | Art. 24      | `SecurityContact` / `Advisories` / `VulnerabilityAssertion` external ref OR `psirtUrl` / `vulnerabilityDisclosureUrl` |
+| `CRA Art. 13(7): Coordinated vulnerability disclosure policy` (relaxed to Warning under steward) | Art. 13(7) | `Advisories` external ref OR `coordinatedDisclosurePolicyUrl` |
+
+Article 24 *suppresses* manufacturer-only checks (Art. 13(15) email,
+Annex VII DoC, Annex VIII attestation, Article 14 channels, hardware
+[PRE-8-RQ-02], vendor-hash carry-through).
+
+## CRA-P3.2 product-class severity calibration
+
+When `--cra-product-class` (or sidecar `productClass`) is set, the
+severity of certain checks scales per Annex III/IV class. Selecting a
+class also implies a default conformity-assessment route (Annex VIII),
+overridable via sidecar `conformityAssessmentRoute`.
+
+| Check                          | Default | Important-1 | Important-2 | Critical |
+|--------------------------------|---------|-------------|-------------|----------|
+| Vendor-hash coverage threshold | 50%     | 80%         | 80%         | 100%     |
+| Vendor-hash severity           | Warning | Warning     | Error       | Error    |
+| EOL components                 | Warning | Warning     | Error       | Error    |
+| Cycles                         | Warning | Warning     | Error       | Error    |
+| Annex VII DoC reference        | Info    | Warning     | Error       | Error    |
+| EUCC reference                 | n/a     | n/a         | Info        | Error    |
+| PSIRT documented               | Warning | Warning     | Error       | Error    |
+| Module attestation reference   | n/a     | Warning (B+C) | Error (B+C/H) | Error (EUCC) |
+
+Default conformity routes per class:
+
+| Class             | Default route       |
+|-------------------|---------------------|
+| Default           | Module A (self-assessment) |
+| ImportantClass1   | Module A (self-assessment, B+C optional) |
+| ImportantClass2   | Module B+C          |
+| Critical          | EUCC                |
+
+## BSI TR-03183-2 — quick mapping
+
+`ComplianceLevel::BsiTr03183_2` runs the §5 mandatory rules plus §6
+recommendations. SARIF rule prefix: `SBOM-BSI-TR-03183-2-*`. Canonical URL:
+[bsi.bund.de TR-03183](https://www.bsi.bund.de/EN/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/Technische-Richtlinien/TR-nach-Thema-sortiert/tr03183/TR-03183_node.html).
+
+| BSI section | Required signal                                                | Cleared by                                                  |
+|-------------|----------------------------------------------------------------|-------------------------------------------------------------|
+| §5.1        | Mandatory ISO 8601 timestamp on document metadata              | parse-time validation                                        |
+| §5.2        | Mandatory creator + tool identification                        | SBOM `metadata.tools` / SPDX `creator`                      |
+| §5.3        | Mandatory PURL or other unique identifier per component        | one of `purl` / `cpe` / `swid` / `swhid` per component       |
+| §5.4        | Mandatory SHA-256+ hash per component                          | strong hash on every component                              |
+| §5.5        | Mandatory dependency relationships                             | populated `dependencies` graph                              |
+| §6 (reco.)  | License, supplier, lifecycle phase                             | `license` / `supplier` / lifecycle properties               |
+
+## CSAF v2.0 (ISO/IEC 20153:2025)
+
+CSAF advisories ingest into `VexEnricher` alongside OpenVEX and
+CycloneDX VEX. Format auto-detection: `document.csaf_version` starts
+with `2.`. CSAF emit support: see
+[`vex export --format csaf`](#csaf-emit) (P4.2).
+
+| CSAF field                                | Internal mapping                              |
+|-------------------------------------------|-----------------------------------------------|
+| `vulnerabilities[].cve`                   | `Vulnerability.id`                            |
+| `vulnerabilities[].ids[].text` (fallback) | `Vulnerability.id` (e.g., GHSA)               |
+| `product_status.known_affected`           | `VexState::Affected`                          |
+| `product_status.known_not_affected`       | `VexState::NotAffected`                       |
+| `product_status.fixed`, `first_fixed`, `last_affected` | `VexState::Fixed`                |
+| `product_status.under_investigation`      | `VexState::UnderInvestigation`                |
+| `product_status.recommended`              | `VexState::Affected` (with note)              |
+| `product_tree.full_product_names[].product_identification_helper.purl` | `(vuln_id, purl)` lookup key |
+
+## CLI cheat sheet
+
+```bash
+# Multi-standard validate with CRA + BSI + NTIA in one pass
+sbom-tools validate sbom.json --standard cra,bsi,ntia
+
+# CRA Phase 2 with product-class calibration via sidecar
+sbom-tools validate sbom.json --standard cra --cra-sidecar sbom.cra.yaml
+
+# CRA validation with explicit product class
+sbom-tools validate sbom.json --standard cra --cra-product-class important-class-2
+
+# Article 24 steward profile
+sbom-tools validate sbom.json --standard oss-steward
+
+# SARIF output for CI (with helpUri populated)
+sbom-tools validate sbom.json --standard cra -o sarif -O compliance.sarif
+
+# Generate CRA technical-documentation dossier (Annex V)
+sbom-tools cra-docs sbom.json --output dossier/ --cra-sidecar sbom.cra.yaml
+
+# Apply CSAF advisories to enrich SBOM with VEX data
+sbom-tools vex apply sbom.json --vex advisory.csaf.json
+```
+
+## Sidecar example
+
+```yaml
+manufacturerName: "Example Corp"
+manufacturerEmail: "legal@example.com"
+productName: "Example Product"
+productVersion: "1.0.0"
+ceMarkingReference: "EU-DoC-2026-001"
+supportEndDate: "2030-12-31T00:00:00Z"
+
+productClass: "important-class-1"
+conformityAssessmentRoute: "module-a"
+
+riskAssessmentUrl: "https://example.com/risk-assessment.pdf"
+riskAssessmentMethodology: "ISO/IEC 27005:2022"
+
+securityContact: "security@example.com"
+psirtUrl: "https://example.com/psirt"
+coordinatedDisclosurePolicyUrl: "https://example.com/security/cvd-policy"
+earlyWarningContact: "ew@example.com"
+incidentReportContact: "incidents@example.com"
+enisaReportingPlatformId: "EU-MFR-12345"
+
+isOssSteward: false
+```
+
+Auto-discovered next to the SBOM at any of:
+`<stem>.cra.{json,yaml,yml}`, `<stem>-cra.{json,yaml}`, with multi-extension
+stems also tried (`app.cdx.json` → `app.cra.json` works).
+
+## Standards bibliography
+
+| Standard / regulation              | URL                                                                                                                                                |
+|------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
+| CRA — Regulation (EU) 2024/2847    | https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng                                                                                                 |
+| prEN 40000-1-3 (in development)    | (CEN-CENELEC JTC 13 — paywalled draft; URLs unstable)                                                                                              |
+| BSI TR-03183-2                     | https://www.bsi.bund.de/EN/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/Technische-Richtlinien/TR-nach-Thema-sortiert/tr03183/TR-03183_node.html |
+| ENISA SBOM Implementation Guidance | https://www.enisa.europa.eu/publications/sbom-implementation-guidance                                                                              |
+| NIST SP 800-218 SSDF               | https://doi.org/10.6028/NIST.SP.800-218                                                                                                            |
+| EO 14028                           | https://www.federalregister.gov/d/2021-10460                                                                                                       |
+| FDA premarket cybersecurity        | https://www.fda.gov/regulatory-information/search-fda-guidance-documents/cybersecurity-medical-devices-quality-system-considerations-and-content-premarket-submissions |
+| NTIA SBOM minimum elements         | https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf                                                                  |
+| CSAF v2.0 (ISO/IEC 20153:2025)     | https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html                                                                                          |
+| OpenVEX                            | https://github.com/openvex/spec                                                                                                                    |
+| CISA KEV                           | https://www.cisa.gov/known-exploited-vulnerabilities-catalog                                                                                       |
+| OSV.dev                            | https://osv.dev                                                                                                                                    |
+| EUCC (Reg. (EU) 2024/482)          | https://eur-lex.europa.eu/eli/reg/2024/482/oj/eng                                                                                                  |
+
+## Where this map lives in the code
+
+- `Violation::derive_standard_refs()` in `src/quality/compliance.rs` —
+  string → `(StandardKind, id)` mapping. Drives SARIF
+  `properties.standardIds`.
+- `StandardKind::canonical_help_uri()` in `src/quality/compliance.rs` —
+  `(StandardKind, id)` → URL. Drives SARIF `helpUri` and
+  `properties.standardHelpUris`.
+- `rule_help_uri()` in `src/reports/sarif.rs` — rule-ID prefix → URL
+  for `runs[].tool.driver.rules[].helpUri`.
+- `ComplianceChecker::class_severity()` in `src/quality/compliance.rs` —
+  P3.2 calibration table.
+- `cli::run_cra_docs` in `src/cli/cra_docs.rs` — Annex V dossier
+  generator.

--- a/src/cli/cra_docs.rs
+++ b/src/cli/cra_docs.rs
@@ -202,8 +202,7 @@ fn render_tech_doc(
         let warnings = compliance.warning_count;
         let infos = compliance.info_count;
         violations_md.push_str(&format!(
-            "**Compliance check summary** ({} errors, {} warnings, {} info):\n\n",
-            errors, warnings, infos
+            "**Compliance check summary** ({errors} errors, {warnings} warnings, {infos} info):\n\n"
         ));
         for v in compliance.violations.iter().take(10) {
             let sev = match v.severity {

--- a/src/cli/cra_docs.rs
+++ b/src/cli/cra_docs.rs
@@ -1,0 +1,447 @@
+//! `cra-docs` command handler.
+//!
+//! Generates a CRA technical-documentation dossier (Annex V templates)
+//! prefilled from the SBOM and an optional CRA sidecar. Output is a
+//! directory containing three Markdown files that a notified body or
+//! auditor can use as a starting point:
+//!
+//! - `eu-declaration-of-conformity.md` — Annex V Declaration of Conformity
+//! - `technical-documentation.md`      — Annex V technical-documentation summary
+//! - `vulnerability-handling-policy.md` — Annex I Part II policy stub
+//!
+//! Fields the SBOM/sidecar can supply are filled in; everything else is
+//! left as `_TBD_` so the operator can complete the document by hand.
+
+use crate::model::{
+    ConformityRoute, CraProductClass, CraSidecarMetadata, NormalizedSbom,
+};
+use crate::pipeline::parse_sbom_with_context;
+use crate::quality::{ComplianceChecker, ComplianceLevel, ComplianceResult};
+use anyhow::{Context, Result};
+use std::path::PathBuf;
+
+/// Run the `cra-docs` command. Generates 3 Markdown files in `output_dir`.
+#[allow(clippy::needless_pass_by_value)]
+pub fn run_cra_docs(
+    sbom_path: PathBuf,
+    output_dir: PathBuf,
+    cra_sidecar_path: Option<PathBuf>,
+    cra_product_class: Option<String>,
+) -> Result<()> {
+    let parsed = parse_sbom_with_context(&sbom_path, false)?;
+    let sbom = parsed.sbom();
+
+    // Sidecar resolution: explicit path → auto-discover.
+    let sidecar = match cra_sidecar_path {
+        Some(p) => Some(
+            CraSidecarMetadata::from_file(&p).map_err(|e| {
+                anyhow::anyhow!("Failed to load CRA sidecar from {}: {e}", p.display())
+            })?,
+        ),
+        None => CraSidecarMetadata::find_for_sbom(&sbom_path),
+    };
+
+    // Effective product class: sidecar wins, else CLI flag, else Default.
+    let cli_class = cra_product_class
+        .as_deref()
+        .and_then(CraProductClass::parse_cli);
+    let sidecar_class = sidecar.as_ref().and_then(|s| s.product_class);
+    if let (Some(cli), Some(side)) = (cli_class, sidecar_class)
+        && cli != side
+    {
+        tracing::warn!(
+            "CRA product class mismatch: --cra-product-class={} but sidecar says {}; using sidecar.",
+            cli.label(),
+            side.label()
+        );
+    }
+    let effective_class = sidecar_class
+        .or(cli_class)
+        .unwrap_or(CraProductClass::Default);
+
+    // Build a compliance result so the dossier can summarise readiness.
+    let mut checker = ComplianceChecker::new(ComplianceLevel::CraPhase2);
+    if let Some(sc) = sidecar.clone() {
+        checker = checker.with_sidecar(sc);
+    }
+    checker = checker.with_product_class(effective_class);
+    let compliance = checker.check(sbom);
+    let route = checker.effective_route();
+
+    std::fs::create_dir_all(&output_dir).with_context(|| {
+        format!("creating output directory {}", output_dir.display())
+    })?;
+
+    write_doc(
+        &output_dir.join("eu-declaration-of-conformity.md"),
+        &render_doc(sbom, sidecar.as_ref(), effective_class, route),
+    )?;
+    write_doc(
+        &output_dir.join("technical-documentation.md"),
+        &render_tech_doc(sbom, sidecar.as_ref(), effective_class, route, &compliance),
+    )?;
+    write_doc(
+        &output_dir.join("vulnerability-handling-policy.md"),
+        &render_vuln_policy(sbom, sidecar.as_ref()),
+    )?;
+
+    println!(
+        "CRA dossier written to {} ({} files)",
+        output_dir.display(),
+        3
+    );
+    Ok(())
+}
+
+fn write_doc(path: &std::path::Path, content: &str) -> Result<()> {
+    std::fs::write(path, content)
+        .with_context(|| format!("writing {}", path.display()))
+}
+
+/// Render the EU Declaration of Conformity (Annex V) template.
+fn render_doc(
+    sbom: &NormalizedSbom,
+    sidecar: Option<&CraSidecarMetadata>,
+    class: CraProductClass,
+    route: ConformityRoute,
+) -> String {
+    let manufacturer = sidecar
+        .and_then(|s| s.manufacturer_name.as_deref())
+        .or_else(|| {
+            sbom.document
+                .creators
+                .iter()
+                .find(|c| {
+                    matches!(c.creator_type, crate::model::CreatorType::Organization)
+                })
+                .map(|c| c.name.as_str())
+        })
+        .unwrap_or("_TBD: manufacturer name_");
+    let manufacturer_email = sidecar
+        .and_then(|s| s.manufacturer_email.as_deref())
+        .unwrap_or("_TBD: manufacturer email_");
+    let product_name = sidecar
+        .and_then(|s| s.product_name.as_deref())
+        .or(sbom.document.name.as_deref())
+        .unwrap_or("_TBD: product name_");
+    let product_version = sidecar
+        .and_then(|s| s.product_version.as_deref())
+        .unwrap_or("_TBD: product version_");
+    let ce_marking = sidecar
+        .and_then(|s| s.ce_marking_reference.as_deref())
+        .unwrap_or("_TBD: CE marking reference / DoC document ID_");
+
+    format!(
+        "# EU Declaration of Conformity (Cyber Resilience Act, Annex V)\n\n\
+         > **Generated by sbom-tools cra-docs.** Review and complete the `_TBD_` \
+         placeholders before relying on this document for conformity assessment.\n\n\
+         **1. Product**\n\
+         - Name: {product_name}\n\
+         - Version: {product_version}\n\
+         - CE marking / DoC reference: {ce_marking}\n\
+         - CRA product class: {class_name}\n\n\
+         **2. Manufacturer**\n\
+         - Name: {manufacturer}\n\
+         - Contact: {manufacturer_email}\n\
+         - Address: _TBD: registered office address_\n\n\
+         **3. Conformity-assessment route (CRA Annex VIII)**\n\
+         - Route: {route_name}\n\
+         - Notified body (if applicable): _TBD: notified body name + 4-digit number_\n\
+         - Certificate / attestation reference: _TBD_\n\n\
+         **4. Applicable CRA requirements**\n\
+         - Regulation (EU) 2024/2847 — Annex I (Essential cybersecurity requirements)\n\
+         - Annex I Part I (1) — Cybersecurity properties of products with digital elements\n\
+         - Annex I Part I (2) — Vulnerability-handling requirements\n\
+         - Annex II — Information and instructions to the user\n\n\
+         **5. Harmonised standards / common specifications applied**\n\
+         - prEN 40000-1-3 (horizontal SBOM and vulnerability-handling requirements)\n\
+         - BSI TR-03183-2 (German national CRA-aligned SBOM technical guideline)\n\
+         - _TBD: any vertical EN 304-6xx product-class standards applied_\n\n\
+         **6. Other Union legislation in conjunction with which conformity is declared**\n\
+         - _TBD: list any other applicable EU regulations (NIS2, GDPR, AI Act, …)_\n\n\
+         **7. Signed for and on behalf of the manufacturer**\n\
+         - Place: _TBD_\n\
+         - Date: _TBD_\n\
+         - Name and function: _TBD_\n\
+         - Signature: _TBD_\n",
+        product_name = product_name,
+        product_version = product_version,
+        ce_marking = ce_marking,
+        class_name = class.name(),
+        manufacturer = manufacturer,
+        manufacturer_email = manufacturer_email,
+        route_name = route.name(),
+    )
+}
+
+/// Render the Annex V technical-documentation summary.
+fn render_tech_doc(
+    sbom: &NormalizedSbom,
+    sidecar: Option<&CraSidecarMetadata>,
+    class: CraProductClass,
+    route: ConformityRoute,
+    compliance: &ComplianceResult,
+) -> String {
+    let component_count = sbom.components.len();
+    let dependency_count = sbom.edges.len();
+    let format_label = format!("{:?} {}", sbom.document.format, sbom.document.spec_version);
+    let risk_assessment = sidecar
+        .and_then(|s| s.risk_assessment_url.as_deref())
+        .unwrap_or("_TBD: link to documented risk assessment (CRA Art. 13(2))_");
+    let methodology = sidecar
+        .and_then(|s| s.risk_assessment_methodology.as_deref())
+        .unwrap_or("_TBD: e.g., ISO/IEC 27005:2022_");
+    let psirt = sidecar
+        .and_then(|s| s.psirt_url.as_deref())
+        .unwrap_or("_TBD: PSIRT URL (CRA Art. 14)_");
+    let support_end = sidecar
+        .and_then(|s| s.support_end_date)
+        .map(|d| d.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "_TBD: support end date (CRA Art. 13(8))_".to_string());
+
+    let mut violations_md = String::new();
+    if compliance.violations.is_empty() {
+        violations_md.push_str("_No CRA compliance issues detected by sbom-tools._\n");
+    } else {
+        let errors = compliance.error_count;
+        let warnings = compliance.warning_count;
+        let infos = compliance.info_count;
+        violations_md.push_str(&format!(
+            "**Compliance check summary** ({} errors, {} warnings, {} info):\n\n",
+            errors, warnings, infos
+        ));
+        for v in compliance.violations.iter().take(10) {
+            let sev = match v.severity {
+                crate::quality::ViolationSeverity::Error => "ERROR",
+                crate::quality::ViolationSeverity::Warning => "WARN",
+                crate::quality::ViolationSeverity::Info => "INFO",
+            };
+            violations_md.push_str(&format!(
+                "- **[{}] {}** — {}\n",
+                sev, v.requirement, v.message
+            ));
+        }
+        if compliance.violations.len() > 10 {
+            violations_md.push_str(&format!(
+                "- … and {} more findings (see SARIF / JSON output)\n",
+                compliance.violations.len() - 10
+            ));
+        }
+    }
+
+    format!(
+        "# Technical Documentation Summary (CRA Annex V)\n\n\
+         > **Generated by sbom-tools cra-docs.** Use this document as a \
+         starting point; complete the `_TBD_` fields and attach evidence \
+         before submission.\n\n\
+         ## 1. Product description\n\
+         - SBOM format: {format_label}\n\
+         - Components in scope: {component_count}\n\
+         - Declared dependency edges: {dependency_count}\n\
+         - CRA product class: {class_name}\n\
+         - Conformity route: {route_name}\n\n\
+         ## 2. Risk assessment (CRA Art. 13(2))\n\
+         - Risk-assessment document: {risk_assessment}\n\
+         - Methodology: {methodology}\n\
+         - Annex II Part 3 risk-acceptance criteria: _TBD_\n\n\
+         ## 3. Vulnerability-handling process (Annex I Part II)\n\
+         - Process description: see `vulnerability-handling-policy.md` in this dossier\n\
+         - PSIRT: {psirt}\n\
+         - Support / security-update end date: {support_end}\n\n\
+         ## 4. Software Bill of Materials\n\
+         - Embedded SBOM: provided as a separate file in this submission\n\
+         - Generated by sbom-tools v{tool_version}\n\
+         - SBOM serial number: {serial}\n\n\
+         ## 5. Compliance check summary\n\n\
+         {violations_md}\n\
+         ## 6. Test and evaluation reports\n\
+         - Penetration test report: _TBD_\n\
+         - Code review / SAST report: _TBD_\n\
+         - DAST / fuzzing report: _TBD_\n\
+         - Third-party attestation (Module B+C / H / EUCC): _TBD_\n\n\
+         ## 7. Cybersecurity-relevant changes since previous version\n\
+         - _TBD: changelog of security-relevant changes_\n",
+        format_label = format_label,
+        component_count = component_count,
+        dependency_count = dependency_count,
+        class_name = class.name(),
+        route_name = route.name(),
+        risk_assessment = risk_assessment,
+        methodology = methodology,
+        psirt = psirt,
+        support_end = support_end,
+        tool_version = env!("CARGO_PKG_VERSION"),
+        serial = sbom
+            .document
+            .serial_number
+            .as_deref()
+            .unwrap_or("_TBD: assign a unique serial / namespace_"),
+        violations_md = violations_md,
+    )
+}
+
+/// Render the Annex I Part II vulnerability-handling policy stub.
+fn render_vuln_policy(sbom: &NormalizedSbom, sidecar: Option<&CraSidecarMetadata>) -> String {
+    let psirt = sidecar
+        .and_then(|s| s.psirt_url.as_deref())
+        .unwrap_or("_TBD: PSIRT URL_");
+    let security_contact = sidecar
+        .and_then(|s| s.security_contact.as_deref())
+        .unwrap_or("_TBD: security contact email_");
+    let cvd_policy = sidecar
+        .and_then(|s| s.coordinated_disclosure_policy_url.as_deref())
+        .unwrap_or("_TBD: coordinated vulnerability-disclosure policy URL_");
+    let early = sidecar
+        .and_then(|s| s.early_warning_contact.as_deref())
+        .unwrap_or("_TBD: 24-hour early-warning channel (CRA Art. 14(1))_");
+    let incident = sidecar
+        .and_then(|s| s.incident_report_contact.as_deref())
+        .unwrap_or("_TBD: 72-hour incident-report channel (CRA Art. 14(2))_");
+    let enisa = sidecar
+        .and_then(|s| s.enisa_reporting_platform_id.as_deref())
+        .unwrap_or("_TBD: ENISA single-reporting-platform manufacturer ID (Art. 14(7))_");
+
+    format!(
+        "# Vulnerability-Handling Policy (CRA Annex I Part II)\n\n\
+         > **Generated by sbom-tools cra-docs.** Replace `_TBD_` placeholders \
+         with your operational details before publishing this document.\n\n\
+         ## 1. Scope\n\
+         This policy applies to all products with digital elements identified in \
+         the accompanying SBOM ({components} components, primary identifier \
+         {primary_id}).\n\n\
+         ## 2. Reporting channels\n\
+         | Channel | Endpoint |\n\
+         |---|---|\n\
+         | PSIRT (public reporting portal) | {psirt} |\n\
+         | Security contact (encrypted email) | {security_contact} |\n\
+         | Coordinated disclosure policy | {cvd_policy} |\n\
+         | 24-hour early warning (CRA Art. 14(1)) | {early} |\n\
+         | 72-hour incident report (CRA Art. 14(2)) | {incident} |\n\
+         | ENISA single reporting platform (Art. 14(7)) | {enisa} |\n\n\
+         ## 3. Process commitments\n\
+         - **Acknowledgement**: we will acknowledge receipt of any vulnerability \
+         report within _TBD_ business days.\n\
+         - **Assessment**: we will perform an initial impact assessment within \
+         _TBD_ business days.\n\
+         - **Disclosure**: we follow ISO/IEC 29147 / 30111 coordinated-disclosure \
+         practice (target embargo: _TBD_).\n\
+         - **Patch availability**: security patches are made available free of \
+         charge for the duration of the support period.\n\n\
+         ## 4. Active-exploitation handling\n\
+         - We monitor CISA KEV, ENISA EU-VDB, and OSV.dev for actively-exploited \
+         vulnerabilities affecting components in our SBOMs.\n\
+         - When an actively-exploited vulnerability is confirmed, the early-warning \
+         channel above is engaged within 24 hours and a CSAF v2.0 advisory is \
+         published as soon as a remediation or mitigation is available.\n\n\
+         ## 5. SBOM update commitment\n\
+         - The SBOM accompanying this product is regenerated and re-signed on \
+         every release that introduces, removes, or upgrades a tracked \
+         component (CRA Art. 13(3)).\n\
+         - VEX statements (CSAF v2.0 / OpenVEX / CycloneDX VEX) are published \
+         alongside the SBOM whenever a vulnerability affecting a tracked \
+         component is acknowledged.\n",
+        components = sbom.components.len(),
+        primary_id = sbom
+            .primary_component_id
+            .as_ref()
+            .map(|c| c.value().to_string())
+            .unwrap_or_else(|| "_TBD: primary component ID_".to_string()),
+        psirt = psirt,
+        security_contact = security_contact,
+        cvd_policy = cvd_policy,
+        early = early,
+        incident = incident,
+        enisa = enisa,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::Component;
+    use tempfile::tempdir;
+
+    #[test]
+    fn dossier_files_created_for_minimal_sbom() {
+        let dir = tempdir().unwrap();
+        let sbom_path = dir.path().join("app.cdx.json");
+        std::fs::write(
+            &sbom_path,
+            r#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[]}"#,
+        )
+        .unwrap();
+        let out = dir.path().join("dossier");
+
+        run_cra_docs(sbom_path, out.clone(), None, None).expect("cra-docs runs");
+
+        assert!(out.join("eu-declaration-of-conformity.md").exists());
+        assert!(out.join("technical-documentation.md").exists());
+        assert!(out.join("vulnerability-handling-policy.md").exists());
+    }
+
+    #[test]
+    fn doc_template_is_filled_from_sidecar() {
+        let mut sbom = NormalizedSbom::default();
+        sbom.add_component(Component::new("c".to_string(), "c".to_string()));
+        let sidecar = CraSidecarMetadata {
+            manufacturer_name: Some("ExCorp".to_string()),
+            manufacturer_email: Some("legal@example.com".to_string()),
+            product_name: Some("ExProduct".to_string()),
+            product_version: Some("1.0".to_string()),
+            ce_marking_reference: Some("EU-DoC-2026-001".to_string()),
+            ..Default::default()
+        };
+        let doc = render_doc(
+            &sbom,
+            Some(&sidecar),
+            CraProductClass::ImportantClass1,
+            ConformityRoute::ModuleA,
+        );
+        assert!(doc.contains("ExCorp"));
+        assert!(doc.contains("legal@example.com"));
+        assert!(doc.contains("ExProduct"));
+        assert!(doc.contains("EU-DoC-2026-001"));
+        assert!(doc.contains("Important Class I"));
+        assert!(doc.contains("Module A"));
+    }
+
+    #[test]
+    fn vuln_policy_filled_from_sidecar() {
+        let sbom = NormalizedSbom::default();
+        let sidecar = CraSidecarMetadata {
+            psirt_url: Some("https://example.com/psirt".to_string()),
+            security_contact: Some("security@example.com".to_string()),
+            coordinated_disclosure_policy_url: Some(
+                "https://example.com/security/cvd".to_string(),
+            ),
+            early_warning_contact: Some("ew@example.com".to_string()),
+            incident_report_contact: Some("incidents@example.com".to_string()),
+            enisa_reporting_platform_id: Some("EU-MFR-1".to_string()),
+            ..Default::default()
+        };
+        let policy = render_vuln_policy(&sbom, Some(&sidecar));
+        assert!(policy.contains("https://example.com/psirt"));
+        assert!(policy.contains("security@example.com"));
+        assert!(policy.contains("https://example.com/security/cvd"));
+        assert!(policy.contains("ew@example.com"));
+        assert!(policy.contains("incidents@example.com"));
+        assert!(policy.contains("EU-MFR-1"));
+    }
+
+    #[test]
+    fn tech_doc_includes_compliance_summary() {
+        let mut sbom = NormalizedSbom::default();
+        sbom.add_component(Component::new("c".to_string(), "c".to_string()));
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        let tech = render_tech_doc(
+            &sbom,
+            None,
+            CraProductClass::Default,
+            ConformityRoute::ModuleA,
+            &result,
+        );
+        // should mention component count + compliance summary header
+        assert!(tech.contains("Components in scope: 1"));
+        assert!(tech.contains("Compliance check summary"));
+    }
+}

--- a/src/cli/cra_docs.rs
+++ b/src/cli/cra_docs.rs
@@ -200,6 +200,7 @@ fn render_tech_doc(
         .unwrap_or_else(|| "_TBD: support end date (CRA Art. 13(8))_".to_string());
 
     let adjacent_regulation_md = render_adjacent_regulation_section(sidecar);
+    let controls_assertion_md = render_controls_assertion_section(sidecar);
 
     let mut violations_md = String::new();
     if compliance.violations.is_empty() {
@@ -263,6 +264,7 @@ fn render_tech_doc(
          - Third-party attestation (Module B+C / H / EUCC): _TBD_\n\n\
          ## 7. Cybersecurity-relevant changes since previous version\n\
          - _TBD: changelog of security-relevant changes_\n\
+         {controls_assertion_md}\
          {adjacent_regulation_md}",
         format_label = format_label,
         component_count = component_count,
@@ -280,8 +282,46 @@ fn render_tech_doc(
             .as_deref()
             .unwrap_or("_TBD: assign a unique serial / namespace_"),
         violations_md = violations_md,
+        controls_assertion_md = controls_assertion_md,
         adjacent_regulation_md = adjacent_regulation_md,
     )
+}
+
+/// Render the prEN 40000-1-2/1-4 controls-assertion block (CRA-P5.5).
+/// Empty sidecars or sidecars without `annex_i_part_i_controls` skip the
+/// section entirely so the dossier stays clean for products that don't
+/// claim per-control assertions.
+fn render_controls_assertion_section(sidecar: Option<&CraSidecarMetadata>) -> String {
+    let Some(sc) = sidecar else {
+        return String::new();
+    };
+    if sc.annex_i_part_i_controls.is_empty() {
+        return String::new();
+    }
+    let mut s = String::from("\n## 8. Annex I Part I controls assertion (prEN 40000-1-2/1-4)\n\n");
+    s.push_str(
+        "Per-control assertions for CRA Annex I Part I, sourced from the \
+         sidecar `annex_i_part_i_controls` block. `Satisfied` rows must \
+         carry an evidence URL — un-evidenced claims are flagged by \
+         `sbom-tools validate --standard cra` as Warnings.\n\n",
+    );
+    s.push_str("| Control | Satisfied | Methodology | Evidence | Note |\n");
+    s.push_str("|---------|-----------|-------------|----------|------|\n");
+    for (id, claim) in &sc.annex_i_part_i_controls {
+        let satisfied = if claim.satisfied { "✅" } else { "❌" };
+        let methodology = claim.methodology.as_deref().unwrap_or("_TBD_");
+        let evidence = claim
+            .evidence_url
+            .as_deref()
+            .map(|u| format!("[link]({u})"))
+            .unwrap_or_else(|| "_TBD_".to_string());
+        let note = claim.note.as_deref().unwrap_or("");
+        s.push_str(&format!(
+            "| {id} | {satisfied} | {methodology} | {evidence} | {note} |\n"
+        ));
+    }
+    s.push('\n');
+    s
 }
 
 /// Render the "Adjacent regulation" section (CRA-P4.4). Only fires for

--- a/src/cli/cra_docs.rs
+++ b/src/cli/cra_docs.rs
@@ -12,9 +12,7 @@
 //! Fields the SBOM/sidecar can supply are filled in; everything else is
 //! left as `_TBD_` so the operator can complete the document by hand.
 
-use crate::model::{
-    ConformityRoute, CraProductClass, CraSidecarMetadata, NormalizedSbom,
-};
+use crate::model::{ConformityRoute, CraProductClass, CraSidecarMetadata, NormalizedSbom};
 use crate::pipeline::parse_sbom_with_context;
 use crate::quality::{ComplianceChecker, ComplianceLevel, ComplianceResult};
 use anyhow::{Context, Result};
@@ -33,11 +31,9 @@ pub fn run_cra_docs(
 
     // Sidecar resolution: explicit path → auto-discover.
     let sidecar = match cra_sidecar_path {
-        Some(p) => Some(
-            CraSidecarMetadata::from_file(&p).map_err(|e| {
-                anyhow::anyhow!("Failed to load CRA sidecar from {}: {e}", p.display())
-            })?,
-        ),
+        Some(p) => Some(CraSidecarMetadata::from_file(&p).map_err(|e| {
+            anyhow::anyhow!("Failed to load CRA sidecar from {}: {e}", p.display())
+        })?),
         None => CraSidecarMetadata::find_for_sbom(&sbom_path),
     };
 
@@ -68,9 +64,8 @@ pub fn run_cra_docs(
     let compliance = checker.check(sbom);
     let route = checker.effective_route();
 
-    std::fs::create_dir_all(&output_dir).with_context(|| {
-        format!("creating output directory {}", output_dir.display())
-    })?;
+    std::fs::create_dir_all(&output_dir)
+        .with_context(|| format!("creating output directory {}", output_dir.display()))?;
 
     write_doc(
         &output_dir.join("eu-declaration-of-conformity.md"),
@@ -94,8 +89,7 @@ pub fn run_cra_docs(
 }
 
 fn write_doc(path: &std::path::Path, content: &str) -> Result<()> {
-    std::fs::write(path, content)
-        .with_context(|| format!("writing {}", path.display()))
+    std::fs::write(path, content).with_context(|| format!("writing {}", path.display()))
 }
 
 /// Render the EU Declaration of Conformity (Annex V) template.
@@ -111,9 +105,7 @@ fn render_doc(
             sbom.document
                 .creators
                 .iter()
-                .find(|c| {
-                    matches!(c.creator_type, crate::model::CreatorType::Organization)
-                })
+                .find(|c| matches!(c.creator_type, crate::model::CreatorType::Organization))
                 .map(|c| c.name.as_str())
         })
         .unwrap_or("_TBD: manufacturer name_");
@@ -550,9 +542,7 @@ mod tests {
         let sidecar = CraSidecarMetadata {
             psirt_url: Some("https://example.com/psirt".to_string()),
             security_contact: Some("security@example.com".to_string()),
-            coordinated_disclosure_policy_url: Some(
-                "https://example.com/security/cvd".to_string(),
-            ),
+            coordinated_disclosure_policy_url: Some("https://example.com/security/cvd".to_string()),
             early_warning_contact: Some("ew@example.com".to_string()),
             incident_report_contact: Some("incidents@example.com".to_string()),
             enisa_reporting_platform_id: Some("EU-MFR-1".to_string()),

--- a/src/cli/cra_docs.rs
+++ b/src/cli/cra_docs.rs
@@ -340,7 +340,9 @@ fn render_adjacent_regulation_section(sidecar: Option<&CraSidecarMetadata>) -> S
         return String::new();
     }
 
-    let mut s = String::from("\n## 8. Adjacent regulation\n\n");
+    // Numbered after the controls-assertion block so the dossier reads
+    // 7 → 8 → 9 when both are present (controls = §8, adjacent = §9).
+    let mut s = String::from("\n## 9. Adjacent regulation\n\n");
     s.push_str(
         "The CRA does not operate in isolation. The following adjacent EU \
          legal acts apply to this product based on the sidecar declarations \

--- a/src/cli/cra_docs.rs
+++ b/src/cli/cra_docs.rs
@@ -199,6 +199,8 @@ fn render_tech_doc(
         .map(|d| d.format("%Y-%m-%d").to_string())
         .unwrap_or_else(|| "_TBD: support end date (CRA Art. 13(8))_".to_string());
 
+    let adjacent_regulation_md = render_adjacent_regulation_section(sidecar);
+
     let mut violations_md = String::new();
     if compliance.violations.is_empty() {
         violations_md.push_str("_No CRA compliance issues detected by sbom-tools._\n");
@@ -260,7 +262,8 @@ fn render_tech_doc(
          - DAST / fuzzing report: _TBD_\n\
          - Third-party attestation (Module B+C / H / EUCC): _TBD_\n\n\
          ## 7. Cybersecurity-relevant changes since previous version\n\
-         - _TBD: changelog of security-relevant changes_\n",
+         - _TBD: changelog of security-relevant changes_\n\
+         {adjacent_regulation_md}",
         format_label = format_label,
         component_count = component_count,
         dependency_count = dependency_count,
@@ -277,7 +280,101 @@ fn render_tech_doc(
             .as_deref()
             .unwrap_or("_TBD: assign a unique serial / namespace_"),
         violations_md = violations_md,
+        adjacent_regulation_md = adjacent_regulation_md,
     )
+}
+
+/// Render the "Adjacent regulation" section (CRA-P4.4). Only fires for
+/// the regulatory overlap flags actually set on the sidecar, so an
+/// SBOM-only dossier (no sidecar) skips the section entirely.
+fn render_adjacent_regulation_section(sidecar: Option<&CraSidecarMetadata>) -> String {
+    let Some(sc) = sidecar else {
+        return String::new();
+    };
+    let any = sc.is_nis2_essential_entity
+        || sc.is_nis2_important_entity
+        || sc.processes_personal_data
+        || sc.is_high_risk_ai
+        || sc.red_repealed_until.is_some();
+    if !any {
+        return String::new();
+    }
+
+    let mut s = String::from("\n## 8. Adjacent regulation\n\n");
+    s.push_str(
+        "The CRA does not operate in isolation. The following adjacent EU \
+         legal acts apply to this product based on the sidecar declarations \
+         and must be coordinated with CRA conformity assessment.\n\n",
+    );
+
+    if sc.is_nis2_essential_entity || sc.is_nis2_important_entity {
+        let entity_kind = if sc.is_nis2_essential_entity {
+            "essential entity (NIS2 Annex I)"
+        } else {
+            "important entity (NIS2 Annex II)"
+        };
+        s.push_str(&format!(
+            "### NIS2 — Directive (EU) 2022/2555\n\n\
+             - Manufacturer is registered as an **{entity_kind}**.\n\
+             - **Art. 23 incident reporting** runs in parallel with CRA \
+             Art. 14: a 24-hour early warning to the national CSIRT *and* \
+             ENISA, followed by a 72-hour incident notification, and a \
+             1-month final report.\n\
+             - **Art. 21 risk-management measures** overlap with CRA \
+             Annex I Part I and the documented risk assessment in §2 \
+             above.\n\
+             - National competent authority registration (NIS2 Art. 27) \
+             is a precondition for the Art. 23 reporting channels listed \
+             in `vulnerability-handling-policy.md`.\n\n",
+        ));
+    }
+
+    if sc.processes_personal_data {
+        s.push_str(
+            "### GDPR — Regulation (EU) 2016/679\n\n\
+             - The product processes personal data, so **GDPR Art. 32 \
+             (security of processing)** applies alongside CRA Annex I \
+             Part I (1) cybersecurity properties.\n\
+             - Personal-data breaches must additionally be reported to \
+             the supervisory authority under **Art. 33** (within 72 h) \
+             and to data subjects under **Art. 34** when the breach is \
+             likely to result in a high risk.\n\
+             - The CRA technical-documentation set (this dossier) should \
+             cross-reference the Data Protection Impact Assessment \
+             (DPIA) when one has been performed under Art. 35.\n\n",
+        );
+    }
+
+    if sc.is_high_risk_ai {
+        s.push_str(
+            "### AI Act — Regulation (EU) 2024/1689\n\n\
+             - The product is a **high-risk AI system** within the meaning \
+             of the AI Act.\n\
+             - AI-Act conformity assessment runs **in addition to** CRA \
+             Annex VIII; the CE marking covers both regulations \
+             simultaneously and the EU Declaration of Conformity must \
+             list both legal bases.\n\
+             - The post-market monitoring plan (AI Act Art. 72) and \
+             serious-incident reporting (Art. 73) are coordinated with \
+             CRA Art. 14 reporting; use the same channels listed in \
+             `vulnerability-handling-policy.md`.\n\n",
+        );
+    }
+
+    if let Some(until) = sc.red_repealed_until {
+        s.push_str(&format!(
+            "### Radio Equipment Directive (RED) — Directive 2014/53/EU\n\n\
+             - The cybersecurity provisions in **RED Art. 3(3)(d/e/f)** \
+             apply to this product until **{}** (sidecar field \
+             `red_repealed_until`).\n\
+             - Once superseded by the CRA, RED references in the SBOM / \
+             technical documentation should be retired and replaced with \
+             the matching CRA Annex I requirement.\n\n",
+            until.format("%Y-%m-%d"),
+        ));
+    }
+
+    s
 }
 
 /// Render the Annex I Part II vulnerability-handling policy stub.

--- a/src/cli/cra_standards_watch.rs
+++ b/src/cli/cra_standards_watch.rs
@@ -242,7 +242,11 @@ mod tests {
         for s in CATALOGUE {
             assert!(!s.id.is_empty(), "catalogue id must not be empty");
             assert!(!s.title.is_empty(), "catalogue title must not be empty");
-            assert!(s.url.starts_with("https://"), "catalogue URL must be https: {}", s.url);
+            assert!(
+                s.url.starts_with("https://"),
+                "catalogue URL must be https: {}",
+                s.url
+            );
         }
     }
 
@@ -256,8 +260,7 @@ mod tests {
 
     #[test]
     fn catalogue_covers_core_artefacts() {
-        let ids: std::collections::HashSet<&str> =
-            CATALOGUE.iter().map(|s| s.id).collect();
+        let ids: std::collections::HashSet<&str> = CATALOGUE.iter().map(|s| s.id).collect();
         for required in [
             "prEN-40000-1-3",
             "BSI-TR-03183-2",

--- a/src/cli/cra_standards_watch.rs
+++ b/src/cli/cra_standards_watch.rs
@@ -1,0 +1,284 @@
+//! `cra-standards-watch` command handler.
+//!
+//! Curated, offline-first list of CRA-related standards bodies and their
+//! tracked artefacts (prEN 40000 series, BSI TR-03183, ETSI EN 303 6xx,
+//! STAN4CRA hub). The command prints the catalogue with last-known
+//! version dates so operators can spot-check freshness without firing
+//! HTTP requests; an optional `--check-online` flag follows the URLs
+//! and reports HTTP status codes (best-effort, may be rate-limited).
+//!
+//! Out of scope: scraping working-group draft contents (paywalled), and
+//! parsing PDF version histories. The CLI is informational — it does not
+//! mutate any project state.
+
+use anyhow::Result;
+use serde::Serialize;
+use std::time::Duration;
+
+/// One tracked artefact in the CRA standards landscape.
+#[derive(Debug, Clone, Serialize)]
+pub struct TrackedStandard {
+    pub id: &'static str,
+    pub title: &'static str,
+    pub body: &'static str,
+    pub status: &'static str,
+    pub last_known_version: &'static str,
+    pub last_known_date: &'static str,
+    pub url: &'static str,
+    pub watch_reason: &'static str,
+}
+
+/// Curated catalogue. Update entries here when standards bodies publish a
+/// new draft or final version. Dates are last-confirmed by hand; the
+/// command does not mutate this list at runtime.
+const CATALOGUE: &[TrackedStandard] = &[
+    TrackedStandard {
+        id: "prEN-40000-1-3",
+        title: "prEN 40000-1-3 — SBOM and vulnerability-handling requirements",
+        body: "CEN-CENELEC JTC 13",
+        status: "Draft (not freely available)",
+        last_known_version: "Draft",
+        last_known_date: "2025-Q4",
+        url: "https://www.cencenelec.eu/areas-of-work/cen-cenelec-topics/cybersecurity-and-data-protection/",
+        watch_reason: "Normative requirement IDs (PRE-7-RQ-*, PRE-8-RQ-*, RLS-2-RQ-*) referenced by sbom-tools",
+    },
+    TrackedStandard {
+        id: "prEN-40000-1-2",
+        title: "prEN 40000-1-2 — Cybersecurity properties (Annex I Part I)",
+        body: "CEN-CENELEC JTC 13",
+        status: "Draft (not freely available)",
+        last_known_version: "Draft",
+        last_known_date: "2025-Q4",
+        url: "https://www.cencenelec.eu/areas-of-work/cen-cenelec-topics/cybersecurity-and-data-protection/",
+        watch_reason: "Drives Annex I Part I controls-assertion sidecar block (CRA-P5.5)",
+    },
+    TrackedStandard {
+        id: "BSI-TR-03183-2",
+        title: "BSI TR-03183-2 — Technical Guideline (national CRA-aligned SBOM)",
+        body: "BSI (Germany)",
+        status: "Public",
+        last_known_version: "2.0.0",
+        last_known_date: "2024-09",
+        url: "https://www.bsi.bund.de/EN/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/Technische-Richtlinien/TR-nach-Thema-sortiert/tr03183/TR-03183_node.html",
+        watch_reason: "Free, ENISA-cited; sbom-tools `--standard bsi` runs §5/§6 checks",
+    },
+    TrackedStandard {
+        id: "CSAF-v2.0",
+        title: "CSAF v2.0 — Common Security Advisory Framework (ISO/IEC 20153:2025)",
+        body: "OASIS / ISO",
+        status: "Final",
+        last_known_version: "2.0",
+        last_known_date: "2022-11",
+        url: "https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html",
+        watch_reason: "Advisory format named in CRA prEN 40000-1-3 [RLS-2-RQ-03-RE]",
+    },
+    TrackedStandard {
+        id: "ENISA-SBOM-Guidance",
+        title: "ENISA SBOM Implementation Guidance",
+        body: "ENISA",
+        status: "Public",
+        last_known_version: "v1.0",
+        last_known_date: "2024",
+        url: "https://www.enisa.europa.eu/publications/sbom-implementation-guidance",
+        watch_reason: "ENISA's reference for CRA-aligned SBOM practice",
+    },
+    TrackedStandard {
+        id: "EUCC",
+        title: "EUCC scheme — Common Criteria (Reg. (EU) 2024/482)",
+        body: "European Commission / ENISA",
+        status: "Final",
+        last_known_version: "Reg. 2024/482",
+        last_known_date: "2024-01-31",
+        url: "https://eur-lex.europa.eu/eli/reg/2024/482/oj/eng",
+        watch_reason: "Mandatory for CRA Annex IV (Critical) products",
+    },
+    TrackedStandard {
+        id: "STAN4CRA",
+        title: "STAN4CRA — CEN-CENELEC standardisation hub for CRA",
+        body: "CEN-CENELEC",
+        status: "Hub",
+        last_known_version: "Live",
+        last_known_date: "n/a",
+        url: "https://www.stan4cra.eu/",
+        watch_reason: "Aggregates harmonised standards under the CRA mandate",
+    },
+    TrackedStandard {
+        id: "ETSI-EN-303-6xx",
+        title: "ETSI EN 303 6xx — vertical product-class cybersecurity",
+        body: "ETSI TC CYBER",
+        status: "Mixed",
+        last_known_version: "Various",
+        last_known_date: "ongoing",
+        url: "https://docbox.etsi.org/CYBER/EUSR/Open/",
+        watch_reason: "Product-class verticals (browsers, AV, OS, password managers) under CRA",
+    },
+];
+
+/// Output format for `cra-standards-watch`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WatchOutputFormat {
+    Table,
+    Json,
+}
+
+impl WatchOutputFormat {
+    pub fn parse(s: &str) -> anyhow::Result<Self> {
+        match s.to_lowercase().as_str() {
+            "table" | "auto" => Ok(Self::Table),
+            "json" => Ok(Self::Json),
+            other => anyhow::bail!("Unsupported format '{other}'. Valid: table, json"),
+        }
+    }
+}
+
+/// Run the `cra-standards-watch` command.
+pub fn run_cra_standards_watch(
+    format: WatchOutputFormat,
+    check_online: bool,
+    timeout_secs: u64,
+) -> Result<()> {
+    let entries = CATALOGUE.to_vec();
+    let online_status = if check_online {
+        Some(probe_urls(&entries, Duration::from_secs(timeout_secs)))
+    } else {
+        None
+    };
+
+    match format {
+        WatchOutputFormat::Json => {
+            let payload = serde_json::json!({
+                "tool": "sbom-tools",
+                "version": env!("CARGO_PKG_VERSION"),
+                "catalogue": entries,
+                "online_status": online_status,
+            });
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        }
+        WatchOutputFormat::Table => {
+            println!("CRA standards watch — last-known versions");
+            println!("{}", "=".repeat(60));
+            for s in &entries {
+                println!("\n[{}] {}", s.id, s.title);
+                println!("  Body:        {}", s.body);
+                println!("  Status:      {}", s.status);
+                println!(
+                    "  Version:     {} ({})",
+                    s.last_known_version, s.last_known_date
+                );
+                println!("  URL:         {}", s.url);
+                println!("  Watch:       {}", s.watch_reason);
+                if let Some(ref probes) = online_status
+                    && let Some(probe) = probes.iter().find(|p| p.id == s.id)
+                {
+                    println!("  HTTP status: {}", probe.status);
+                }
+            }
+            println!();
+            println!(
+                "Catalogue is curated and shipped with sbom-tools v{}; \
+                 update via PR when standards bodies publish new versions.",
+                env!("CARGO_PKG_VERSION")
+            );
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct OnlineProbe {
+    id: &'static str,
+    status: String,
+}
+
+/// Fire HEAD requests at each catalogue URL with the supplied timeout.
+/// Best-effort — many of these endpoints don't accept HEAD; we report
+/// the resulting status string verbatim. No retries, no caching.
+fn probe_urls(entries: &[TrackedStandard], timeout: Duration) -> Vec<OnlineProbe> {
+    #[cfg(feature = "enrichment")]
+    {
+        let client = reqwest::blocking::Client::builder()
+            .timeout(timeout)
+            .user_agent(concat!("sbom-tools/", env!("CARGO_PKG_VERSION")))
+            .build();
+        let Ok(client) = client else {
+            return entries
+                .iter()
+                .map(|s| OnlineProbe {
+                    id: s.id,
+                    status: "client-init-failed".to_string(),
+                })
+                .collect();
+        };
+        entries
+            .iter()
+            .map(|s| {
+                let status = match client.head(s.url).send() {
+                    Ok(resp) => format!("{}", resp.status()),
+                    Err(e) => format!("error: {e}"),
+                };
+                OnlineProbe { id: s.id, status }
+            })
+            .collect()
+    }
+    #[cfg(not(feature = "enrichment"))]
+    {
+        let _ = timeout;
+        entries
+            .iter()
+            .map(|s| OnlineProbe {
+                id: s.id,
+                status: "online-checks require the 'enrichment' feature".to_string(),
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalogue_has_no_empty_fields() {
+        for s in CATALOGUE {
+            assert!(!s.id.is_empty(), "catalogue id must not be empty");
+            assert!(!s.title.is_empty(), "catalogue title must not be empty");
+            assert!(s.url.starts_with("https://"), "catalogue URL must be https: {}", s.url);
+        }
+    }
+
+    #[test]
+    fn catalogue_ids_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for s in CATALOGUE {
+            assert!(seen.insert(s.id), "duplicate catalogue id: {}", s.id);
+        }
+    }
+
+    #[test]
+    fn catalogue_covers_core_artefacts() {
+        let ids: std::collections::HashSet<&str> =
+            CATALOGUE.iter().map(|s| s.id).collect();
+        for required in [
+            "prEN-40000-1-3",
+            "BSI-TR-03183-2",
+            "CSAF-v2.0",
+            "EUCC",
+            "STAN4CRA",
+        ] {
+            assert!(ids.contains(required), "catalogue must include {required}");
+        }
+    }
+
+    #[test]
+    fn output_format_parser_is_strict() {
+        assert!(matches!(
+            WatchOutputFormat::parse("table").unwrap(),
+            WatchOutputFormat::Table
+        ));
+        assert!(matches!(
+            WatchOutputFormat::parse("json").unwrap(),
+            WatchOutputFormat::Json
+        ));
+        assert!(WatchOutputFormat::parse("xml").is_err());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@
 //! Each handler implements the business logic for a specific CLI subcommand.
 
 mod cra_docs;
+mod cra_standards_watch;
 mod diff;
 #[cfg(feature = "enrichment")]
 mod enrich;
@@ -20,6 +21,7 @@ mod view;
 mod watch;
 
 pub use cra_docs::run_cra_docs;
+pub use cra_standards_watch::{WatchOutputFormat, run_cra_standards_watch};
 pub use diff::run_diff;
 #[cfg(feature = "enrichment")]
 pub use enrich::run_enrich;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -31,7 +31,7 @@ pub use query::{QueryFilter, run_query};
 pub use tailor::run_tailor;
 pub use validate::run_validate;
 pub use verify::{VerifyAction, run_verify};
-pub use vex::{VexAction, run_vex};
+pub use vex::{VexAction, VexExportFormat, run_vex};
 pub use view::run_view;
 pub use watch::run_watch;
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides testable command handlers that are invoked by main.rs.
 //! Each handler implements the business logic for a specific CLI subcommand.
 
+mod cra_docs;
 mod diff;
 #[cfg(feature = "enrichment")]
 mod enrich;
@@ -18,6 +19,7 @@ mod vex;
 mod view;
 mod watch;
 
+pub use cra_docs::run_cra_docs;
 pub use diff::run_diff;
 #[cfg(feature = "enrichment")]
 pub use enrich::run_enrich;

--- a/src/cli/quality.rs
+++ b/src/cli/quality.rs
@@ -25,6 +25,8 @@ pub struct QualityConfig {
     /// when None). Supplements the embedded compliance check used by the
     /// `cra` scoring profile.
     pub cra_sidecar_path: Option<PathBuf>,
+    /// CRA Annex III/IV product class (CLI string form). Sidecar value wins.
+    pub cra_product_class: Option<String>,
 }
 
 /// Run the quality command, returning the desired exit code.
@@ -42,6 +44,7 @@ pub fn run_quality(
     min_score: Option<f32>,
     no_color: bool,
     cra_sidecar_path: Option<PathBuf>,
+    cra_product_class: Option<String>,
 ) -> Result<i32> {
     let config = QualityConfig {
         sbom_path,
@@ -53,6 +56,7 @@ pub fn run_quality(
         min_score,
         no_color,
         cra_sidecar_path,
+        cra_product_class,
     };
 
     run_quality_impl(config)
@@ -71,10 +75,29 @@ fn run_quality_impl(config: QualityConfig) -> Result<i32> {
         Some(p) => crate::model::CraSidecarMetadata::from_file(p).ok(),
         None => crate::model::CraSidecarMetadata::find_for_sbom(&config.sbom_path),
     };
-    let scorer = match sidecar {
-        Some(sc) => QualityScorer::new(profile).with_cra_sidecar(sc),
-        None => QualityScorer::new(profile),
-    };
+    let cli_class = config
+        .cra_product_class
+        .as_deref()
+        .and_then(crate::model::CraProductClass::parse_cli);
+    let sidecar_class = sidecar.as_ref().and_then(|s| s.product_class);
+    if let (Some(cli), Some(side)) = (cli_class, sidecar_class)
+        && cli != side
+    {
+        tracing::warn!(
+            "CRA product class mismatch: --cra-product-class={} but sidecar says {}; using sidecar.",
+            cli.label(),
+            side.label()
+        );
+    }
+    let effective_class = sidecar_class.or(cli_class);
+
+    let mut scorer = QualityScorer::new(profile);
+    if let Some(sc) = sidecar {
+        scorer = scorer.with_cra_sidecar(sc);
+    }
+    if let Some(c) = effective_class {
+        scorer = scorer.with_cra_product_class(c);
+    }
     let report = scorer.score(parsed.sbom());
 
     // Build output based on format

--- a/src/cli/quality.rs
+++ b/src/cli/quality.rs
@@ -21,6 +21,10 @@ pub struct QualityConfig {
     pub show_metrics: bool,
     pub min_score: Option<f32>,
     pub no_color: bool,
+    /// Optional CRA sidecar metadata path (auto-discovered next to the SBOM
+    /// when None). Supplements the embedded compliance check used by the
+    /// `cra` scoring profile.
+    pub cra_sidecar_path: Option<PathBuf>,
 }
 
 /// Run the quality command, returning the desired exit code.
@@ -37,6 +41,7 @@ pub fn run_quality(
     show_metrics: bool,
     min_score: Option<f32>,
     no_color: bool,
+    cra_sidecar_path: Option<PathBuf>,
 ) -> Result<i32> {
     let config = QualityConfig {
         sbom_path,
@@ -47,6 +52,7 @@ pub fn run_quality(
         show_metrics,
         min_score,
         no_color,
+        cra_sidecar_path,
     };
 
     run_quality_impl(config)
@@ -60,7 +66,15 @@ fn run_quality_impl(config: QualityConfig) -> Result<i32> {
 
     tracing::info!("Running quality assessment with {:?} profile", profile);
 
-    let scorer = QualityScorer::new(profile);
+    // Honour explicit --cra-sidecar; otherwise auto-discover.
+    let sidecar = match &config.cra_sidecar_path {
+        Some(p) => crate::model::CraSidecarMetadata::from_file(p).ok(),
+        None => crate::model::CraSidecarMetadata::find_for_sbom(&config.sbom_path),
+    };
+    let scorer = match sidecar {
+        Some(sc) => QualityScorer::new(profile).with_cra_sidecar(sc),
+        None => QualityScorer::new(profile),
+    };
     let report = scorer.score(parsed.sbom());
 
     // Build output based on format
@@ -97,11 +111,12 @@ fn parse_scoring_profile(profile_name: &str) -> Result<ScoringProfile> {
         "security" => Ok(ScoringProfile::Security),
         "license-compliance" | "license" => Ok(ScoringProfile::LicenseCompliance),
         "cra" | "cyber-resilience" => Ok(ScoringProfile::Cra),
+        "bsi" | "tr-03183" | "tr03183" | "bsi-tr-03183-2" => Ok(ScoringProfile::BsiTr03183_2),
         "comprehensive" | "full" => Ok(ScoringProfile::Comprehensive),
         "cbom" | "cryptographic" => Ok(ScoringProfile::Cbom),
         _ => {
             bail!(
-                "Unknown scoring profile: {profile_name}. Valid options: minimal, standard, security, license-compliance, cra, comprehensive, cbom"
+                "Unknown scoring profile: {profile_name}. Valid options: minimal, standard, security, license-compliance, cra, bsi, comprehensive, cbom"
             );
         }
     }

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -14,7 +14,7 @@ use std::collections::HashSet;
 use std::path::PathBuf;
 
 /// Run the validate command
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 pub fn run_validate(
     sbom_path: PathBuf,
     standard: String,
@@ -23,6 +23,7 @@ pub fn run_validate(
     fail_on_warning: bool,
     summary: bool,
     cra_sidecar_path: Option<PathBuf>,
+    cra_product_class: Option<String>,
 ) -> Result<()> {
     let parsed = parse_sbom_with_context(&sbom_path, false)?;
 
@@ -36,6 +37,24 @@ pub fn run_validate(
         None => crate::model::CraSidecarMetadata::find_for_sbom(&sbom_path),
     };
 
+    // Resolve effective product class: sidecar wins; otherwise CLI flag.
+    // Mismatch between explicit CLI flag and sidecar is reported as a Warning
+    // on stderr (not turned into a Violation — sidecar is authoritative).
+    let cli_class = cra_product_class
+        .as_deref()
+        .and_then(crate::model::CraProductClass::parse_cli);
+    let sidecar_class = cra_sidecar.as_ref().and_then(|s| s.product_class);
+    if let (Some(cli), Some(side)) = (cli_class, sidecar_class)
+        && cli != side
+    {
+        tracing::warn!(
+            "CRA product class mismatch: --cra-product-class={} but sidecar says {}; using sidecar.",
+            cli.label(),
+            side.label()
+        );
+    }
+    let effective_class = sidecar_class.or(cli_class);
+
     let standards: Vec<&str> = standard.split(',').map(str::trim).collect();
     let mut results = Vec::new();
 
@@ -47,6 +66,9 @@ pub fn run_validate(
                 let mut checker = ComplianceChecker::new(ComplianceLevel::CraPhase2);
                 if let Some(sc) = cra_sidecar.clone() {
                     checker = checker.with_sidecar(sc);
+                }
+                if let Some(c) = effective_class {
+                    checker = checker.with_product_class(c);
                 }
                 checker.check(parsed.sbom())
             }

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -94,10 +94,17 @@ pub fn run_validate(
                 }
                 checker.check(parsed.sbom())
             }
+            "eucc" | "eucc-substantial" | "common-criteria" => {
+                let mut checker = ComplianceChecker::new(ComplianceLevel::EuccSubstantial);
+                if let Some(sc) = cra_sidecar.clone() {
+                    checker = checker.with_sidecar(sc);
+                }
+                checker.check(parsed.sbom())
+            }
             _ => {
                 bail!(
                     "Unknown validation standard: {std_name}. \
-                    Valid options: ntia, fda, cra, ssdf, eo14028, cnsa2, pqc, bsi, oss-steward"
+                    Valid options: ntia, fda, cra, ssdf, eo14028, cnsa2, pqc, bsi, oss-steward, eucc"
                 );
             }
         };

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -87,10 +87,17 @@ pub fn run_validate(
             "bsi" | "tr-03183" | "tr03183" | "bsi-tr-03183-2" => {
                 ComplianceChecker::new(ComplianceLevel::BsiTr03183_2).check(parsed.sbom())
             }
+            "oss-steward" | "cra-oss-steward" | "cra-oss" | "cra-art24" | "art24" => {
+                let mut checker = ComplianceChecker::new(ComplianceLevel::CraOssSteward);
+                if let Some(sc) = cra_sidecar.clone() {
+                    checker = checker.with_sidecar(sc);
+                }
+                checker.check(parsed.sbom())
+            }
             _ => {
                 bail!(
                     "Unknown validation standard: {std_name}. \
-                    Valid options: ntia, fda, cra, ssdf, eo14028, cnsa2, pqc, bsi"
+                    Valid options: ntia, fda, cra, ssdf, eo14028, cnsa2, pqc, bsi, oss-steward"
                 );
             }
         };

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -22,8 +22,19 @@ pub fn run_validate(
     output_file: Option<PathBuf>,
     fail_on_warning: bool,
     summary: bool,
+    cra_sidecar_path: Option<PathBuf>,
 ) -> Result<()> {
     let parsed = parse_sbom_with_context(&sbom_path, false)?;
+
+    // Load CRA sidecar — explicit flag wins, otherwise auto-discover next to the SBOM
+    let cra_sidecar = match cra_sidecar_path {
+        Some(p) => Some(
+            crate::model::CraSidecarMetadata::from_file(&p).map_err(|e| {
+                anyhow::anyhow!("Failed to load CRA sidecar from {}: {e}", p.display())
+            })?,
+        ),
+        None => crate::model::CraSidecarMetadata::find_for_sbom(&sbom_path),
+    };
 
     let standards: Vec<&str> = standard.split(',').map(str::trim).collect();
     let mut results = Vec::new();
@@ -32,7 +43,13 @@ pub fn run_validate(
         let result = match std_name.to_lowercase().as_str() {
             "ntia" => check_ntia_compliance(parsed.sbom()),
             "fda" => check_fda_compliance(parsed.sbom()),
-            "cra" => ComplianceChecker::new(ComplianceLevel::CraPhase2).check(parsed.sbom()),
+            "cra" => {
+                let mut checker = ComplianceChecker::new(ComplianceLevel::CraPhase2);
+                if let Some(sc) = cra_sidecar.clone() {
+                    checker = checker.with_sidecar(sc);
+                }
+                checker.check(parsed.sbom())
+            }
             "ssdf" | "nist-ssdf" | "nist_ssdf" => {
                 ComplianceChecker::new(ComplianceLevel::NistSsdf).check(parsed.sbom())
             }
@@ -45,10 +62,13 @@ pub fn run_validate(
             "pqc" | "nist-pqc" | "nist_pqc" => {
                 ComplianceChecker::new(ComplianceLevel::NistPqc).check(parsed.sbom())
             }
+            "bsi" | "tr-03183" | "tr03183" | "bsi-tr-03183-2" => {
+                ComplianceChecker::new(ComplianceLevel::BsiTr03183_2).check(parsed.sbom())
+            }
             _ => {
                 bail!(
                     "Unknown validation standard: {std_name}. \
-                    Valid options: ntia, fda, cra, ssdf, eo14028, cnsa2, pqc"
+                    Valid options: ntia, fda, cra, ssdf, eo14028, cnsa2, pqc, bsi"
                 );
             }
         };
@@ -254,6 +274,7 @@ fn check_ntia_compliance(sbom: &NormalizedSbom) -> ComplianceResult {
             message: "Missing author/creator information".to_string(),
             element: None,
             requirement: "NTIA Minimum Elements: Author".to_string(),
+            standard_refs: Vec::new(),
         });
     }
 
@@ -265,6 +286,7 @@ fn check_ntia_compliance(sbom: &NormalizedSbom) -> ComplianceResult {
                 message: "Component missing name".to_string(),
                 element: None,
                 requirement: "NTIA Minimum Elements: Component Name".to_string(),
+                standard_refs: Vec::new(),
             });
         }
         if comp.version.is_none() {
@@ -274,6 +296,7 @@ fn check_ntia_compliance(sbom: &NormalizedSbom) -> ComplianceResult {
                 message: format!("Component '{}' missing version", comp.name),
                 element: Some(comp.name.clone()),
                 requirement: "NTIA Minimum Elements: Version".to_string(),
+                standard_refs: Vec::new(),
             });
         }
         if comp.supplier.is_none() {
@@ -283,6 +306,7 @@ fn check_ntia_compliance(sbom: &NormalizedSbom) -> ComplianceResult {
                 message: format!("Component '{}' missing supplier", comp.name),
                 element: Some(comp.name.clone()),
                 requirement: "NTIA Minimum Elements: Supplier Name".to_string(),
+                standard_refs: Vec::new(),
             });
         }
         if comp.identifiers.purl.is_none()
@@ -298,6 +322,7 @@ fn check_ntia_compliance(sbom: &NormalizedSbom) -> ComplianceResult {
                 ),
                 element: Some(comp.name.clone()),
                 requirement: "NTIA Minimum Elements: Unique Identifier".to_string(),
+                standard_refs: Vec::new(),
             });
         }
     }
@@ -309,6 +334,7 @@ fn check_ntia_compliance(sbom: &NormalizedSbom) -> ComplianceResult {
             message: "Missing dependency relationships".to_string(),
             element: None,
             requirement: "NTIA Minimum Elements: Dependency Relationship".to_string(),
+            standard_refs: Vec::new(),
         });
     }
 
@@ -342,6 +368,7 @@ fn check_fda_compliance(sbom: &NormalizedSbom) -> ComplianceResult {
             requirement: format!("FDA Medical Device: {}", issue.category),
             message: issue.message,
             element: None,
+            standard_refs: Vec::new(),
         })
         .collect();
 

--- a/src/cli/vex.rs
+++ b/src/cli/vex.rs
@@ -19,6 +19,16 @@ pub enum VexAction {
     Status,
     /// Filter vulnerabilities by VEX state
     Filter,
+    /// Export the SBOM's VEX state as a CSAF v2.0 advisory
+    /// (or other advisory format).
+    Export(VexExportFormat),
+}
+
+/// Export format for `vex export`. CSAF v2.0 is the only one wired up
+/// today; OpenVEX / CycloneDX VEX emit can be added later.
+#[derive(Debug, Clone, Copy)]
+pub enum VexExportFormat {
+    Csaf,
 }
 
 /// Run the vex subcommand.
@@ -72,7 +82,27 @@ pub fn run_vex(config: VexConfig, action: VexAction) -> Result<i32> {
         VexAction::Apply => run_vex_apply(parsed.sbom(), &config),
         VexAction::Status => run_vex_status(parsed.sbom(), &config),
         VexAction::Filter => run_vex_filter(parsed.sbom(), &config),
+        VexAction::Export(format) => run_vex_export(parsed.sbom(), &config, format),
     }
+}
+
+/// Emit a CSAF v2.0 (or future) advisory document derived from the SBOM's
+/// per-vulnerability VEX state.
+fn run_vex_export(
+    sbom: &NormalizedSbom,
+    config: &VexConfig,
+    format: VexExportFormat,
+) -> Result<i32> {
+    let output = match format {
+        VexExportFormat::Csaf => {
+            let opts = crate::reports::CsafEmitOptions::default();
+            crate::reports::emit_csaf(sbom, &opts)
+                .map_err(|e| anyhow::anyhow!("CSAF emit failed: {e}"))?
+        }
+    };
+    let target = OutputTarget::from_option(config.output_file.clone());
+    write_output(&output, &target, false)?;
+    Ok(exit_codes::SUCCESS)
 }
 
 /// Apply VEX documents and output the enriched SBOM vulnerability data as JSON.

--- a/src/cli/view.rs
+++ b/src/cli/view.rs
@@ -99,8 +99,19 @@ pub fn run_view(config: ViewConfig) -> Result<i32> {
     tracing::info!("BOM profile: {bom_profile}");
 
     if effective_output == ReportFormat::Tui {
+        // Resolve sidecar so the compliance tab's OSS-Steward / EUCC /
+        // Article 14 / product-class checks render against the same
+        // metadata the CLI uses (auto-discovered next to the SBOM when
+        // `--cra-sidecar` is omitted).
+        let tui_sidecar = match &config.cra_sidecar_path {
+            Some(p) => crate::model::CraSidecarMetadata::from_file(p).ok(),
+            None => crate::model::CraSidecarMetadata::find_for_sbom(&config.sbom_path),
+        };
         let (sbom, raw_content) = parsed.into_parts();
         let mut app = ViewApp::new(sbom, &raw_content, bom_profile);
+        if let Some(sc) = tui_sidecar {
+            app = app.with_cra_sidecar(sc);
+        }
         app.export_template = config.output.export_template.clone();
 
         // Show enrichment warnings in TUI footer

--- a/src/cli/view.rs
+++ b/src/cli/view.rs
@@ -221,10 +221,29 @@ fn output_view_report(
         Some(p) => crate::model::CraSidecarMetadata::from_file(p).ok(),
         None => crate::model::CraSidecarMetadata::find_for_sbom(&config.sbom_path),
     };
+    let cli_class = config
+        .cra_product_class
+        .as_deref()
+        .and_then(crate::model::CraProductClass::parse_cli);
+    let sidecar_class = sidecar.as_ref().and_then(|s| s.product_class);
+    if let (Some(cli), Some(side)) = (cli_class, sidecar_class)
+        && cli != side
+    {
+        tracing::warn!(
+            "CRA product class mismatch: --cra-product-class={} but sidecar says {}; using sidecar.",
+            cli.label(),
+            side.label()
+        );
+    }
+    let effective_class = sidecar_class.or(cli_class);
+
     let mut checker =
         crate::quality::ComplianceChecker::new(crate::quality::ComplianceLevel::CraPhase2);
     if let Some(sc) = sidecar {
         checker = checker.with_sidecar(sc);
+    }
+    if let Some(c) = effective_class {
+        checker = checker.with_product_class(c);
     }
     let cra_result = checker.check(sbom);
 
@@ -302,6 +321,7 @@ mod tests {
             bom_profile: None,
             enrichment: crate::config::EnrichmentConfig::default(),
             cra_sidecar_path: None,
+            cra_product_class: None,
         };
 
         let removed = apply_view_filters(&mut sbom, &config);

--- a/src/cli/view.rs
+++ b/src/cli/view.rs
@@ -215,10 +215,18 @@ fn output_view_report(
 ) -> Result<()> {
     let effective_output = auto_detect_format(config.output.format, output_target);
 
-    // Pre-compute CRA compliance once for reporters
-    let cra_result =
-        crate::quality::ComplianceChecker::new(crate::quality::ComplianceLevel::CraPhase2)
-            .check(sbom);
+    // Pre-compute CRA compliance once for reporters.
+    // Honour explicit --cra-sidecar; otherwise auto-discover next to the SBOM.
+    let sidecar = match &config.cra_sidecar_path {
+        Some(p) => crate::model::CraSidecarMetadata::from_file(p).ok(),
+        None => crate::model::CraSidecarMetadata::find_for_sbom(&config.sbom_path),
+    };
+    let mut checker =
+        crate::quality::ComplianceChecker::new(crate::quality::ComplianceLevel::CraPhase2);
+    if let Some(sc) = sidecar {
+        checker = checker.with_sidecar(sc);
+    }
+    let cra_result = checker.check(sbom);
 
     let report_config = ReportConfig {
         report_types: vec![config.output.report_types],
@@ -293,6 +301,7 @@ mod tests {
             fail_on_vuln: false,
             bom_profile: None,
             enrichment: crate::config::EnrichmentConfig::default(),
+            cra_sidecar_path: None,
         };
 
         let removed = apply_view_filters(&mut sbom, &config);

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -403,6 +403,10 @@ pub struct ViewConfig {
     pub bom_profile: Option<crate::model::BomProfile>,
     /// Enrichment configuration
     pub enrichment: EnrichmentConfig,
+    /// Optional CRA sidecar metadata path (auto-discovered next to the SBOM
+    /// when None). Supplements CRA compliance checks with manufacturer /
+    /// disclosure / lifecycle fields the SBOM doesn't carry.
+    pub cra_sidecar_path: Option<PathBuf>,
 }
 
 /// Configuration for multi-diff operations

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -407,6 +407,10 @@ pub struct ViewConfig {
     /// when None). Supplements CRA compliance checks with manufacturer /
     /// disclosure / lifecycle fields the SBOM doesn't carry.
     pub cra_sidecar_path: Option<PathBuf>,
+    /// CRA Annex III/IV product class as a CLI string (kebab-case).
+    /// Sidecar `productClass` overrides this. Drives severity calibration
+    /// for vendor-hash, EOL, cycles, DoC, EUCC, PSIRT, attestation checks.
+    pub cra_product_class: Option<String>,
 }
 
 /// Configuration for multi-diff operations

--- a/src/enrichment/vex/csaf.rs
+++ b/src/enrichment/vex/csaf.rs
@@ -326,8 +326,7 @@ mod tests {
 
     #[test]
     fn does_not_misdetect_openvex() {
-        let openvex =
-            r#"{"@context":"https://openvex.dev/ns/v0.2.0","statements":[]}"#;
+        let openvex = r#"{"@context":"https://openvex.dev/ns/v0.2.0","statements":[]}"#;
         assert!(!is_csaf(openvex));
     }
 
@@ -437,7 +436,10 @@ mod tests {
         let result = parse_csaf(csaf).unwrap();
         assert!(result.scoped.is_empty());
         assert_eq!(
-            result.unscoped.get("CVE-2024-77777").map(|v| v.status.clone()),
+            result
+                .unscoped
+                .get("CVE-2024-77777")
+                .map(|v| v.status.clone()),
             Some(VexState::Affected)
         );
     }

--- a/src/enrichment/vex/csaf.rs
+++ b/src/enrichment/vex/csaf.rs
@@ -1,0 +1,477 @@
+//! CSAF v2.0 (ISO/IEC 20153:2025) document parser.
+//!
+//! CSAF (Common Security Advisory Framework) is the OASIS-published advisory
+//! format named in CRA prEN 40000-1-3 [RLS-2-RQ-03-RE]. Red Hat, Cisco,
+//! Siemens, Bosch, and other large vendors publish CSAF advisories that
+//! include VEX-style product status information.
+//!
+//! This module parses the VEX-relevant subset of a CSAF document:
+//! `vulnerabilities[].product_status.{known_affected,known_not_affected,
+//! fixed,first_fixed,under_investigation,recommended,last_affected}` arrays
+//! resolved against `product_tree.full_product_names[].product_identification_helper.purl`.
+//!
+//! Other CSAF sections (notes, threats, references, document-level metadata)
+//! are accepted-but-ignored — VexEnricher only consumes status information.
+//!
+//! See <https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html>.
+
+use crate::model::{VexState, VexStatus};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+use super::openvex::VexParseError;
+
+// ============================================================================
+// CSAF serde structs (minimal, VEX-focused subset)
+// ============================================================================
+
+/// Top-level CSAF v2.0 document.
+#[derive(Debug, Deserialize)]
+struct CsafDocument {
+    document: CsafHeader,
+    #[serde(default)]
+    product_tree: Option<CsafProductTree>,
+    #[serde(default)]
+    vulnerabilities: Vec<CsafVulnerability>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CsafHeader {
+    csaf_version: String,
+    /// `csaf_security_advisory` / `csaf_vex` / etc. — accepted but currently
+    /// unused; we ingest VEX-relevant status from any CSAF v2.x category.
+    #[serde(default)]
+    #[allow(dead_code)]
+    category: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CsafProductTree {
+    #[serde(default)]
+    full_product_names: Vec<CsafProduct>,
+    /// Some publishers nest products in `branches[]` rather than at the top
+    /// level. Branches can recurse — flattened during parsing.
+    #[serde(default)]
+    branches: Vec<CsafBranch>,
+    /// Relationships pair a product_id with another (e.g., "is_installed_on").
+    /// We treat the relationship's `full_product_name` as a regular product.
+    #[serde(default)]
+    relationships: Vec<CsafRelationship>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct CsafProduct {
+    product_id: String,
+    /// Display name — captured for forward compatibility (e.g., relationship
+    /// summaries) but not used by the VEX lookup.
+    #[serde(default)]
+    #[allow(dead_code)]
+    name: Option<String>,
+    #[serde(default)]
+    product_identification_helper: Option<CsafProductHelper>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct CsafProductHelper {
+    #[serde(default)]
+    purl: Option<String>,
+    /// CPE (`cpe22Type`/`cpe23Type`) — accepted-but-unused for now; PURL is
+    /// the only identifier we propagate to VexStatus lookup keys.
+    #[serde(default)]
+    #[allow(dead_code)]
+    cpe: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CsafBranch {
+    #[serde(default)]
+    product: Option<CsafProduct>,
+    #[serde(default)]
+    branches: Vec<CsafBranch>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CsafRelationship {
+    #[serde(default)]
+    full_product_name: Option<CsafProduct>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CsafVulnerability {
+    /// CVE identifier (preferred). Falls back to `ids[].text` when absent.
+    #[serde(default)]
+    cve: Option<String>,
+    #[serde(default)]
+    ids: Vec<CsafVulnId>,
+    #[serde(default)]
+    product_status: Option<CsafProductStatus>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CsafVulnId {
+    #[serde(default)]
+    text: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct CsafProductStatus {
+    #[serde(default)]
+    known_affected: Vec<String>,
+    #[serde(default)]
+    known_not_affected: Vec<String>,
+    #[serde(default)]
+    fixed: Vec<String>,
+    #[serde(default)]
+    first_fixed: Vec<String>,
+    #[serde(default)]
+    under_investigation: Vec<String>,
+    #[serde(default)]
+    recommended: Vec<String>,
+    #[serde(default)]
+    last_affected: Vec<String>,
+}
+
+// ============================================================================
+// Parsing functions
+// ============================================================================
+
+/// Quick peek to decide whether `content` is a CSAF v2.0 document. Looks
+/// for `document.csaf_version` starting with `"2."` and a `vulnerabilities`
+/// or `product_tree` block. Tolerant of extra/missing fields.
+pub(crate) fn is_csaf(content: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(content) else {
+        return false;
+    };
+    let Some(obj) = value.as_object() else {
+        return false;
+    };
+    let has_csaf_version = obj
+        .get("document")
+        .and_then(|d| d.as_object())
+        .and_then(|d| d.get("csaf_version"))
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| s.starts_with("2."));
+    let has_vex_payload = obj.get("vulnerabilities").is_some() || obj.get("product_tree").is_some();
+    has_csaf_version && has_vex_payload
+}
+
+/// Parse a CSAF v2.0 document and return VEX-relevant status entries.
+///
+/// Resolves `product_id` references against `product_tree.full_product_names`
+/// (and recursively-flattened `branches[].product`) to PURL strings. Entries
+/// without a PURL are emitted as unscoped (`vuln_id` only) so that fuzzy
+/// product matching can still apply.
+pub(crate) fn parse_csaf(content: &str) -> Result<CsafVexResult, VexParseError> {
+    let doc: CsafDocument = serde_json::from_str(content)?;
+    if !doc.document.csaf_version.starts_with("2.") {
+        return Err(VexParseError::InvalidDocument(format!(
+            "unsupported CSAF version {} (expected 2.x)",
+            doc.document.csaf_version
+        )));
+    }
+
+    let product_lookup = build_product_lookup(doc.product_tree.as_ref());
+
+    let mut scoped: HashMap<(String, String), VexStatus> = HashMap::new();
+    let mut unscoped: HashMap<String, VexStatus> = HashMap::new();
+    let mut statements_parsed = 0;
+
+    for vuln in &doc.vulnerabilities {
+        let Some(vuln_id) = pick_vuln_id(vuln) else {
+            continue;
+        };
+        let Some(status) = vuln.product_status.as_ref() else {
+            continue;
+        };
+
+        let mut apply = |product_ids: &[String], state: VexState| {
+            for pid in product_ids {
+                statements_parsed += 1;
+                let vex_status = VexStatus::new(state.clone());
+                if let Some(purl) = product_lookup.get(pid).cloned() {
+                    scoped.insert((vuln_id.clone(), purl), vex_status);
+                } else {
+                    // No PURL available — emit as unscoped fallback.
+                    // Later identical vuln_ids overwrite, which matches the
+                    // OpenVEX/CDX path's "later wins" semantics.
+                    unscoped.insert(vuln_id.clone(), vex_status);
+                }
+            }
+        };
+
+        apply(&status.known_affected, VexState::Affected);
+        apply(&status.known_not_affected, VexState::NotAffected);
+        apply(&status.fixed, VexState::Fixed);
+        apply(&status.first_fixed, VexState::Fixed);
+        apply(&status.under_investigation, VexState::UnderInvestigation);
+        apply(&status.recommended, VexState::Affected); // "recommended" upgrade
+        apply(&status.last_affected, VexState::Fixed); // last vuln cycle, fixed in newer
+    }
+
+    Ok(CsafVexResult {
+        scoped,
+        unscoped,
+        statements_parsed,
+    })
+}
+
+#[derive(Debug)]
+pub(crate) struct CsafVexResult {
+    /// `(vuln_id, purl)` → status for product-scoped entries.
+    pub scoped: HashMap<(String, String), VexStatus>,
+    /// `vuln_id` → status for entries without a resolvable PURL.
+    pub unscoped: HashMap<String, VexStatus>,
+    pub statements_parsed: usize,
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+fn pick_vuln_id(vuln: &CsafVulnerability) -> Option<String> {
+    if let Some(cve) = vuln.cve.as_deref() {
+        if !cve.is_empty() {
+            return Some(cve.to_string());
+        }
+    }
+    vuln.ids
+        .iter()
+        .find_map(|i| i.text.clone().filter(|s| !s.is_empty()))
+}
+
+/// Flatten `product_tree.full_product_names` + recursive `branches[].product`
+/// + `relationships[].full_product_name` into a `product_id → PURL` map.
+fn build_product_lookup(tree: Option<&CsafProductTree>) -> HashMap<String, String> {
+    let mut out: HashMap<String, String> = HashMap::new();
+    let Some(tree) = tree else {
+        return out;
+    };
+    for p in &tree.full_product_names {
+        record_product(p, &mut out);
+    }
+    for b in &tree.branches {
+        walk_branch(b, &mut out);
+    }
+    for r in &tree.relationships {
+        if let Some(p) = r.full_product_name.as_ref() {
+            record_product(p, &mut out);
+        }
+    }
+    out
+}
+
+fn walk_branch(b: &CsafBranch, out: &mut HashMap<String, String>) {
+    if let Some(p) = b.product.as_ref() {
+        record_product(p, out);
+    }
+    for inner in &b.branches {
+        walk_branch(inner, out);
+    }
+}
+
+fn record_product(p: &CsafProduct, out: &mut HashMap<String, String>) {
+    if let Some(helper) = p.product_identification_helper.as_ref()
+        && let Some(purl) = helper.purl.as_deref()
+        && !purl.is_empty()
+    {
+        out.insert(p.product_id.clone(), purl.to_string());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MINIMAL_CSAF: &str = r#"{
+        "document": {
+            "category": "csaf_security_advisory",
+            "csaf_version": "2.0",
+            "publisher": { "category": "vendor", "name": "Example" },
+            "title": "Example advisory",
+            "tracking": { "id": "EX-2024-001" }
+        },
+        "product_tree": {
+            "full_product_names": [
+                {
+                    "product_id": "CSAFPID-001",
+                    "name": "ExampleApp 1.0",
+                    "product_identification_helper": {
+                        "purl": "pkg:cargo/example-app@1.0"
+                    }
+                },
+                {
+                    "product_id": "CSAFPID-002",
+                    "name": "ExampleApp 1.1",
+                    "product_identification_helper": {
+                        "purl": "pkg:cargo/example-app@1.1"
+                    }
+                }
+            ]
+        },
+        "vulnerabilities": [
+            {
+                "cve": "CVE-2024-12345",
+                "product_status": {
+                    "known_affected": ["CSAFPID-001"],
+                    "fixed": ["CSAFPID-002"]
+                }
+            }
+        ]
+    }"#;
+
+    #[test]
+    fn detects_csaf_document() {
+        assert!(is_csaf(MINIMAL_CSAF));
+    }
+
+    #[test]
+    fn does_not_misdetect_openvex() {
+        let openvex =
+            r#"{"@context":"https://openvex.dev/ns/v0.2.0","statements":[]}"#;
+        assert!(!is_csaf(openvex));
+    }
+
+    #[test]
+    fn does_not_misdetect_cyclonedx() {
+        let cdx = r#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[]}"#;
+        assert!(!is_csaf(cdx));
+    }
+
+    #[test]
+    fn parses_known_affected_and_fixed() {
+        let result = parse_csaf(MINIMAL_CSAF).unwrap();
+        assert_eq!(result.statements_parsed, 2);
+
+        let affected = result
+            .scoped
+            .get(&(
+                "CVE-2024-12345".to_string(),
+                "pkg:cargo/example-app@1.0".to_string(),
+            ))
+            .expect("affected entry");
+        assert_eq!(affected.status, VexState::Affected);
+
+        let fixed = result
+            .scoped
+            .get(&(
+                "CVE-2024-12345".to_string(),
+                "pkg:cargo/example-app@1.1".to_string(),
+            ))
+            .expect("fixed entry");
+        assert_eq!(fixed.status, VexState::Fixed);
+    }
+
+    #[test]
+    fn rejects_non_csaf_2() {
+        let bad = r#"{
+            "document": {"csaf_version": "1.5", "category": "x", "publisher":{"category":"vendor","name":"X"}, "title":"x", "tracking":{"id":"x"}},
+            "vulnerabilities": []
+        }"#;
+        let err = parse_csaf(bad).unwrap_err();
+        assert!(matches!(err, VexParseError::InvalidDocument(_)));
+    }
+
+    #[test]
+    fn handles_branches_recursively() {
+        let csaf = r#"{
+            "document": {
+                "category": "csaf_security_advisory",
+                "csaf_version": "2.0",
+                "publisher": {"category":"vendor","name":"X"},
+                "title": "x",
+                "tracking": {"id":"x"}
+            },
+            "product_tree": {
+                "branches": [
+                    {
+                        "branches": [
+                            {
+                                "product": {
+                                    "product_id": "DEEP-1",
+                                    "name": "deep",
+                                    "product_identification_helper": {
+                                        "purl": "pkg:cargo/deep@1.0"
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                ]
+            },
+            "vulnerabilities": [
+                {
+                    "cve": "CVE-2024-99999",
+                    "product_status": { "known_affected": ["DEEP-1"] }
+                }
+            ]
+        }"#;
+        let result = parse_csaf(csaf).unwrap();
+        assert!(result.scoped.contains_key(&(
+            "CVE-2024-99999".to_string(),
+            "pkg:cargo/deep@1.0".to_string()
+        )));
+    }
+
+    #[test]
+    fn missing_purl_falls_back_to_unscoped() {
+        let csaf = r#"{
+            "document": {
+                "category": "csaf_security_advisory",
+                "csaf_version": "2.0",
+                "publisher": {"category":"vendor","name":"X"},
+                "title": "x",
+                "tracking": {"id":"x"}
+            },
+            "product_tree": {
+                "full_product_names": [
+                    { "product_id": "P1", "name": "x" }
+                ]
+            },
+            "vulnerabilities": [
+                {
+                    "cve": "CVE-2024-77777",
+                    "product_status": { "known_affected": ["P1"] }
+                }
+            ]
+        }"#;
+        let result = parse_csaf(csaf).unwrap();
+        assert!(result.scoped.is_empty());
+        assert_eq!(
+            result.unscoped.get("CVE-2024-77777").map(|v| v.status.clone()),
+            Some(VexState::Affected)
+        );
+    }
+
+    #[test]
+    fn falls_back_from_cve_to_ids_text() {
+        let csaf = r#"{
+            "document": {
+                "category": "csaf_security_advisory",
+                "csaf_version": "2.0",
+                "publisher": {"category":"vendor","name":"X"},
+                "title": "x",
+                "tracking": {"id":"x"}
+            },
+            "product_tree": {
+                "full_product_names": [
+                    {
+                        "product_id": "P1",
+                        "name": "x",
+                        "product_identification_helper": {"purl": "pkg:cargo/p@1"}
+                    }
+                ]
+            },
+            "vulnerabilities": [
+                {
+                    "ids": [{"system_name":"GHSA","text":"GHSA-aaaa-bbbb-cccc"}],
+                    "product_status": { "known_affected": ["P1"] }
+                }
+            ]
+        }"#;
+        let result = parse_csaf(csaf).unwrap();
+        assert!(result.scoped.contains_key(&(
+            "GHSA-aaaa-bbbb-cccc".to_string(),
+            "pkg:cargo/p@1".to_string()
+        )));
+    }
+}

--- a/src/enrichment/vex/mod.rs
+++ b/src/enrichment/vex/mod.rs
@@ -1,12 +1,15 @@
 //! VEX (Vulnerability Exploitability eXchange) enrichment.
 //!
-//! Parses external VEX documents (OpenVEX and CycloneDX VEX formats) and
-//! applies VEX status to matching vulnerabilities in an SBOM.
+//! Parses external VEX documents (OpenVEX, CycloneDX VEX, and CSAF v2.0 /
+//! ISO/IEC 20153:2025) and applies VEX status to matching vulnerabilities
+//! in an SBOM. Format is auto-detected from each file's content.
 
+pub(crate) mod csaf;
 pub(crate) mod cyclonedx_vex;
 pub(crate) mod openvex;
 
 use crate::model::{NormalizedSbom, VexStatus};
+use csaf::{is_csaf, parse_csaf};
 use cyclonedx_vex::{is_cyclonedx_vex, parse_cyclonedx_vex};
 use openvex::{VexParseError, extract_product_purl, parse_openvex, vex_status_from_statement};
 use std::collections::HashMap;
@@ -43,9 +46,12 @@ pub struct VexEnricher {
 impl VexEnricher {
     /// Load VEX data from one or more VEX files.
     ///
-    /// Supports both OpenVEX and CycloneDX VEX formats (auto-detected).
-    /// Files are processed in order; later files override earlier entries
-    /// for the same `(vuln_id, purl)` key.
+    /// Supports OpenVEX, CycloneDX VEX, and CSAF v2.0 (auto-detected by
+    /// content peek). Detection priority: CSAF (`document.csaf_version`
+    /// starts with `2.`) → CycloneDX VEX (`bomFormat: CycloneDX` + empty
+    /// components) → OpenVEX (catch-all). Files are processed in order;
+    /// later files override earlier entries for the same `(vuln_id, purl)`
+    /// key.
     pub fn from_files(paths: &[PathBuf]) -> Result<Self, VexParseError> {
         let mut lookup = HashMap::new();
         let mut vuln_only = HashMap::new();
@@ -56,7 +62,17 @@ impl VexEnricher {
             // Auto-detect format by peeking at file content
             let content = std::fs::read_to_string(path)?;
 
-            if is_cyclonedx_vex(&content) {
+            if is_csaf(&content) {
+                let result = parse_csaf(&content)?;
+                documents_loaded += 1;
+                statements_parsed += result.statements_parsed;
+                for ((vuln_id, purl), status) in result.scoped {
+                    lookup.insert((vuln_id, purl), status);
+                }
+                for (vuln_id, status) in result.unscoped {
+                    vuln_only.insert(vuln_id, status);
+                }
+            } else if is_cyclonedx_vex(&content) {
                 let result = parse_cyclonedx_vex(&content)?;
                 documents_loaded += 1;
                 statements_parsed += result.statements_parsed;

--- a/src/main.rs
+++ b/src/main.rs
@@ -852,6 +852,9 @@ enum Commands {
     /// Generate CRA technical-documentation dossier (Annex V templates)
     CraDocs(CraDocsArgs),
 
+    /// Show curated CRA standards-watch catalogue (prEN, BSI, CSAF, EUCC, …)
+    CraStandardsWatch(CraStandardsWatchArgs),
+
     /// Generate a man page and print it to stdout
     Man,
 }
@@ -1090,6 +1093,27 @@ struct MergeArgs {
     /// Deduplication strategy (name, purl, none)
     #[arg(long, default_value = "name")]
     dedup: String,
+}
+
+/// Arguments for the `cra-standards-watch` subcommand. Curated, offline-first
+/// catalogue of CRA-related standards bodies and their tracked artefacts.
+#[derive(Parser)]
+#[command(after_help = "EXAMPLES:
+    sbom-tools cra-standards-watch                   # Print the curated catalogue
+    sbom-tools cra-standards-watch --format json     # Machine-readable output
+    sbom-tools cra-standards-watch --check-online    # HEAD-probe each URL")]
+struct CraStandardsWatchArgs {
+    /// Output format: table (default) or json
+    #[arg(short, long, default_value = "table")]
+    format: String,
+
+    /// Issue HEAD requests against each tracked URL and report HTTP status
+    #[arg(long)]
+    check_online: bool,
+
+    /// Online-probe timeout in seconds
+    #[arg(long, default_value = "10")]
+    timeout: u64,
 }
 
 /// Arguments for the `cra-docs` subcommand — generates a CRA technical
@@ -1776,6 +1800,12 @@ fn main() -> Result<()> {
             args.output,
             args.cra_sidecar,
             args.cra_product_class,
+        ),
+
+        Commands::CraStandardsWatch(args) => cli::run_cra_standards_watch(
+            cli::WatchOutputFormat::parse(&args.format)?,
+            args.check_online,
+            args.timeout,
         ),
 
         Commands::Man => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -337,6 +337,11 @@ struct ViewArgs {
     #[arg(long, value_name = "TYPE")]
     bom_type: Option<String>,
 
+    /// Path to a CRA sidecar metadata file (JSON or YAML).
+    /// If omitted, auto-discovers `<sbom>.cra.json|yaml` next to the SBOM.
+    #[arg(long, value_name = "PATH")]
+    cra_sidecar: Option<PathBuf>,
+
     #[command(flatten)]
     enrichment: SharedEnrichmentArgs,
 }
@@ -371,6 +376,13 @@ struct ValidateArgs {
     /// Output only a compact JSON summary (overrides --output)
     #[arg(long)]
     summary: bool,
+
+    /// Path to a CRA sidecar metadata file (JSON or YAML) supplying
+    /// security_contact, manufacturer, support_end_date, ce_marking_reference,
+    /// and similar CRA fields the SBOM itself doesn't carry.
+    /// If omitted, sbom-tools auto-discovers `<sbom>.cra.json|yaml` next to the SBOM.
+    #[arg(long, value_name = "PATH")]
+    cra_sidecar: Option<PathBuf>,
 }
 
 /// Arguments for the `diff-multi` subcommand
@@ -607,6 +619,12 @@ struct QualityArgs {
     /// Fail if quality score is below threshold (0-100)
     #[arg(long)]
     min_score: Option<f32>,
+
+    /// Path to a CRA sidecar metadata file (JSON or YAML).
+    /// Consulted by the embedded CRA compliance check when running
+    /// `--profile cra`. Auto-discovered next to the SBOM if omitted.
+    #[arg(long, value_name = "PATH")]
+    cra_sidecar: Option<PathBuf>,
 }
 
 /// Arguments for the `query` subcommand
@@ -1160,6 +1178,7 @@ fn main() -> Result<()> {
                     .as_deref()
                     .and_then(sbom_tools::BomProfile::from_str_opt),
                 enrichment,
+                cra_sidecar_path: args.cra_sidecar.clone(),
             };
             let exit_code = cli::run_view(config)?;
             if exit_code != 0 {
@@ -1175,6 +1194,7 @@ fn main() -> Result<()> {
             args.output_file,
             args.fail_on_warning,
             args.summary,
+            args.cra_sidecar,
         ),
 
         Commands::DiffMulti(args) => {
@@ -1355,6 +1375,7 @@ fn main() -> Result<()> {
                 args.metrics,
                 args.min_score,
                 cli.no_color,
+                args.cra_sidecar,
             )?;
             if exit_code != 0 {
                 std::process::exit(exit_code);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1539,9 +1539,9 @@ fn main() -> Result<()> {
                 VexAction::Export(export_args) => {
                     let fmt = match export_args.format.to_lowercase().as_str() {
                         "csaf" | "csaf-v2.0" | "csaf2" => cli::VexExportFormat::Csaf,
-                        other => anyhow::bail!(
-                            "Unsupported VEX export format '{other}'. Valid: csaf"
-                        ),
+                        other => {
+                            anyhow::bail!("Unsupported VEX export format '{other}'. Valid: csaf")
+                        }
                     };
                     let synth_args = VexArgs {
                         sbom: export_args.sbom,

--- a/src/main.rs
+++ b/src/main.rs
@@ -876,6 +876,27 @@ enum VexAction {
     Status(VexArgs),
     /// Filter vulnerabilities by VEX state (for CI pipelines)
     Filter(VexArgs),
+    /// Export the SBOM's VEX state as a CSAF v2.0 advisory document
+    Export(VexExportArgs),
+}
+
+/// Arguments for `vex export`. Output format defaults to CSAF v2.0.
+#[derive(Parser)]
+struct VexExportArgs {
+    /// Path to the SBOM file
+    sbom: PathBuf,
+
+    /// Apply external VEX document(s) before exporting (OpenVEX / CycloneDX VEX / CSAF).
+    #[arg(long = "vex", value_name = "PATH")]
+    vex: Vec<PathBuf>,
+
+    /// Output advisory format. Currently: csaf (CSAF v2.0).
+    #[arg(short, long, default_value = "csaf")]
+    format: String,
+
+    /// Output file path (stdout if not specified)
+    #[arg(short = 'O', long)]
+    output_file: Option<PathBuf>,
 }
 
 /// Shared arguments for all VEX subcommands
@@ -1491,6 +1512,29 @@ fn main() -> Result<()> {
                 VexAction::Apply(args) => (args, cli::VexAction::Apply),
                 VexAction::Status(args) => (args, cli::VexAction::Status),
                 VexAction::Filter(args) => (args, cli::VexAction::Filter),
+                VexAction::Export(export_args) => {
+                    let fmt = match export_args.format.to_lowercase().as_str() {
+                        "csaf" | "csaf-v2.0" | "csaf2" => cli::VexExportFormat::Csaf,
+                        other => anyhow::bail!(
+                            "Unsupported VEX export format '{other}'. Valid: csaf"
+                        ),
+                    };
+                    let synth_args = VexArgs {
+                        sbom: export_args.sbom,
+                        vex: export_args.vex,
+                        output: ReportFormat::Json,
+                        output_file: export_args.output_file,
+                        actionable_only: false,
+                        state: None,
+                        enrich_vulns: false,
+                        enrich_eol: false,
+                        vuln_cache_ttl: 24,
+                        vuln_cache_dir: None,
+                        refresh_vulns: false,
+                        api_timeout: 10,
+                    };
+                    (synth_args, cli::VexAction::Export(fmt))
+                }
             };
 
             let enrichment = EnrichmentConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -849,6 +849,9 @@ enum Commands {
     /// Merge two SBOMs into one
     Merge(MergeArgs),
 
+    /// Generate CRA technical-documentation dossier (Annex V templates)
+    CraDocs(CraDocsArgs),
+
     /// Generate a man page and print it to stdout
     Man,
 }
@@ -1066,6 +1069,34 @@ struct MergeArgs {
     /// Deduplication strategy (name, purl, none)
     #[arg(long, default_value = "name")]
     dedup: String,
+}
+
+/// Arguments for the `cra-docs` subcommand — generates a CRA technical
+/// documentation dossier (Annex V templates) prefilled from the SBOM and
+/// optional CRA sidecar metadata.
+#[derive(Parser)]
+#[command(after_help = "EXAMPLES:
+    sbom-tools cra-docs app.cdx.json --output dossier/                # Markdown dossier
+    sbom-tools cra-docs app.cdx.json --output dossier/ --cra-sidecar app.cra.yaml
+    sbom-tools cra-docs app.cdx.json --output dossier/ --cra-product-class important-class-1")]
+struct CraDocsArgs {
+    /// Path to the SBOM file
+    sbom: PathBuf,
+
+    /// Output directory (will be created if it doesn't exist)
+    #[arg(short, long, default_value = "cra-dossier")]
+    output: PathBuf,
+
+    /// Path to a CRA sidecar metadata file (JSON or YAML).
+    /// If omitted, auto-discovers `<sbom>.cra.json|yaml` next to the SBOM.
+    #[arg(long, value_name = "PATH")]
+    cra_sidecar: Option<PathBuf>,
+
+    /// CRA Annex III/IV product class.
+    /// One of: default, important-class-1, important-class-2, critical.
+    /// Sidecar `productClass` wins.
+    #[arg(long, value_name = "CLASS")]
+    cra_product_class: Option<String>,
 }
 
 /// Validate VEX state filter values at the CLI boundary.
@@ -1695,6 +1726,13 @@ fn main() -> Result<()> {
             }
             Ok(())
         }
+
+        Commands::CraDocs(args) => cli::run_cra_docs(
+            args.sbom,
+            args.output,
+            args.cra_sidecar,
+            args.cra_product_class,
+        ),
 
         Commands::Man => {
             let cmd = Cli::command();

--- a/src/main.rs
+++ b/src/main.rs
@@ -342,6 +342,12 @@ struct ViewArgs {
     #[arg(long, value_name = "PATH")]
     cra_sidecar: Option<PathBuf>,
 
+    /// CRA Annex III/IV product class (drives severity calibration).
+    /// One of: default, important-class-1, important-class-2, critical.
+    /// Sidecar `productClass` wins over this flag.
+    #[arg(long, value_name = "CLASS")]
+    cra_product_class: Option<String>,
+
     #[command(flatten)]
     enrichment: SharedEnrichmentArgs,
 }
@@ -383,6 +389,12 @@ struct ValidateArgs {
     /// If omitted, sbom-tools auto-discovers `<sbom>.cra.json|yaml` next to the SBOM.
     #[arg(long, value_name = "PATH")]
     cra_sidecar: Option<PathBuf>,
+
+    /// CRA Annex III/IV product class (drives severity calibration).
+    /// One of: default, important-class-1, important-class-2, critical.
+    /// Sidecar `productClass` wins over this flag.
+    #[arg(long, value_name = "CLASS")]
+    cra_product_class: Option<String>,
 }
 
 /// Arguments for the `diff-multi` subcommand
@@ -625,6 +637,12 @@ struct QualityArgs {
     /// `--profile cra`. Auto-discovered next to the SBOM if omitted.
     #[arg(long, value_name = "PATH")]
     cra_sidecar: Option<PathBuf>,
+
+    /// CRA Annex III/IV product class (drives severity calibration).
+    /// One of: default, important-class-1, important-class-2, critical.
+    /// Sidecar `productClass` wins over this flag.
+    #[arg(long, value_name = "CLASS")]
+    cra_product_class: Option<String>,
 }
 
 /// Arguments for the `query` subcommand
@@ -1179,6 +1197,7 @@ fn main() -> Result<()> {
                     .and_then(sbom_tools::BomProfile::from_str_opt),
                 enrichment,
                 cra_sidecar_path: args.cra_sidecar.clone(),
+                cra_product_class: args.cra_product_class.clone(),
             };
             let exit_code = cli::run_view(config)?;
             if exit_code != 0 {
@@ -1195,6 +1214,7 @@ fn main() -> Result<()> {
             args.fail_on_warning,
             args.summary,
             args.cra_sidecar,
+            args.cra_product_class,
         ),
 
         Commands::DiffMulti(args) => {
@@ -1376,6 +1396,7 @@ fn main() -> Result<()> {
                 args.min_score,
                 cli.no_color,
                 args.cra_sidecar,
+                args.cra_product_class,
             )?;
             if exit_code != 0 {
                 std::process::exit(exit_code);

--- a/src/model/cra_sidecar.rs
+++ b/src/model/cra_sidecar.rs
@@ -94,6 +94,144 @@ pub struct CraSidecarMetadata {
     /// "ISO/IEC 27005:2022", "NIST SP 800-30 r1", "ETSI TS 102 165-1 TVRA").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub risk_assessment_methodology: Option<String>,
+
+    // -------- CRA Annex III/IV product class & conformity-assessment route --------
+    /// CRA product class drives the conformity-assessment route and the
+    /// severity calibration of compliance checks (vendor-hash coverage,
+    /// PSIRT, EUCC reference, attestation).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub product_class: Option<CraProductClass>,
+
+    /// Conformity-assessment route per CRA Annex VIII (Module A self-assessment,
+    /// B+C EU-type examination, H full QA, or EUCC). Sidecar value wins over
+    /// any CLI-provided default.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conformity_assessment_route: Option<ConformityRoute>,
+}
+
+/// CRA product class per Regulation (EU) 2024/2847 Annex III/IV.
+///
+/// The class drives the conformity-assessment route and the severity
+/// calibration of compliance checks (per CRA-P3.2 calibration table):
+/// stricter classes upgrade Warning→Error and add EUCC / attestation
+/// expectations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum CraProductClass {
+    /// Default — neither Annex III nor Annex IV. Module A self-assessment.
+    #[serde(rename = "default")]
+    Default,
+    /// Annex III items 1–11 (Important Class I). Module A or B+C.
+    #[serde(rename = "important-class-1", alias = "important1", alias = "ImportantClass1")]
+    ImportantClass1,
+    /// Annex III items 12–17 (Important Class II). Module B+C, H, or EUCC.
+    #[serde(rename = "important-class-2", alias = "important2", alias = "ImportantClass2")]
+    ImportantClass2,
+    /// Annex IV (Critical). EUCC mandatory.
+    #[serde(rename = "critical")]
+    Critical,
+}
+
+impl CraProductClass {
+    /// Short label for compact display.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Default => "Default",
+            Self::ImportantClass1 => "Important-1",
+            Self::ImportantClass2 => "Important-2",
+            Self::Critical => "Critical",
+        }
+    }
+
+    /// Long human-readable name including Annex reference.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::Default => "Default (no Annex)",
+            Self::ImportantClass1 => "Important Class I (Annex III items 1–11)",
+            Self::ImportantClass2 => "Important Class II (Annex III items 12–17)",
+            Self::Critical => "Critical (Annex IV)",
+        }
+    }
+
+    /// Parse from the CLI-friendly kebab-case form. Accepts a few aliases.
+    #[must_use]
+    pub fn parse_cli(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "default" | "none" => Some(Self::Default),
+            "important-class-1" | "important-1" | "important1" | "annex-iii-1" => {
+                Some(Self::ImportantClass1)
+            }
+            "important-class-2" | "important-2" | "important2" | "annex-iii-2" => {
+                Some(Self::ImportantClass2)
+            }
+            "critical" | "annex-iv" => Some(Self::Critical),
+            _ => None,
+        }
+    }
+
+    /// The conformity-assessment route the regulation expects (or strictly
+    /// requires) for this class. Manufacturers may choose a stricter route.
+    #[must_use]
+    pub const fn default_route(self) -> ConformityRoute {
+        match self {
+            Self::Default | Self::ImportantClass1 => ConformityRoute::ModuleA,
+            Self::ImportantClass2 => ConformityRoute::ModuleBC,
+            Self::Critical => ConformityRoute::Eucc,
+        }
+    }
+}
+
+/// Conformity-assessment module per CRA Annex VIII.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+#[non_exhaustive]
+pub enum ConformityRoute {
+    /// Module A — internal control / self-assessment.
+    ModuleA,
+    /// Module B+C — EU-type examination plus production conformity.
+    ModuleBC,
+    /// Module H — full quality assurance.
+    ModuleH,
+    /// EUCC — Common Criteria via European Cybersecurity Certification scheme.
+    Eucc,
+}
+
+impl ConformityRoute {
+    /// Short label.
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::ModuleA => "Module A",
+            Self::ModuleBC => "Module B+C",
+            Self::ModuleH => "Module H",
+            Self::Eucc => "EUCC",
+        }
+    }
+
+    /// Long descriptive name.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Self::ModuleA => "Module A — internal control (self-assessment)",
+            Self::ModuleBC => "Module B+C — EU-type examination + production conformity",
+            Self::ModuleH => "Module H — full quality assurance",
+            Self::Eucc => "EUCC — Common Criteria via EU certification scheme",
+        }
+    }
+
+    /// Parse from the CLI-friendly kebab-case form.
+    #[must_use]
+    pub fn parse_cli(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "module-a" | "a" | "self-assessment" => Some(Self::ModuleA),
+            "module-bc" | "module-b+c" | "module-b-c" | "bc" | "b+c" => Some(Self::ModuleBC),
+            "module-h" | "h" => Some(Self::ModuleH),
+            "eucc" | "common-criteria" => Some(Self::Eucc),
+            _ => None,
+        }
+    }
 }
 
 impl CraSidecarMetadata {
@@ -169,6 +307,8 @@ impl CraSidecarMetadata {
             || self.coordinated_disclosure_policy_url.is_some()
             || self.risk_assessment_url.is_some()
             || self.risk_assessment_methodology.is_some()
+            || self.product_class.is_some()
+            || self.conformity_assessment_route.is_some()
     }
 
     /// Generate an example sidecar file content
@@ -195,6 +335,8 @@ impl CraSidecarMetadata {
                 "https://example.com/docs/risk-assessment-2026.pdf".to_string(),
             ),
             risk_assessment_methodology: Some("ISO/IEC 27005:2022".to_string()),
+            product_class: Some(CraProductClass::ImportantClass1),
+            conformity_assessment_route: Some(ConformityRoute::ModuleA),
         };
         serde_json::to_string_pretty(&example).unwrap_or_default()
     }
@@ -258,5 +400,75 @@ mod tests {
         let json = serde_json::to_string(&original).unwrap();
         let parsed: CraSidecarMetadata = serde_json::from_str(&json).unwrap();
         assert_eq!(original.security_contact, parsed.security_contact);
+    }
+
+    #[test]
+    fn product_class_parse_cli_accepts_aliases() {
+        assert_eq!(
+            CraProductClass::parse_cli("default"),
+            Some(CraProductClass::Default)
+        );
+        assert_eq!(
+            CraProductClass::parse_cli("important-class-1"),
+            Some(CraProductClass::ImportantClass1)
+        );
+        assert_eq!(
+            CraProductClass::parse_cli("important-2"),
+            Some(CraProductClass::ImportantClass2)
+        );
+        assert_eq!(
+            CraProductClass::parse_cli("CRITICAL"),
+            Some(CraProductClass::Critical)
+        );
+        assert_eq!(CraProductClass::parse_cli("nonsense"), None);
+    }
+
+    #[test]
+    fn product_class_default_route_matches_regulation() {
+        assert_eq!(
+            CraProductClass::Default.default_route(),
+            ConformityRoute::ModuleA
+        );
+        assert_eq!(
+            CraProductClass::ImportantClass1.default_route(),
+            ConformityRoute::ModuleA
+        );
+        assert_eq!(
+            CraProductClass::ImportantClass2.default_route(),
+            ConformityRoute::ModuleBC
+        );
+        assert_eq!(
+            CraProductClass::Critical.default_route(),
+            ConformityRoute::Eucc
+        );
+    }
+
+    #[test]
+    fn product_class_serde_kebab_case() {
+        let json = serde_json::to_string(&CraProductClass::ImportantClass1).unwrap();
+        assert_eq!(json, "\"important-class-1\"");
+        let parsed: CraProductClass = serde_json::from_str("\"critical\"").unwrap();
+        assert_eq!(parsed, CraProductClass::Critical);
+    }
+
+    #[test]
+    fn conformity_route_parse_cli_accepts_aliases() {
+        assert_eq!(
+            ConformityRoute::parse_cli("module-a"),
+            Some(ConformityRoute::ModuleA)
+        );
+        assert_eq!(
+            ConformityRoute::parse_cli("B+C"),
+            Some(ConformityRoute::ModuleBC)
+        );
+        assert_eq!(
+            ConformityRoute::parse_cli("Module-H"),
+            Some(ConformityRoute::ModuleH)
+        );
+        assert_eq!(
+            ConformityRoute::parse_cli("EUCC"),
+            Some(ConformityRoute::Eucc)
+        );
+        assert_eq!(ConformityRoute::parse_cli("module-z"), None);
     }
 }

--- a/src/model/cra_sidecar.rs
+++ b/src/model/cra_sidecar.rs
@@ -107,6 +107,14 @@ pub struct CraSidecarMetadata {
     /// any CLI-provided default.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conformity_assessment_route: Option<ConformityRoute>,
+
+    // -------- CRA Article 24 — open-source steward profile --------
+    /// Whether this product is supplied by an open-source software steward
+    /// (CRA Art. 24). When `true`, manufacturer-only obligations (DoC,
+    /// notified-body attestation, manufacturer email) are not enforced;
+    /// SBOM, vulnerability-handling, and CVD policy are still required.
+    #[serde(default, skip_serializing_if = "core::ops::Not::not")]
+    pub is_oss_steward: bool,
 }
 
 /// CRA product class per Regulation (EU) 2024/2847 Annex III/IV.
@@ -309,6 +317,7 @@ impl CraSidecarMetadata {
             || self.risk_assessment_methodology.is_some()
             || self.product_class.is_some()
             || self.conformity_assessment_route.is_some()
+            || self.is_oss_steward
     }
 
     /// Generate an example sidecar file content
@@ -337,6 +346,7 @@ impl CraSidecarMetadata {
             risk_assessment_methodology: Some("ISO/IEC 27005:2022".to_string()),
             product_class: Some(CraProductClass::ImportantClass1),
             conformity_assessment_route: Some(ConformityRoute::ModuleA),
+            is_oss_steward: false,
         };
         serde_json::to_string_pretty(&example).unwrap_or_default()
     }

--- a/src/model/cra_sidecar.rs
+++ b/src/model/cra_sidecar.rs
@@ -11,6 +11,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::Path;
 
 /// CRA sidecar metadata that supplements SBOM information
@@ -146,6 +147,59 @@ pub struct CraSidecarMetadata {
     /// horizon.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub red_repealed_until: Option<DateTime<Utc>>,
+
+    // -------- EUCC Substantial (CRA-P5.4 reference profile) --------
+    /// Common Criteria Protection Profile identifier (e.g., "PP-CC-MFR-2024-01").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eucc_protection_profile_id: Option<String>,
+
+    /// Common Criteria Target of Evaluation reference (URL or document ID).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eucc_target_of_evaluation: Option<String>,
+
+    /// IT Security Evaluation Facility (ITSEF) identifier — the accredited
+    /// laboratory that performed the EUCC evaluation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eucc_itsef_identifier: Option<String>,
+
+    /// EUCC certificate valid-until date.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub eucc_valid_until: Option<DateTime<Utc>>,
+
+    // -------- prEN 40000-1-2/1-4 controls-assertion (CRA-P5.5) --------
+    /// Per-control assertions for CRA Annex I Part I, keyed by control ID
+    /// (e.g., `"1.a"` through `"1.l"` for §1, `"2.a"` through `"2.m"` for
+    /// §2 vulnerability-handling). Each entry records whether the
+    /// manufacturer claims the control is satisfied, the evidence URL,
+    /// and the methodology used.
+    ///
+    /// `BTreeMap` for deterministic ordering in dossier output.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub annex_i_part_i_controls: BTreeMap<String, ControlAssertion>,
+}
+
+/// A manufacturer-supplied assertion that a specific Annex I Part I control
+/// is satisfied. Surfaced verbatim in the cra-docs technical-documentation
+/// dossier and cross-checked by `ComplianceChecker` (a control claimed
+/// `satisfied = true` without an `evidence_url` is flagged as a Warning).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ControlAssertion {
+    /// Whether the manufacturer claims this control is satisfied.
+    #[serde(default)]
+    pub satisfied: bool,
+    /// URL pointing at the evidence document (test report, design review,
+    /// SAST/DAST output, etc.). Required when `satisfied = true`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub evidence_url: Option<String>,
+    /// Methodology / standard the assertion was made against
+    /// (e.g., `"prEN 40000-1-2 §5.3"`, `"OWASP ASVS L2"`,
+    /// `"NIST SP 800-53 SI-10"`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub methodology: Option<String>,
+    /// Free-form notes from the manufacturer (rationale, caveats).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
 }
 
 /// CRA product class per Regulation (EU) 2024/2847 Annex III/IV.
@@ -350,7 +404,7 @@ impl CraSidecarMetadata {
 
     /// Check if any CRA-relevant fields are populated
     #[must_use]
-    pub const fn has_cra_data(&self) -> bool {
+    pub fn has_cra_data(&self) -> bool {
         self.security_contact.is_some()
             || self.vulnerability_disclosure_url.is_some()
             || self.support_end_date.is_some()
@@ -371,6 +425,11 @@ impl CraSidecarMetadata {
             || self.processes_personal_data
             || self.is_high_risk_ai
             || self.red_repealed_until.is_some()
+            || self.eucc_protection_profile_id.is_some()
+            || self.eucc_target_of_evaluation.is_some()
+            || self.eucc_itsef_identifier.is_some()
+            || self.eucc_valid_until.is_some()
+            || !self.annex_i_part_i_controls.is_empty()
     }
 
     /// Generate an example sidecar file content
@@ -405,6 +464,11 @@ impl CraSidecarMetadata {
             processes_personal_data: false,
             is_high_risk_ai: false,
             red_repealed_until: None,
+            eucc_protection_profile_id: None,
+            eucc_target_of_evaluation: None,
+            eucc_itsef_identifier: None,
+            eucc_valid_until: None,
+            annex_i_part_i_controls: BTreeMap::new(),
         };
         serde_json::to_string_pretty(&example).unwrap_or_default()
     }

--- a/src/model/cra_sidecar.rs
+++ b/src/model/cra_sidecar.rs
@@ -115,6 +115,37 @@ pub struct CraSidecarMetadata {
     /// SBOM, vulnerability-handling, and CVD policy are still required.
     #[serde(default, skip_serializing_if = "core::ops::Not::not")]
     pub is_oss_steward: bool,
+
+    // -------- Adjacent regulation overlap (CRA-P4.4) --------
+    /// True if the manufacturer is a NIS2 essential entity (Annex I of
+    /// Directive (EU) 2022/2555). Triggers Art. 23 incident-reporting
+    /// guidance in the cra-docs dossier.
+    #[serde(default, skip_serializing_if = "core::ops::Not::not")]
+    pub is_nis2_essential_entity: bool,
+
+    /// True if the manufacturer is a NIS2 important entity (Annex II of
+    /// Directive (EU) 2022/2555).
+    #[serde(default, skip_serializing_if = "core::ops::Not::not")]
+    pub is_nis2_important_entity: bool,
+
+    /// True when the product processes personal data (GDPR Art. 32
+    /// security-of-processing applies in parallel to CRA Annex I).
+    #[serde(default, skip_serializing_if = "core::ops::Not::not")]
+    pub processes_personal_data: bool,
+
+    /// True when the product is a high-risk AI system per the AI Act
+    /// (Regulation (EU) 2024/1689). AI-Act conformity coordination must
+    /// be handled alongside CRA Module assessment.
+    #[serde(default, skip_serializing_if = "core::ops::Not::not")]
+    pub is_high_risk_ai: bool,
+
+    /// Date until which the Radio Equipment Directive (RED, Directive
+    /// 2014/53/EU) cybersecurity provisions still apply for this product.
+    /// CRA repeals RED Art. 3(3)(d/e/f) on 2025-08-01; older device
+    /// inventories may carry RED references through their support
+    /// horizon.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub red_repealed_until: Option<DateTime<Utc>>,
 }
 
 /// CRA product class per Regulation (EU) 2024/2847 Annex III/IV.
@@ -335,6 +366,11 @@ impl CraSidecarMetadata {
             || self.product_class.is_some()
             || self.conformity_assessment_route.is_some()
             || self.is_oss_steward
+            || self.is_nis2_essential_entity
+            || self.is_nis2_important_entity
+            || self.processes_personal_data
+            || self.is_high_risk_ai
+            || self.red_repealed_until.is_some()
     }
 
     /// Generate an example sidecar file content
@@ -364,6 +400,11 @@ impl CraSidecarMetadata {
             product_class: Some(CraProductClass::ImportantClass1),
             conformity_assessment_route: Some(ConformityRoute::ModuleA),
             is_oss_steward: false,
+            is_nis2_essential_entity: false,
+            is_nis2_important_entity: false,
+            processes_personal_data: false,
+            is_high_risk_ai: false,
+            red_repealed_until: None,
         };
         serde_json::to_string_pretty(&example).unwrap_or_default()
     }

--- a/src/model/cra_sidecar.rs
+++ b/src/model/cra_sidecar.rs
@@ -272,28 +272,45 @@ impl CraSidecarMetadata {
         }
     }
 
-    /// Try to find a sidecar file for the given SBOM path
-    /// Looks for .cra.json or .cra.yaml files alongside the SBOM
+    /// Try to find a sidecar file for the given SBOM path.
+    ///
+    /// Looks for `<stem>.cra.{json,yaml,yml}` and `<stem>-cra.{json,yaml}`
+    /// alongside the SBOM. Multi-extension stems (`app.cdx.json`,
+    /// `app.spdx.json`, `app.spdx3.json`) also try the inner stem
+    /// (`app.cra.json`) so the common SBOM naming conventions work
+    /// without forcing operators to repeat the format suffix.
     #[must_use]
     pub fn find_for_sbom(sbom_path: &Path) -> Option<Self> {
         let parent = sbom_path.parent()?;
         let stem = sbom_path.file_stem()?.to_str()?;
 
-        // Try common sidecar naming patterns
-        let patterns = [
-            format!("{stem}.cra.json"),
-            format!("{stem}.cra.yaml"),
-            format!("{stem}.cra.yml"),
-            format!("{stem}-cra.json"),
-            format!("{stem}-cra.yaml"),
-        ];
-
-        for pattern in &patterns {
-            let sidecar_path = parent.join(pattern);
-            if sidecar_path.exists()
-                && let Ok(metadata) = Self::from_file(&sidecar_path)
+        // Build the list of stems to try. Strip well-known SBOM format
+        // suffixes (`.cdx`, `.spdx`, `.spdx3`, `.cyclonedx`) so e.g.
+        // `app.cdx.json` looks for `app.cra.json` as well as
+        // `app.cdx.cra.json`.
+        let mut stems: Vec<&str> = vec![stem];
+        for suffix in [".cdx", ".cyclonedx", ".spdx", ".spdx3"] {
+            if let Some(inner) = stem.strip_suffix(suffix)
+                && !inner.is_empty()
             {
-                return Some(metadata);
+                stems.push(inner);
+            }
+        }
+
+        for s in &stems {
+            for pattern in [
+                format!("{s}.cra.json"),
+                format!("{s}.cra.yaml"),
+                format!("{s}.cra.yml"),
+                format!("{s}-cra.json"),
+                format!("{s}-cra.yaml"),
+            ] {
+                let sidecar_path = parent.join(&pattern);
+                if sidecar_path.exists()
+                    && let Ok(metadata) = Self::from_file(&sidecar_path)
+                {
+                    return Some(metadata);
+                }
             }
         }
 

--- a/src/model/cra_sidecar.rs
+++ b/src/model/cra_sidecar.rs
@@ -215,10 +215,18 @@ pub enum CraProductClass {
     #[serde(rename = "default")]
     Default,
     /// Annex III items 1–11 (Important Class I). Module A or B+C.
-    #[serde(rename = "important-class-1", alias = "important1", alias = "ImportantClass1")]
+    #[serde(
+        rename = "important-class-1",
+        alias = "important1",
+        alias = "ImportantClass1"
+    )]
     ImportantClass1,
     /// Annex III items 12–17 (Important Class II). Module B+C, H, or EUCC.
-    #[serde(rename = "important-class-2", alias = "important2", alias = "ImportantClass2")]
+    #[serde(
+        rename = "important-class-2",
+        alias = "important2",
+        alias = "ImportantClass2"
+    )]
     ImportantClass2,
     /// Annex IV (Critical). EUCC mandatory.
     #[serde(rename = "critical")]

--- a/src/model/cra_sidecar.rs
+++ b/src/model/cra_sidecar.rs
@@ -52,6 +52,48 @@ pub struct CraSidecarMetadata {
     /// Security update delivery mechanism description
     #[serde(skip_serializing_if = "Option::is_none")]
     pub update_mechanism: Option<String>,
+
+    // -------- CRA Article 14 reporting-readiness fields (apply 2026-09-11) --------
+    /// PSIRT (Product Security Incident Response Team) public URL.
+    /// Required to handle external vulnerability reports under Annex I Part II
+    /// and Art. 14 incident reporting.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub psirt_url: Option<String>,
+
+    /// Channel (email, URL, phone) for the 24-hour early-warning notification
+    /// to ENISA / CSIRT under CRA Art. 14(1) when an actively-exploited
+    /// vulnerability is identified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub early_warning_contact: Option<String>,
+
+    /// Channel for the 72-hour incident report under CRA Art. 14(2).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub incident_report_contact: Option<String>,
+
+    /// Manufacturer-side identifier for the ENISA single reporting platform
+    /// (Art. 14(7)). Until ENISA publishes the technical interface this is a
+    /// placeholder string — typically a manufacturer registration ID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub enisa_reporting_platform_id: Option<String>,
+
+    /// Coordinated vulnerability disclosure policy URL.
+    /// Distinct from `vulnerability_disclosure_url` (which may point at a
+    /// portal) — this is the published *policy* that meets CRA Art. 13(7)
+    /// and ISO/IEC 29147 expectations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub coordinated_disclosure_policy_url: Option<String>,
+
+    // -------- CRA Article 13(2) risk-assessment fields --------
+    /// URL or document reference for the documented risk assessment
+    /// required by CRA Art. 13(2). Annex V technical documentation must
+    /// include or reference this assessment.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk_assessment_url: Option<String>,
+
+    /// Methodology used for the risk assessment (e.g.,
+    /// "ISO/IEC 27005:2022", "NIST SP 800-30 r1", "ETSI TS 102 165-1 TVRA").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub risk_assessment_methodology: Option<String>,
 }
 
 impl CraSidecarMetadata {
@@ -120,6 +162,13 @@ impl CraSidecarMetadata {
             || self.support_end_date.is_some()
             || self.manufacturer_name.is_some()
             || self.ce_marking_reference.is_some()
+            || self.psirt_url.is_some()
+            || self.early_warning_contact.is_some()
+            || self.incident_report_contact.is_some()
+            || self.enisa_reporting_platform_id.is_some()
+            || self.coordinated_disclosure_policy_url.is_some()
+            || self.risk_assessment_url.is_some()
+            || self.risk_assessment_methodology.is_some()
     }
 
     /// Generate an example sidecar file content
@@ -135,6 +184,17 @@ impl CraSidecarMetadata {
             product_version: Some("1.0.0".to_string()),
             ce_marking_reference: Some("EU-DoC-2024-001".to_string()),
             update_mechanism: Some("Automatic OTA updates via secure channel".to_string()),
+            psirt_url: Some("https://example.com/psirt".to_string()),
+            early_warning_contact: Some("psirt@example.com".to_string()),
+            incident_report_contact: Some("incidents@example.com".to_string()),
+            enisa_reporting_platform_id: Some("EU-MFR-12345".to_string()),
+            coordinated_disclosure_policy_url: Some(
+                "https://example.com/security/cvd-policy".to_string(),
+            ),
+            risk_assessment_url: Some(
+                "https://example.com/docs/risk-assessment-2026.pdf".to_string(),
+            ),
+            risk_assessment_methodology: Some("ISO/IEC 27005:2022".to_string()),
         };
         serde_json::to_string_pretty(&example).unwrap_or_default()
     }

--- a/src/model/identifiers.rs
+++ b/src/model/identifiers.rs
@@ -5,9 +5,13 @@
 //!
 //! 1. **PURL** (Package URL) - Most reliable, globally unique
 //! 2. **CPE** (Common Platform Enumeration) - Industry standard for vulnerability matching
-//! 3. **SWID** (Software Identification) - ISO standard tag
-//! 4. **Synthetic** - Generated from group:name@version (stable across regenerations)
-//! 5. **`FormatSpecific`** - Original format ID (least stable, may be UUIDs)
+//! 3. **SWHID** (Software Heritage persistent ID) - Content-addressed, ISO/IEC 18670
+//! 4. **SWID** (Software Identification) - ISO standard tag
+//! 5. **Synthetic** - Generated from group:name@version (stable across regenerations)
+//! 6. **`FormatSpecific`** - Original format ID (least stable, may be UUIDs)
+//!
+//! SWHID is one of the three identifier types named by CRA prEN 40000-1-3
+//! `[PRE-7-RQ-07]` (alongside PURL and CPE).
 
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -31,11 +35,14 @@ pub struct CanonicalId {
 
 /// Source of the canonical identifier, ordered by reliability
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
 pub enum IdSource {
     /// Derived from Package URL (most reliable)
     Purl,
     /// Derived from CPE
     Cpe,
+    /// Derived from Software Heritage persistent identifier (content-addressed)
+    Swhid,
     /// Derived from SWID tag
     Swid,
     /// Derived from name and version (stable)
@@ -52,7 +59,7 @@ impl IdSource {
     pub const fn is_stable(&self) -> bool {
         matches!(
             self,
-            Self::Purl | Self::Cpe | Self::Swid | Self::NameVersion | Self::Synthetic
+            Self::Purl | Self::Cpe | Self::Swhid | Self::Swid | Self::NameVersion | Self::Synthetic
         )
     }
 
@@ -62,10 +69,11 @@ impl IdSource {
         match self {
             Self::Purl => 0,
             Self::Cpe => 1,
-            Self::Swid => 2,
-            Self::NameVersion => 3,
-            Self::Synthetic => 4,
-            Self::FormatSpecific => 5,
+            Self::Swhid => 2,
+            Self::Swid => 3,
+            Self::NameVersion => 4,
+            Self::Synthetic => 5,
+            Self::FormatSpecific => 6,
         }
     }
 }
@@ -152,6 +160,41 @@ impl CanonicalId {
         }
     }
 
+    /// Create from a Software Heritage persistent identifier (SWHID).
+    ///
+    /// SWHIDs are content-addressed identifiers of the form
+    /// `swh:1:<kind>:<sha1-hex>[;<qualifier>=<value>...]`.
+    /// Named explicitly by CRA prEN 40000-1-3 `[PRE-7-RQ-07]` alongside PURL/CPE.
+    ///
+    /// Falls back to a `FormatSpecific` identifier (marked unstable) if the
+    /// input does not look like a valid SWHID.
+    #[must_use]
+    pub fn from_swhid(swhid: &str) -> Self {
+        match SwhidObject::parse(swhid) {
+            Ok(obj) => Self {
+                // Display reconstitutes the canonical lowercase form with qualifiers
+                value: obj.to_string(),
+                source: IdSource::Swhid,
+                stable: true,
+            },
+            Err(_) => Self {
+                value: swhid.to_string(),
+                source: IdSource::FormatSpecific,
+                stable: false,
+            },
+        }
+    }
+
+    /// Create from a structured `SwhidObject` (preferred internal path).
+    #[must_use]
+    pub fn from_swhid_object(obj: &SwhidObject) -> Self {
+        Self {
+            value: obj.to_string(),
+            source: IdSource::Swhid,
+            stable: true,
+        }
+    }
+
     /// Get the canonical ID value
     #[must_use]
     pub fn value(&self) -> &str {
@@ -188,6 +231,206 @@ impl CanonicalId {
     }
 }
 
+/// Software Heritage persistent identifier kind.
+///
+/// Per the SWHID spec (<https://www.swhid.org/>), every SWHID identifies one of
+/// five object kinds in the Software Heritage archive.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum SwhidKind {
+    /// File content (blob)
+    Cnt,
+    /// Directory (tree)
+    Dir,
+    /// Revision (commit)
+    Rev,
+    /// Release (tag)
+    Rel,
+    /// Snapshot (repository state)
+    Snp,
+}
+
+impl SwhidKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Cnt => "cnt",
+            Self::Dir => "dir",
+            Self::Rev => "rev",
+            Self::Rel => "rel",
+            Self::Snp => "snp",
+        }
+    }
+
+    fn parse(s: &str) -> Option<Self> {
+        match s.to_ascii_lowercase().as_str() {
+            "cnt" => Some(Self::Cnt),
+            "dir" => Some(Self::Dir),
+            "rev" => Some(Self::Rev),
+            "rel" => Some(Self::Rel),
+            "snp" => Some(Self::Snp),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for SwhidKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A structured Software Heritage persistent identifier.
+///
+/// Format: `swh:1:<kind>:<sha1-hex-40>[;<qualifier>=<value>...]`. Recognised
+/// by CRA prEN 40000-1-3 `[PRE-7-RQ-07]` as one of the three named identifier
+/// types (alongside PURL and CPE).
+///
+/// Serialised as a plain string in JSON to match CycloneDX/SPDX wire formats
+/// (`["swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2", ...]`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SwhidObject {
+    /// Object kind (cnt/dir/rev/rel/snp)
+    pub kind: SwhidKind,
+    /// 20-byte SHA-1 of the canonical object representation
+    pub hash: [u8; 20],
+    /// Optional contextual qualifiers (origin, visit, anchor, path, lines)
+    pub qualifiers: Vec<(String, String)>,
+}
+
+/// Errors returned when parsing a SWHID string.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SwhidParseError {
+    /// String didn't have the four-part `swh:1:<kind>:<hash>` shape
+    BadShape,
+    /// Prefix wasn't `swh:1:`
+    BadPrefix,
+    /// Kind wasn't one of cnt/dir/rev/rel/snp
+    BadKind,
+    /// Hash wasn't 40 hex characters
+    BadHash,
+    /// Qualifier didn't have the `key=value` shape
+    BadQualifier,
+}
+
+impl fmt::Display for SwhidParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadShape => f.write_str("SWHID does not have shape swh:1:<kind>:<hash>"),
+            Self::BadPrefix => f.write_str("SWHID prefix is not 'swh:1:'"),
+            Self::BadKind => f.write_str("SWHID kind must be one of cnt/dir/rev/rel/snp"),
+            Self::BadHash => f.write_str("SWHID hash must be 40 hexadecimal characters"),
+            Self::BadQualifier => f.write_str("SWHID qualifier missing '=' separator"),
+        }
+    }
+}
+
+impl std::error::Error for SwhidParseError {}
+
+impl SwhidObject {
+    /// Parse a SWHID string into structured form.
+    ///
+    /// Validation is case-insensitive on the prefix, kind, and hash; the
+    /// canonical form (returned by `Display`) is lowercase. Qualifier values
+    /// are preserved verbatim — the SWHID spec does not mandate a case
+    /// convention for qualifier values (e.g., URLs in `origin=`).
+    pub fn parse(s: &str) -> Result<Self, SwhidParseError> {
+        let (core, qualifier_str) = s.split_once(';').unwrap_or((s, ""));
+        let parts: Vec<&str> = core.split(':').collect();
+        if parts.len() != 4 {
+            return Err(SwhidParseError::BadShape);
+        }
+        if !parts[0].eq_ignore_ascii_case("swh") || parts[1] != "1" {
+            return Err(SwhidParseError::BadPrefix);
+        }
+        let kind = SwhidKind::parse(parts[2]).ok_or(SwhidParseError::BadKind)?;
+
+        if parts[3].len() != 40 || !parts[3].chars().all(|c| c.is_ascii_hexdigit()) {
+            return Err(SwhidParseError::BadHash);
+        }
+        let mut hash = [0u8; 20];
+        let bytes = parts[3].as_bytes();
+        for (i, byte) in hash.iter_mut().enumerate() {
+            let high = hex_digit(bytes[i * 2]).ok_or(SwhidParseError::BadHash)?;
+            let low = hex_digit(bytes[i * 2 + 1]).ok_or(SwhidParseError::BadHash)?;
+            *byte = (high << 4) | low;
+        }
+
+        let mut qualifiers = Vec::new();
+        if !qualifier_str.is_empty() {
+            for q in qualifier_str.split(';') {
+                if q.is_empty() {
+                    continue;
+                }
+                let (k, v) = q.split_once('=').ok_or(SwhidParseError::BadQualifier)?;
+                qualifiers.push((k.to_string(), v.to_string()));
+            }
+        }
+
+        Ok(Self {
+            kind,
+            hash,
+            qualifiers,
+        })
+    }
+
+    /// Canonical lowercase hex representation of the SHA-1 hash.
+    #[must_use]
+    pub fn hash_hex(&self) -> String {
+        let mut s = String::with_capacity(40);
+        for b in &self.hash {
+            s.push(hex_char(b >> 4));
+            s.push(hex_char(b & 0xf));
+        }
+        s
+    }
+}
+
+const fn hex_char(n: u8) -> char {
+    match n {
+        0..=9 => (b'0' + n) as char,
+        10..=15 => (b'a' + n - 10) as char,
+        _ => '?',
+    }
+}
+
+const fn hex_digit(c: u8) -> Option<u8> {
+    match c {
+        b'0'..=b'9' => Some(c - b'0'),
+        b'a'..=b'f' => Some(c - b'a' + 10),
+        b'A'..=b'F' => Some(c - b'A' + 10),
+        _ => None,
+    }
+}
+
+impl fmt::Display for SwhidObject {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "swh:1:{}:{}", self.kind, self.hash_hex())?;
+        for (k, v) in &self.qualifiers {
+            write!(f, ";{k}={v}")?;
+        }
+        Ok(())
+    }
+}
+
+// Keep the wire format as a plain string so CycloneDX/SPDX I/O stays unchanged.
+impl Serialize for SwhidObject {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for SwhidObject {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Self::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Validate a SWHID string (convenience predicate over `SwhidObject::parse`).
+#[must_use]
+pub fn is_valid_swhid(s: &str) -> bool {
+    SwhidObject::parse(s).is_ok()
+}
+
 impl PartialEq for CanonicalId {
     fn eq(&self, other: &Self) -> bool {
         self.value == other.value
@@ -213,6 +456,18 @@ pub struct ComponentIdentifiers {
     pub purl: Option<String>,
     /// Common Platform Enumeration identifiers
     pub cpe: Vec<String>,
+    /// Software Heritage persistent identifiers (SWHIDs).
+    ///
+    /// Multiple values supported because a component may be expressible by
+    /// several SWHID kinds (e.g., one `cnt` per archive entry plus a `dir`
+    /// for the unpacked tree). CRA prEN 40000-1-3 `[PRE-7-RQ-07]` accepts
+    /// SWHIDs as one of three named identifier types.
+    ///
+    /// Stored as structured `SwhidObject` for downstream consumers; on the
+    /// wire (JSON), each element serialises as a plain string to match the
+    /// CycloneDX / SPDX 3.0 `swhid` array shape.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub swhid: Vec<SwhidObject>,
     /// Software Identification tag
     pub swid: Option<String>,
     /// Original format-specific identifier
@@ -246,21 +501,20 @@ impl ComponentIdentifiers {
     /// generate synthetic IDs from component metadata.
     #[must_use]
     pub fn canonical_id(&self) -> CanonicalId {
-        // Tiered fallback: PURL → CPE → SWID → format_id
-        self.purl.as_ref().map_or_else(
-            || {
-                self.cpe.first().map_or_else(
-                    || {
-                        self.swid.as_ref().map_or_else(
-                            || CanonicalId::from_format_id(&self.format_id),
-                            |swid| CanonicalId::from_swid(swid),
-                        )
-                    },
-                    |cpe| CanonicalId::from_cpe(cpe),
-                )
-            },
-            |purl| CanonicalId::from_purl(purl),
-        )
+        // Tiered fallback: PURL → CPE → SWHID → SWID → format_id
+        if let Some(purl) = &self.purl {
+            return CanonicalId::from_purl(purl);
+        }
+        if let Some(cpe) = self.cpe.first() {
+            return CanonicalId::from_cpe(cpe);
+        }
+        if let Some(swhid) = self.swhid.first() {
+            return CanonicalId::from_swhid_object(swhid);
+        }
+        if let Some(swid) = &self.swid {
+            return CanonicalId::from_swid(swid);
+        }
+        CanonicalId::from_format_id(&self.format_id)
     }
 
     /// Get the best available canonical ID with component context for stable fallback
@@ -268,9 +522,10 @@ impl ComponentIdentifiers {
     /// This method uses a tiered fallback strategy:
     /// 1. PURL (most reliable)
     /// 2. CPE
-    /// 3. SWID
-    /// 4. Synthetic (group:name@version) - stable across regenerations
-    /// 5. Format-specific ID (least stable)
+    /// 3. SWHID (content-addressed, CRA prEN 40000-1-3 named)
+    /// 4. SWID
+    /// 5. Synthetic (group:name@version) - stable across regenerations
+    /// 6. Format-specific ID (least stable)
     ///
     /// Returns both the ID and any warnings about stability.
     #[must_use]
@@ -296,7 +551,15 @@ impl ComponentIdentifiers {
             };
         }
 
-        // Tier 3: SWID
+        // Tier 3: SWHID (content-addressed)
+        if let Some(swhid) = self.swhid.first() {
+            return CanonicalIdResult {
+                id: CanonicalId::from_swhid_object(swhid),
+                warning: None,
+            };
+        }
+
+        // Tier 4: SWID
         if let Some(swid) = &self.swid {
             return CanonicalIdResult {
                 id: CanonicalId::from_swid(swid),
@@ -304,19 +567,19 @@ impl ComponentIdentifiers {
             };
         }
 
-        // Tier 4: Synthetic from name/version/group (stable)
+        // Tier 5: Synthetic from name/version/group (stable)
         // Only use if we have at least a name
         if !name.is_empty() {
             return CanonicalIdResult {
                 id: CanonicalId::synthetic(group, name, version),
                 warning: Some(format!(
-                    "Component '{name}' lacks PURL/CPE/SWID identifiers; using synthetic ID. \
+                    "Component '{name}' lacks PURL/CPE/SWHID/SWID identifiers; using synthetic ID. \
                      Consider enriching SBOM with package URLs for accurate diffing."
                 )),
             };
         }
 
-        // Tier 5: Format-specific (least stable - may be UUID)
+        // Tier 6: Format-specific (least stable - may be UUID)
         let id = CanonicalId::from_format_id(&self.format_id);
         let warning = if id.is_stable() {
             Some(format!(
@@ -337,7 +600,7 @@ impl ComponentIdentifiers {
     /// Check if this component has any stable identifiers
     #[must_use]
     pub fn has_stable_id(&self) -> bool {
-        self.purl.is_some() || !self.cpe.is_empty() || self.swid.is_some()
+        self.purl.is_some() || !self.cpe.is_empty() || !self.swhid.is_empty() || self.swid.is_some()
     }
 
     /// Get the reliability level of available identifiers
@@ -345,11 +608,19 @@ impl ComponentIdentifiers {
     pub fn id_reliability(&self) -> IdReliability {
         if self.purl.is_some() {
             IdReliability::High
-        } else if !self.cpe.is_empty() || self.swid.is_some() {
+        } else if !self.cpe.is_empty() || !self.swhid.is_empty() || self.swid.is_some() {
             IdReliability::Medium
         } else {
             IdReliability::Low
         }
+    }
+
+    /// Returns true if this component has any of the CRA-named identifier
+    /// types (PURL, CPE, SWHID, or SWID), satisfying CRA Annex I Part II
+    /// identifier-traceability and prEN 40000-1-3 `[PRE-7-RQ-07]`.
+    #[must_use]
+    pub fn has_cra_identifier(&self) -> bool {
+        self.purl.is_some() || !self.cpe.is_empty() || !self.swhid.is_empty() || self.swid.is_some()
     }
 }
 
@@ -603,5 +874,210 @@ impl VulnerabilityRef2 {
     #[must_use]
     pub fn component_name(&self) -> &str {
         self.component.name()
+    }
+}
+
+#[cfg(test)]
+mod swhid_tests {
+    use super::*;
+
+    #[test]
+    fn valid_swhid_content() {
+        assert!(is_valid_swhid(
+            "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2"
+        ));
+    }
+
+    #[test]
+    fn valid_swhid_all_kinds() {
+        for kind in ["cnt", "dir", "rev", "rel", "snp"] {
+            let s = format!("swh:1:{kind}:94a9ed024d3859793618152ea559a168bbcbb5e2");
+            assert!(is_valid_swhid(&s), "kind {kind} should be valid");
+        }
+    }
+
+    #[test]
+    fn valid_swhid_with_qualifier() {
+        let swhid =
+            "swh:1:rev:309cf2674ee7a0749978cf8265ab91a60aea0f7d;origin=https://github.com/x/y";
+        assert!(is_valid_swhid(swhid));
+    }
+
+    #[test]
+    fn invalid_swhid_wrong_prefix() {
+        assert!(!is_valid_swhid(
+            "swhid:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2"
+        ));
+    }
+
+    #[test]
+    fn invalid_swhid_unknown_kind() {
+        assert!(!is_valid_swhid(
+            "swh:1:foo:94a9ed024d3859793618152ea559a168bbcbb5e2"
+        ));
+    }
+
+    #[test]
+    fn invalid_swhid_short_hash() {
+        assert!(!is_valid_swhid("swh:1:cnt:94a9ed024d"));
+    }
+
+    #[test]
+    fn invalid_swhid_non_hex() {
+        assert!(!is_valid_swhid(
+            "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbZZZZ"
+        ));
+    }
+
+    #[test]
+    fn invalid_swhid_falls_back_to_format_specific() {
+        let id = CanonicalId::from_swhid("swh:1:foo:bad");
+        assert_eq!(id.source(), &IdSource::FormatSpecific);
+        assert!(!id.is_stable());
+    }
+
+    #[test]
+    fn valid_swhid_construction_and_round_trip() {
+        let raw = "swh:1:cnt:94A9ED024D3859793618152EA559A168BBCBB5E2";
+        let id = CanonicalId::from_swhid(raw);
+        assert_eq!(id.source(), &IdSource::Swhid);
+        assert!(id.is_stable());
+        assert_eq!(
+            id.value(),
+            "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2"
+        );
+    }
+
+    #[test]
+    fn swhid_qualifier_preserved_after_normalization() {
+        let raw = "swh:1:REV:309CF2674EE7A0749978CF8265AB91A60AEA0F7D;origin=Https://X.Y";
+        let id = CanonicalId::from_swhid(raw);
+        assert_eq!(
+            id.value(),
+            "swh:1:rev:309cf2674ee7a0749978cf8265ab91a60aea0f7d;origin=Https://X.Y"
+        );
+    }
+
+    #[test]
+    fn component_identifiers_canonical_id_prefers_purl() {
+        let mut ids = ComponentIdentifiers::new("synthetic-1".to_string());
+        ids.purl = Some("pkg:cargo/serde@1.0.0".to_string());
+        ids.swhid.push(
+            SwhidObject::parse("swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2").unwrap(),
+        );
+        assert_eq!(ids.canonical_id().source(), &IdSource::Purl);
+    }
+
+    #[test]
+    fn component_identifiers_canonical_id_uses_swhid_when_purl_absent() {
+        let mut ids = ComponentIdentifiers::new("synthetic-1".to_string());
+        ids.swhid.push(
+            SwhidObject::parse("swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2").unwrap(),
+        );
+        let id = ids.canonical_id();
+        assert_eq!(id.source(), &IdSource::Swhid);
+    }
+
+    #[test]
+    fn has_cra_identifier_recognizes_swhid_only() {
+        let mut ids = ComponentIdentifiers::new("synthetic-1".to_string());
+        assert!(!ids.has_cra_identifier());
+        ids.swhid.push(
+            SwhidObject::parse("swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2").unwrap(),
+        );
+        assert!(ids.has_cra_identifier());
+    }
+
+    #[test]
+    fn swhid_object_round_trip_via_display() {
+        let raw = "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2";
+        let obj = SwhidObject::parse(raw).unwrap();
+        assert_eq!(obj.kind, SwhidKind::Cnt);
+        assert_eq!(obj.qualifiers.len(), 0);
+        assert_eq!(obj.to_string(), raw);
+    }
+
+    #[test]
+    fn swhid_object_preserves_qualifiers_in_order() {
+        let raw = "swh:1:rev:309cf2674ee7a0749978cf8265ab91a60aea0f7d;origin=https://github.com/x/y;path=/src";
+        let obj = SwhidObject::parse(raw).unwrap();
+        assert_eq!(obj.kind, SwhidKind::Rev);
+        assert_eq!(obj.qualifiers.len(), 2);
+        assert_eq!(
+            obj.qualifiers[0],
+            ("origin".to_string(), "https://github.com/x/y".to_string())
+        );
+        assert_eq!(obj.qualifiers[1], ("path".to_string(), "/src".to_string()));
+        assert_eq!(obj.to_string(), raw);
+    }
+
+    #[test]
+    fn swhid_object_lowercases_uppercase_input() {
+        let raw = "SWH:1:CNT:94A9ED024D3859793618152EA559A168BBCBB5E2";
+        let obj = SwhidObject::parse(raw).unwrap();
+        assert_eq!(
+            obj.to_string(),
+            "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2"
+        );
+    }
+
+    #[test]
+    fn swhid_object_serde_round_trip_as_string() {
+        let obj = SwhidObject::parse("swh:1:dir:309cf2674ee7a0749978cf8265ab91a60aea0f7d").unwrap();
+        let json = serde_json::to_string(&obj).unwrap();
+        assert_eq!(
+            json,
+            "\"swh:1:dir:309cf2674ee7a0749978cf8265ab91a60aea0f7d\""
+        );
+        let back: SwhidObject = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, obj);
+    }
+
+    #[test]
+    fn swhid_object_parse_errors() {
+        assert_eq!(
+            SwhidObject::parse("not-a-swhid").unwrap_err(),
+            SwhidParseError::BadShape
+        );
+        assert_eq!(
+            SwhidObject::parse("swh:2:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2").unwrap_err(),
+            SwhidParseError::BadPrefix
+        );
+        assert_eq!(
+            SwhidObject::parse("swh:1:foo:94a9ed024d3859793618152ea559a168bbcbb5e2").unwrap_err(),
+            SwhidParseError::BadKind
+        );
+        assert_eq!(
+            SwhidObject::parse("swh:1:cnt:not-hex").unwrap_err(),
+            SwhidParseError::BadHash
+        );
+        assert_eq!(
+            SwhidObject::parse("swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2;malformed",)
+                .unwrap_err(),
+            SwhidParseError::BadQualifier
+        );
+    }
+
+    #[test]
+    fn swhid_object_serializes_within_component_identifiers_as_array_of_strings() {
+        let mut ids = ComponentIdentifiers::new("synthetic-1".to_string());
+        ids.swhid.push(
+            SwhidObject::parse("swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2").unwrap(),
+        );
+        ids.swhid.push(
+            SwhidObject::parse("swh:1:dir:309cf2674ee7a0749978cf8265ab91a60aea0f7d").unwrap(),
+        );
+        let json = serde_json::to_value(&ids).unwrap();
+        let arr = json
+            .get("swhid")
+            .and_then(|v| v.as_array())
+            .expect("swhid serialises as array");
+        assert_eq!(arr.len(), 2);
+        assert!(arr.iter().all(serde_json::Value::is_string));
+        // Round-trip via deserialize keeps structure intact
+        let parsed: ComponentIdentifiers = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.swhid.len(), 2);
+        assert_eq!(parsed.swhid[0].kind, SwhidKind::Cnt);
+        assert_eq!(parsed.swhid[1].kind, SwhidKind::Dir);
     }
 }

--- a/src/model/sbom.rs
+++ b/src/model/sbom.rs
@@ -48,6 +48,40 @@ impl NormalizedSbom {
         }
     }
 
+    /// Return the canonical IDs of *direct* dependencies (1 hop from the
+    /// primary component along the dependency graph).
+    ///
+    /// When no `primary_component_id` is set, all components reachable from
+    /// any node with no incoming edges are treated as direct (best-effort
+    /// approximation for SBOMs that don't declare a root).
+    ///
+    /// Used by CRA prEN 40000-1-3 `[PRE-7-RQ-03]` enforcement, which makes
+    /// direct dependencies *mandatory* and transitive *recommended*.
+    #[must_use]
+    pub fn direct_dependency_ids(&self) -> std::collections::HashSet<CanonicalId> {
+        use std::collections::HashSet;
+        if let Some(root) = &self.primary_component_id {
+            return self
+                .edges
+                .iter()
+                .filter(|e| &e.from == root)
+                .map(|e| e.to.clone())
+                .collect();
+        }
+        // Fallback: find roots = nodes with no incoming edges, then take their direct children.
+        let incoming: HashSet<&CanonicalId> = self.edges.iter().map(|e| &e.to).collect();
+        let roots: HashSet<&CanonicalId> = self
+            .components
+            .keys()
+            .filter(|id| !incoming.contains(id))
+            .collect();
+        self.edges
+            .iter()
+            .filter(|e| roots.contains(&e.from))
+            .map(|e| e.to.clone())
+            .collect()
+    }
+
     /// Add a component to the SBOM.
     ///
     /// Returns `true` if a collision occurred (a component with the same canonical ID
@@ -684,6 +718,34 @@ impl Component {
     pub fn with_version(mut self, version: String) -> Self {
         self.semver = semver::Version::parse(&version).ok();
         self.version = Some(version);
+        self
+    }
+
+    /// Add a Software Heritage persistent identifier (SWHID) from a string.
+    ///
+    /// Invalid SWHIDs are silently dropped (matches the parser-tolerant
+    /// behaviour of `CanonicalId::from_swhid`). Use `with_swhid_object` when
+    /// you already have a `SwhidObject` in hand.
+    ///
+    /// Recognised by CRA prEN 40000-1-3 `[PRE-7-RQ-07]` as one of the three
+    /// named identifier types (alongside PURL and CPE). Multiple SWHIDs can
+    /// be attached to a single component (e.g., a `dir` SWHID for the
+    /// unpacked tree plus `cnt` SWHIDs for individual files).
+    #[must_use]
+    pub fn with_swhid(mut self, swhid: String) -> Self {
+        if let Ok(obj) = crate::model::SwhidObject::parse(&swhid) {
+            self.identifiers.swhid.push(obj);
+            // Recompute canonical ID — SWHID may now be the best fallback
+            self.canonical_id = self.identifiers.canonical_id();
+        }
+        self
+    }
+
+    /// Add a structured `SwhidObject` SWHID.
+    #[must_use]
+    pub fn with_swhid_object(mut self, swhid: crate::model::SwhidObject) -> Self {
+        self.identifiers.swhid.push(swhid);
+        self.canonical_id = self.identifiers.canonical_id();
         self
     }
 

--- a/src/parsers/cyclonedx.rs
+++ b/src/parsers/cyclonedx.rs
@@ -377,6 +377,11 @@ impl CycloneDxParser {
             comp.identifiers.cpe.push(cpe.clone());
         }
 
+        // Set SWHIDs (CycloneDX 1.6+, CRA [PRE-7-RQ-07])
+        for swhid in &cdx.swhid {
+            comp = comp.with_swhid(swhid.clone());
+        }
+
         // Set licenses
         if let Some(licenses) = &cdx.licenses {
             for lic in licenses {
@@ -1317,6 +1322,10 @@ struct CdxComponent {
     scope: Option<String>,
     purl: Option<String>,
     cpe: Option<String>,
+    /// Software Heritage persistent identifiers (1.6+).
+    /// CRA prEN 40000-1-3 `[PRE-7-RQ-07]` names SWHID alongside PURL/CPE.
+    #[serde(default)]
+    swhid: Vec<String>,
     description: Option<String>,
     author: Option<String>,
     copyright: Option<String>,

--- a/src/parsers/spdx.rs
+++ b/src/parsers/spdx.rs
@@ -944,6 +944,14 @@ impl SpdxParser {
         // Set external references
         if let Some(ext_refs) = &pkg.external_refs {
             for ext_ref in ext_refs {
+                // Promote PERSISTENT-ID/swh refs to first-class SWHID identifiers
+                // (CRA prEN 40000-1-3 [PRE-7-RQ-07] recognises SWHIDs)
+                if ext_ref.reference_category == "PERSISTENT-ID"
+                    && ext_ref.reference_type.eq_ignore_ascii_case("swh")
+                {
+                    comp = comp.with_swhid(ext_ref.reference_locator.clone());
+                    continue;
+                }
                 let ref_type = match ext_ref.reference_category.as_str() {
                     "SECURITY" => ExternalRefType::Advisories,
                     "PACKAGE-MANAGER" => ExternalRefType::Website,

--- a/src/parsers/spdx3.rs
+++ b/src/parsers/spdx3.rs
@@ -414,6 +414,11 @@ impl Spdx3Parser {
                     Some("swid") => {
                         comp.identifiers.swid = Some(ext_id.identifier.clone());
                     }
+                    // SPDX 3.0 names this externalIdentifierType "swhid"
+                    // (CRA prEN 40000-1-3 [PRE-7-RQ-07])
+                    Some("swhid") => {
+                        comp = comp.with_swhid(ext_id.identifier.clone());
+                    }
                     Some("packageUrl") if comp.identifiers.purl.is_none() => {
                         comp = comp.with_purl(ext_id.identifier.clone());
                     }

--- a/src/quality/compliance.rs
+++ b/src/quality/compliance.rs
@@ -56,6 +56,9 @@ pub enum ComplianceLevel {
     Cnsa2,
     /// NIST PQC Readiness — Post-Quantum Cryptography migration (IR 8547 + FIPS 203/204/205)
     NistPqc,
+    /// BSI TR-03183-2 (German national CRA-aligned SBOM technical guideline).
+    /// Free, ENISA-cited; stricter than NTIA on hashes and identifiers.
+    BsiTr03183_2,
     /// Comprehensive compliance (all recommended fields)
     Comprehensive,
 }
@@ -75,6 +78,7 @@ impl ComplianceLevel {
             Self::Eo14028 => "EO 14028 Section 4",
             Self::Cnsa2 => "CNSA 2.0",
             Self::NistPqc => "NIST PQC Readiness",
+            Self::BsiTr03183_2 => "BSI TR-03183-2",
             Self::Comprehensive => "Comprehensive",
         }
     }
@@ -93,6 +97,7 @@ impl ComplianceLevel {
             Self::Eo14028 => "EO14028",
             Self::Cnsa2 => "CNSA2",
             Self::NistPqc => "PQC",
+            Self::BsiTr03183_2 => "BSI",
             Self::Comprehensive => "Full",
         }
     }
@@ -123,6 +128,9 @@ impl ComplianceLevel {
             Self::NistPqc => {
                 "NIST PQC — quantum-vulnerable algorithm detection, FIPS 203/204/205, SP 800-131A"
             }
+            Self::BsiTr03183_2 => {
+                "BSI TR-03183-2 — German national SBOM guideline (free, ENISA-cited): mandatory hashes, identifiers, ISO-8601 timestamps"
+            }
             Self::Comprehensive => "All recommended fields and best practices",
         }
     }
@@ -141,6 +149,7 @@ impl ComplianceLevel {
             Self::Eo14028,
             Self::Cnsa2,
             Self::NistPqc,
+            Self::BsiTr03183_2,
             Self::Comprehensive,
         ]
     }
@@ -162,6 +171,97 @@ impl ComplianceLevel {
     }
 }
 
+/// Identifies the source standard a `StandardRef` points at.
+///
+/// The CRA harmonised-standard ecosystem references multiple parallel
+/// hierarchies (the regulation itself, the prEN 40000-1-3 horizontal
+/// standard, BSI TR-03183 national guidance) and a violation typically
+/// maps to several at once. Notified bodies will read prEN IDs; auditors
+/// quote regulation articles; engineers prefer BSI sections.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[non_exhaustive]
+pub enum StandardKind {
+    /// EU CRA regulation article (e.g., "Art. 13(4)")
+    CraArticle,
+    /// EU CRA regulation annex (e.g., "Annex I Part II 1")
+    CraAnnex,
+    /// prEN 40000-1-3 normative requirement ID (e.g., "PRE-7-RQ-07")
+    Pren40000_1_3,
+    /// BSI TR-03183-2 section reference
+    BsiTr03183_2,
+    /// NIST SP 800-218 SSDF practice
+    NistSsdf,
+    /// US Executive Order 14028 Section 4
+    Eo14028,
+    /// FDA premarket cybersecurity guidance
+    FdaPremarket,
+    /// NTIA Minimum Elements for an SBOM
+    NtiaMinimum,
+    /// CSAF v2.0 / ISO/IEC 20153:2025 advisory format
+    Csaf2,
+    /// CNSA 2.0 (NSA Commercial National Security Algorithm Suite)
+    Cnsa2,
+    /// NIST Post-Quantum Cryptography (FIPS 203/204/205, SP 800-131A)
+    NistPqc,
+    /// Other / unrecognised standard
+    Other,
+}
+
+impl StandardKind {
+    /// Short label for compact display (≤16 chars).
+    #[must_use]
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::CraArticle => "CRA Article",
+            Self::CraAnnex => "CRA Annex",
+            Self::Pren40000_1_3 => "prEN 40000-1-3",
+            Self::BsiTr03183_2 => "BSI TR-03183-2",
+            Self::NistSsdf => "NIST SSDF",
+            Self::Eo14028 => "EO 14028",
+            Self::FdaPremarket => "FDA",
+            Self::NtiaMinimum => "NTIA",
+            Self::Csaf2 => "CSAF v2.0",
+            Self::Cnsa2 => "CNSA 2.0",
+            Self::NistPqc => "NIST PQC",
+            Self::Other => "Other",
+        }
+    }
+}
+
+/// A reference to a specific clause/requirement in a published standard.
+///
+/// Surfaced in JSON, SARIF, Markdown, and HTML output so that downstream
+/// tooling (notified-body checklists, GRC platforms, internal dashboards)
+/// can map a violation directly to the standards landscape without parsing
+/// the human-readable `requirement` string.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct StandardRef {
+    /// Which standard this reference points at
+    pub standard: StandardKind,
+    /// The clause/requirement ID within that standard (e.g., "PRE-7-RQ-07")
+    pub id: String,
+    /// Optional canonical URL anchor for the clause
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub help_uri: Option<String>,
+}
+
+impl StandardRef {
+    #[must_use]
+    pub fn new(standard: StandardKind, id: impl Into<String>) -> Self {
+        Self {
+            standard,
+            id: id.into(),
+            help_uri: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_uri(mut self, uri: impl Into<String>) -> Self {
+        self.help_uri = Some(uri.into());
+        self
+    }
+}
+
 /// A compliance violation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Violation {
@@ -175,9 +275,198 @@ pub struct Violation {
     pub element: Option<String>,
     /// Standard/requirement being violated
     pub requirement: String,
+    /// Structured references to harmonised-standard / regulation clauses.
+    ///
+    /// Populated by `ComplianceChecker::check()` from `requirement` via
+    /// `Violation::derive_standard_refs()`. Empty when a violation cannot be
+    /// mapped (e.g., custom rules from external configuration).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub standard_refs: Vec<StandardRef>,
 }
 
 impl Violation {
+    /// Derive structured standard references from the violation's
+    /// `requirement` string.
+    ///
+    /// Maps each violation to the canonical IDs in the parallel CRA standards
+    /// hierarchies — CRA regulation articles/annexes, prEN 40000-1-3 normative
+    /// requirements, BSI TR-03183, and adjacent profiles (NIST SSDF, EO 14028,
+    /// FDA, NTIA). The output is deterministic and regenerated on each call,
+    /// so the canonical source of truth remains the `requirement` string.
+    ///
+    /// References are emitted in registration order — typically the most
+    /// specific harmonised-standard ID first, then the regulation reference.
+    ///
+    /// `ComplianceChecker::check()` invokes this once and stores the result
+    /// in `Violation::standard_refs`, so most consumers should read the field
+    /// directly rather than re-deriving.
+    #[must_use]
+    pub fn derive_standard_refs(&self) -> Vec<StandardRef> {
+        let req = self.requirement.to_lowercase();
+        let mut refs: Vec<StandardRef> = Vec::new();
+
+        // ---- CRA Articles -------------------------------------------------
+        let cra_articles: &[(&str, &str)] = &[
+            ("art. 13(2)", "Art. 13(2)"),
+            ("art. 13(3)", "Art. 13(3)"),
+            ("art. 13(4)", "Art. 13(4)"),
+            ("art. 13(5)", "Art. 13(5)"),
+            ("art. 13(6)", "Art. 13(6)"),
+            ("art. 13(7)", "Art. 13(7)"),
+            ("art. 13(8)", "Art. 13(8)"),
+            ("art. 13(9)", "Art. 13(9)"),
+            ("art. 13(11)", "Art. 13(11)"),
+            ("art. 13(12)", "Art. 13(12)"),
+            ("art. 13(15)", "Art. 13(15)"),
+            ("art. 14", "Art. 14"),
+        ];
+        for (needle, id) in cra_articles {
+            if req.contains(needle) {
+                refs.push(StandardRef::new(StandardKind::CraArticle, *id));
+            }
+        }
+
+        // ---- CRA Annexes --------------------------------------------------
+        if req.contains("annex i, part iii") || req.contains("annex i part iii") {
+            refs.push(StandardRef::new(StandardKind::CraAnnex, "Annex I Part III"));
+        }
+        if req.contains("annex i, part ii") || req.contains("annex i part ii") {
+            refs.push(StandardRef::new(StandardKind::CraAnnex, "Annex I Part II"));
+        }
+        if req.contains("annex i,") || req.contains("annex i:") || req.contains("annex i ") {
+            // Avoid double-pushing when more specific Part II/III already matched
+            let already = refs
+                .iter()
+                .any(|r| r.standard == StandardKind::CraAnnex && r.id.starts_with("Annex I"));
+            if !already {
+                refs.push(StandardRef::new(StandardKind::CraAnnex, "Annex I"));
+            }
+        }
+        if req.contains("annex iii") {
+            refs.push(StandardRef::new(StandardKind::CraAnnex, "Annex III"));
+        }
+        if req.contains("annex iv") {
+            refs.push(StandardRef::new(StandardKind::CraAnnex, "Annex IV"));
+        }
+        if req.contains("annex v") && !req.contains("annex vii") {
+            refs.push(StandardRef::new(StandardKind::CraAnnex, "Annex V"));
+        }
+        if req.contains("annex vii") {
+            refs.push(StandardRef::new(StandardKind::CraAnnex, "Annex VII"));
+        }
+        if req.contains("annex viii") {
+            refs.push(StandardRef::new(StandardKind::CraAnnex, "Annex VIII"));
+        }
+
+        // ---- prEN 40000-1-3 normative requirement IDs ---------------------
+        // First, harvest any IDs already mentioned literally in `requirement`.
+        for token in [
+            "PRE-7-RQ-01",
+            "PRE-7-RQ-03",
+            "PRE-7-RQ-04",
+            "PRE-7-RQ-06",
+            "PRE-7-RQ-07",
+            "PRE-7-RQ-07-RE",
+            "PRE-8-RQ-02",
+            "RLS-2-RQ-03-RE",
+        ] {
+            if self.requirement.contains(token) {
+                refs.push(StandardRef::new(StandardKind::Pren40000_1_3, token));
+            }
+        }
+
+        // Inferred mappings — only add if the literal ID was not already present.
+        // (Inline `iter().any()` checks rather than a closure to avoid borrow conflicts.)
+
+        // Art. 13(4) machine-readable format → [PRE-7-RQ-04]
+        if req.contains("art. 13(4)")
+            && req.contains("machine-readable")
+            && !refs.iter().any(|r| r.id == "PRE-7-RQ-04")
+        {
+            refs.push(StandardRef::new(StandardKind::Pren40000_1_3, "PRE-7-RQ-04"));
+        }
+        // Art. 13(7) coordinated disclosure → [RLS-2-RQ-03-RE]
+        if req.contains("art. 13(7)") && !refs.iter().any(|r| r.id == "RLS-2-RQ-03-RE") {
+            refs.push(StandardRef::new(
+                StandardKind::Pren40000_1_3,
+                "RLS-2-RQ-03-RE",
+            ));
+        }
+        // Annex I Part III supply chain → [PRE-7-RQ-01] + [PRE-7-RQ-03]
+        if req.contains("annex i, part iii") || req.contains("annex i part iii") {
+            if !refs.iter().any(|r| r.id == "PRE-7-RQ-01") {
+                refs.push(StandardRef::new(StandardKind::Pren40000_1_3, "PRE-7-RQ-01"));
+            }
+            if !refs.iter().any(|r| r.id == "PRE-7-RQ-03") {
+                refs.push(StandardRef::new(StandardKind::Pren40000_1_3, "PRE-7-RQ-03"));
+            }
+        }
+        // Annex I identifier traceability → [PRE-7-RQ-07]
+        if (req.contains("annex i") && req.contains("identifier"))
+            && !refs.iter().any(|r| r.id == "PRE-7-RQ-07")
+        {
+            refs.push(StandardRef::new(StandardKind::Pren40000_1_3, "PRE-7-RQ-07"));
+        }
+        // Component version (Art. 13(12)) → [PRE-7-RQ-06]
+        if req.contains("art. 13(12)")
+            && req.contains("version")
+            && !refs.iter().any(|r| r.id == "PRE-7-RQ-06")
+        {
+            refs.push(StandardRef::new(StandardKind::Pren40000_1_3, "PRE-7-RQ-06"));
+        }
+        // CSAF advisory format (Art. 13(7)/Annex I Part II 5)
+        if (req.contains("csaf") || req.contains("iso/iec 20153"))
+            && !refs.iter().any(|r| r.standard == StandardKind::Csaf2)
+        {
+            refs.push(StandardRef::new(StandardKind::Csaf2, "CSAF v2.0"));
+        }
+
+        // ---- Adjacent profiles --------------------------------------------
+        if req.contains("nist ssdf") || req.contains("sp 800-218") {
+            // Try to extract the practice ID (e.g., "PS.1", "PW.4", "RV.1")
+            for needle in [
+                "ps.1", "ps.2", "ps.3", "po.1", "po.3", "pw.4", "pw.6", "rv.1",
+            ] {
+                if req.contains(needle) {
+                    refs.push(StandardRef::new(
+                        StandardKind::NistSsdf,
+                        needle.to_uppercase(),
+                    ));
+                }
+            }
+            if !refs.iter().any(|r| r.standard == StandardKind::NistSsdf) {
+                refs.push(StandardRef::new(StandardKind::NistSsdf, "SP 800-218"));
+            }
+        }
+        if req.contains("eo 14028") || req.contains("executive order 14028") {
+            refs.push(StandardRef::new(StandardKind::Eo14028, "EO 14028 §4"));
+        }
+        if req.contains("fda") {
+            refs.push(StandardRef::new(
+                StandardKind::FdaPremarket,
+                "FDA Premarket",
+            ));
+        }
+        if req.contains("ntia") {
+            refs.push(StandardRef::new(
+                StandardKind::NtiaMinimum,
+                "NTIA Minimum Elements",
+            ));
+        }
+        if req.contains("cnsa") {
+            refs.push(StandardRef::new(StandardKind::Cnsa2, "CNSA 2.0"));
+        }
+        if req.contains("nist pqc")
+            || req.contains("fips 203")
+            || req.contains("fips 204")
+            || req.contains("fips 205")
+        {
+            refs.push(StandardRef::new(StandardKind::NistPqc, "NIST PQC"));
+        }
+
+        refs
+    }
+
     /// Return remediation guidance for this violation based on the requirement.
     #[must_use]
     pub fn remediation_guidance(&self) -> &'static str {
@@ -385,13 +674,33 @@ impl ComplianceResult {
 pub struct ComplianceChecker {
     /// Compliance level to check
     level: ComplianceLevel,
+    /// Optional CRA sidecar metadata that supplements the SBOM with
+    /// manufacturer / disclosure / lifecycle fields the SBOM itself doesn't
+    /// carry. When set, document-metadata checks consult the sidecar before
+    /// emitting "missing" violations.
+    sidecar: Option<crate::model::CraSidecarMetadata>,
 }
 
 impl ComplianceChecker {
     /// Create a new compliance checker
     #[must_use]
     pub const fn new(level: ComplianceLevel) -> Self {
-        Self { level }
+        Self {
+            level,
+            sidecar: None,
+        }
+    }
+
+    /// Attach CRA sidecar metadata to supplement SBOM-level fields.
+    ///
+    /// Sidecar values are only consulted as fallbacks — fields present in the
+    /// SBOM always take precedence. Used by `validate`, `quality`, and `view`
+    /// CLIs via the `--cra-sidecar` flag (with auto-discovery for adjacent
+    /// `<sbom>.cra.{json,yaml}` files).
+    #[must_use]
+    pub fn with_sidecar(mut self, sidecar: crate::model::CraSidecarMetadata) -> Self {
+        self.sidecar = Some(sidecar);
+        self
     }
 
     /// Check an SBOM for compliance
@@ -412,6 +721,9 @@ impl ComplianceChecker {
             ComplianceLevel::NistPqc => {
                 self.check_nist_pqc(sbom, &mut violations);
             }
+            ComplianceLevel::BsiTr03183_2 => {
+                self.check_bsi_tr_03183_2(sbom, &mut violations);
+            }
             _ => {
                 // Check document-level requirements
                 self.check_document_metadata(sbom, &mut violations);
@@ -431,7 +743,15 @@ impl ComplianceChecker {
                 // Check CRA-specific gap requirements (Art. 13(3), 13(5), 13(9), Annex I Part III, Annex III)
                 if self.level.is_cra() {
                     self.check_cra_gaps(sbom, &mut violations);
+                    self.check_hardware_components(sbom, &mut violations);
                 }
+            }
+        }
+
+        // Populate harmonised-standard references for every violation.
+        for v in &mut violations {
+            if v.standard_refs.is_empty() {
+                v.standard_refs = v.derive_standard_refs();
             }
         }
 
@@ -452,6 +772,7 @@ impl ComplianceChecker {
                 message: "SBOM must have creator/tool information".to_string(),
                 element: None,
                 requirement: "Document creator identification".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -462,16 +783,34 @@ impl ComplianceChecker {
                 .creators
                 .iter()
                 .any(|c| c.creator_type == CreatorType::Organization);
+            let sidecar_has_manufacturer = self
+                .sidecar
+                .as_ref()
+                .is_some_and(|s| s.manufacturer_name.is_some());
             if !has_org {
-                violations.push(Violation {
-                    severity: ViolationSeverity::Warning,
-                    category: ViolationCategory::DocumentMetadata,
-                    message:
-                        "[CRA Art. 13(15)] SBOM should identify the manufacturer (organization)"
-                            .to_string(),
-                    element: None,
-                    requirement: "CRA Art. 13(15): Manufacturer identification".to_string(),
-                });
+                if sidecar_has_manufacturer {
+                    violations.push(Violation {
+                        severity: ViolationSeverity::Info,
+                        category: ViolationCategory::DocumentMetadata,
+                        message:
+                            "[CRA Art. 13(15)] Manufacturer identified via CRA sidecar (consider adding to the SBOM directly for portability)"
+                                .to_string(),
+                        element: None,
+                        requirement: "CRA Art. 13(15): Manufacturer identification".to_string(),
+                        standard_refs: Vec::new(),
+                    });
+                } else {
+                    violations.push(Violation {
+                        severity: ViolationSeverity::Warning,
+                        category: ViolationCategory::DocumentMetadata,
+                        message:
+                            "[CRA Art. 13(15)] SBOM should identify the manufacturer (organization)"
+                                .to_string(),
+                        element: None,
+                        requirement: "CRA Art. 13(15): Manufacturer identification".to_string(),
+                        standard_refs: Vec::new(),
+                    });
+                }
             }
 
             // Validate manufacturer email format if present
@@ -488,18 +827,36 @@ impl ComplianceChecker {
                         ),
                         element: None,
                         requirement: "CRA Art. 13(15): Valid contact information".to_string(),
+                        standard_refs: Vec::new(),
                     });
                 }
             }
 
             if sbom.document.name.is_none() {
-                violations.push(Violation {
-                    severity: ViolationSeverity::Warning,
-                    category: ViolationCategory::DocumentMetadata,
-                    message: "[CRA Art. 13(12)] SBOM should include the product name".to_string(),
-                    element: None,
-                    requirement: "CRA Art. 13(12): Product identification".to_string(),
-                });
+                let sidecar_has_product_name = self
+                    .sidecar
+                    .as_ref()
+                    .is_some_and(|s| s.product_name.is_some());
+                if sidecar_has_product_name {
+                    violations.push(Violation {
+                        severity: ViolationSeverity::Info,
+                        category: ViolationCategory::DocumentMetadata,
+                        message: "[CRA Art. 13(12)] Product name provided via CRA sidecar (consider adding metadata.component.name to the SBOM)".to_string(),
+                        element: None,
+                        requirement: "CRA Art. 13(12): Product identification".to_string(),
+                        standard_refs: Vec::new(),
+                    });
+                } else {
+                    violations.push(Violation {
+                        severity: ViolationSeverity::Warning,
+                        category: ViolationCategory::DocumentMetadata,
+                        message: "[CRA Art. 13(12)] SBOM should include the product name"
+                            .to_string(),
+                        element: None,
+                        requirement: "CRA Art. 13(12): Product identification".to_string(),
+                        standard_refs: Vec::new(),
+                    });
+                }
             }
 
             // CRA: Security contact / vulnerability disclosure point
@@ -520,13 +877,28 @@ impl ComplianceChecker {
             });
 
             if !has_doc_security_contact && !has_component_security_contact {
-                violations.push(Violation {
-                    severity: ViolationSeverity::Warning,
-                    category: ViolationCategory::SecurityInfo,
-                    message: "[CRA Art. 13(6)] SBOM should include a security contact or vulnerability disclosure reference".to_string(),
-                    element: None,
-                    requirement: "CRA Art. 13(6): Vulnerability disclosure contact".to_string(),
+                let sidecar_has_security = self.sidecar.as_ref().is_some_and(|s| {
+                    s.security_contact.is_some() || s.vulnerability_disclosure_url.is_some()
                 });
+                if sidecar_has_security {
+                    violations.push(Violation {
+                        severity: ViolationSeverity::Info,
+                        category: ViolationCategory::SecurityInfo,
+                        message: "[CRA Art. 13(6)] Security contact provided via CRA sidecar (consider adding a security-contact externalReference to the SBOM)".to_string(),
+                        element: None,
+                        requirement: "CRA Art. 13(6): Vulnerability disclosure contact".to_string(),
+                        standard_refs: Vec::new(),
+                    });
+                } else {
+                    violations.push(Violation {
+                        severity: ViolationSeverity::Warning,
+                        category: ViolationCategory::SecurityInfo,
+                        message: "[CRA Art. 13(6)] SBOM should include a security contact or vulnerability disclosure reference".to_string(),
+                        element: None,
+                        requirement: "CRA Art. 13(6): Vulnerability disclosure contact".to_string(),
+                        standard_refs: Vec::new(),
+                    });
+                }
             }
 
             // CRA: Check for primary/root product component identification
@@ -537,6 +909,7 @@ impl ComplianceChecker {
                     message: "[CRA Annex I] SBOM should identify the primary product component (CycloneDX metadata.component or SPDX documentDescribes)".to_string(),
                     element: None,
                     requirement: "CRA Annex I: Primary product identification".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
 
@@ -548,6 +921,7 @@ impl ComplianceChecker {
                     message: "[CRA Art. 13(8)] Consider specifying a support end date for security updates".to_string(),
                     element: None,
                     requirement: "CRA Art. 13(8): Support period disclosure".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
 
@@ -577,6 +951,7 @@ impl ComplianceChecker {
                     ),
                     element: None,
                     requirement: "CRA Art. 13(4): Machine-readable SBOM format".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
 
@@ -597,6 +972,7 @@ impl ComplianceChecker {
                             ),
                             element: Some(primary.name.clone()),
                             requirement: "CRA Annex I, Part II, 1: Product identifier traceability across updates".to_string(),
+                            standard_refs: Vec::new(),
                         });
             }
         }
@@ -612,13 +988,29 @@ impl ComplianceChecker {
                         .any(|r| matches!(r.ref_type, ExternalRefType::Advisories))
                 });
             if !has_vuln_disclosure_policy {
-                violations.push(Violation {
-                    severity: ViolationSeverity::Warning,
-                    category: ViolationCategory::SecurityInfo,
-                    message: "[CRA Art. 13(7)] SBOM should reference a coordinated vulnerability disclosure policy (advisories URL or disclosure URL)".to_string(),
-                    element: None,
-                    requirement: "CRA Art. 13(7): Coordinated vulnerability disclosure policy".to_string(),
-                });
+                let sidecar_has_cvd = self
+                    .sidecar
+                    .as_ref()
+                    .is_some_and(|s| s.vulnerability_disclosure_url.is_some());
+                if sidecar_has_cvd {
+                    violations.push(Violation {
+                        severity: ViolationSeverity::Info,
+                        category: ViolationCategory::SecurityInfo,
+                        message: "[CRA Art. 13(7)] CVD policy URL provided via CRA sidecar (consider adding an advisories externalReference to the SBOM)".to_string(),
+                        element: None,
+                        requirement: "CRA Art. 13(7): Coordinated vulnerability disclosure policy".to_string(),
+                        standard_refs: Vec::new(),
+                    });
+                } else {
+                    violations.push(Violation {
+                        severity: ViolationSeverity::Warning,
+                        category: ViolationCategory::SecurityInfo,
+                        message: "[CRA Art. 13(7)] SBOM should reference a coordinated vulnerability disclosure policy (advisories URL or disclosure URL)".to_string(),
+                        element: None,
+                        requirement: "CRA Art. 13(7): Coordinated vulnerability disclosure policy".to_string(),
+                        standard_refs: Vec::new(),
+                    });
+                }
             }
 
             // CRA Art. 13(11): Component lifecycle status
@@ -642,6 +1034,7 @@ impl ComplianceChecker {
                     message: "[CRA Art. 13(11)] Consider including component lifecycle/end-of-support information".to_string(),
                     element: None,
                     requirement: "CRA Art. 13(11): Component lifecycle status".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
 
@@ -656,13 +1049,18 @@ impl ComplianceChecker {
                     )
                 })
             });
-            if !has_conformity_ref {
+            let sidecar_has_doc_ref = self
+                .sidecar
+                .as_ref()
+                .is_some_and(|s| s.ce_marking_reference.is_some());
+            if !has_conformity_ref && !sidecar_has_doc_ref {
                 violations.push(Violation {
                     severity: ViolationSeverity::Info,
                     category: ViolationCategory::DocumentMetadata,
                     message: "[CRA Annex VII] Consider including a reference to the EU Declaration of Conformity (attestation or certification external reference)".to_string(),
                     element: None,
                     requirement: "CRA Annex VII: EU Declaration of Conformity reference".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
         }
@@ -682,6 +1080,7 @@ impl ComplianceChecker {
                         .to_string(),
                     element: None,
                     requirement: "FDA: Manufacturer identification".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
 
@@ -694,6 +1093,7 @@ impl ComplianceChecker {
                     message: "FDA: SBOM creators should include contact email".to_string(),
                     element: None,
                     requirement: "FDA: Contact information".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
 
@@ -705,6 +1105,7 @@ impl ComplianceChecker {
                     message: "FDA: SBOM should have a document name/title".to_string(),
                     element: None,
                     requirement: "FDA: Document identification".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
         }
@@ -734,6 +1135,7 @@ impl ComplianceChecker {
                 message: "SBOM should have a serial number/unique identifier".to_string(),
                 element: None,
                 requirement: "Document unique identification".to_string(),
+                standard_refs: Vec::new(),
             });
         }
     }
@@ -751,6 +1153,7 @@ impl ComplianceChecker {
                     message: "Component must have a name".to_string(),
                     element: Some(comp.identifiers.format_id.clone()),
                     requirement: "Component name (required)".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
 
@@ -788,10 +1191,12 @@ impl ComplianceChecker {
                     message: msg,
                     element: Some(comp.name.clone()),
                     requirement: req,
+                    standard_refs: Vec::new(),
                 });
             }
 
-            // Standard+ & FDA: should have PURL or CPE
+            // Standard+ & FDA: should have PURL/CPE/SWHID/SWID
+            // CRA prEN 40000-1-3 [PRE-7-RQ-07] explicitly names PURL, CPE, SWHID
             if matches!(
                 self.level,
                 ComplianceLevel::Standard
@@ -799,9 +1204,7 @@ impl ComplianceChecker {
                     | ComplianceLevel::CraPhase1
                     | ComplianceLevel::CraPhase2
                     | ComplianceLevel::Comprehensive
-            ) && comp.identifiers.purl.is_none()
-                && comp.identifiers.cpe.is_empty()
-                && comp.identifiers.swid.is_none()
+            ) && !comp.identifiers.has_cra_identifier()
             {
                 let severity = if matches!(
                     self.level,
@@ -816,24 +1219,24 @@ impl ComplianceChecker {
                 let (message, requirement) = match self.level {
                     ComplianceLevel::FdaMedicalDevice => (
                         format!(
-                            "Component '{}' missing unique identifier (PURL/CPE/SWID)",
+                            "Component '{}' missing unique identifier (PURL/CPE/SWHID/SWID)",
                             comp.name
                         ),
                         "FDA: Unique component identifier".to_string(),
                     ),
                     ComplianceLevel::CraPhase1 | ComplianceLevel::CraPhase2 => (
                         format!(
-                            "[CRA Annex I] Component '{}' missing unique identifier (PURL/CPE/SWID)",
+                            "[CRA Annex I, [PRE-7-RQ-07]] Component '{}' missing unique identifier (PURL/CPE/SWHID/SWID)",
                             comp.name
                         ),
-                        "CRA Annex I: Unique component identifier (PURL/CPE/SWID)".to_string(),
+                        "CRA Annex I / prEN 40000-1-3 [PRE-7-RQ-07]: Unique component identifier (PURL/CPE/SWHID/SWID)".to_string(),
                     ),
                     _ => (
                         format!(
-                            "Component '{}' missing unique identifier (PURL/CPE/SWID)",
+                            "Component '{}' missing unique identifier (PURL/CPE/SWHID/SWID)",
                             comp.name
                         ),
-                        "Standard identifier (PURL/CPE)".to_string(),
+                        "Standard identifier (PURL/CPE/SWHID)".to_string(),
                     ),
                 };
                 violations.push(Violation {
@@ -842,6 +1245,7 @@ impl ComplianceChecker {
                     message,
                     element: Some(comp.name.clone()),
                     requirement,
+                    standard_refs: Vec::new(),
                 });
             }
 
@@ -885,6 +1289,7 @@ impl ComplianceChecker {
                     message,
                     element: Some(comp.name.clone()),
                     requirement,
+                    standard_refs: Vec::new(),
                 });
             }
 
@@ -901,6 +1306,7 @@ impl ComplianceChecker {
                     message: format!("Component '{}' should have license information", comp.name),
                     element: Some(comp.name.clone()),
                     requirement: "License declaration".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
 
@@ -924,6 +1330,7 @@ impl ComplianceChecker {
                         } else {
                             "Integrity verification (hashes)".to_string()
                         },
+                        standard_refs: Vec::new(),
                     });
                 } else if self.level == ComplianceLevel::FdaMedicalDevice {
                     // FDA: Check for strong hash algorithm (SHA-256 or better)
@@ -955,6 +1362,7 @@ impl ComplianceChecker {
                             element: Some(comp.name.clone()),
                             requirement: "FDA: Strong cryptographic hash (SHA-256 or better)"
                                 .to_string(),
+                            standard_refs: Vec::new(),
                         });
                     }
                 }
@@ -971,6 +1379,7 @@ impl ComplianceChecker {
                     ),
                     element: Some(comp.name.clone()),
                     requirement: "CRA Annex I: Component integrity information (hash)".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
         }
@@ -1006,6 +1415,7 @@ impl ComplianceChecker {
                     message,
                     element: None,
                     requirement,
+                    standard_refs: Vec::new(),
                 });
             }
         }
@@ -1025,6 +1435,7 @@ impl ComplianceChecker {
                     message: "[CRA Annex I] SBOM appears to have multiple root components; identify a primary product component for top-level dependencies".to_string(),
                     element: None,
                     requirement: "CRA Annex I: Top-level dependency clarity".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
         }
@@ -1046,6 +1457,7 @@ impl ComplianceChecker {
                     ),
                     element: Some(comp.name.clone()),
                     requirement: "CRA Art. 13(6): Vulnerability metadata completeness".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
 
@@ -1062,6 +1474,7 @@ impl ComplianceChecker {
                         ),
                         element: Some(comp.name.clone()),
                         requirement: "CRA Art. 13(6): Remediation detail".to_string(),
+                        standard_refs: Vec::new(),
                     });
             }
         }
@@ -1080,6 +1493,7 @@ impl ComplianceChecker {
                 ),
                 element: None,
                 requirement: "CRA Art. 13(3): SBOM update frequency".to_string(),
+                standard_refs: Vec::new(),
             });
         } else if age_days > 30 {
             violations.push(Violation {
@@ -1090,6 +1504,7 @@ impl ComplianceChecker {
                 ),
                 element: None,
                 requirement: "CRA Art. 13(3): SBOM update frequency".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1115,6 +1530,7 @@ impl ComplianceChecker {
                 ),
                 element: None,
                 requirement: "CRA Art. 13(5): Licensed component tracking".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1143,29 +1559,112 @@ impl ComplianceChecker {
                         .to_string(),
                 element: None,
                 requirement: "CRA Art. 13(9): Known vulnerabilities statement".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
-        // B4: Annex I Part III — Supply chain transparency
-        // Transitive dependencies should have supplier information for supply chain visibility
+        // B4: Annex I Part III — Supply-chain transparency.
+        //
+        // prEN 40000-1-3 [PRE-7-RQ-03] makes direct dependencies *mandatory*
+        // and transitive dependencies *recommended*. We split the cohort
+        // accordingly:
+        // - direct (1 hop from the primary component) missing supplier:
+        //   Error under CraPhase2, Warning otherwise.
+        // - transitive missing supplier: Warning under CraPhase2 if >30%,
+        //   Info otherwise.
         if !sbom.edges.is_empty() {
-            let transitive_without_supplier = sbom
-                .components
-                .values()
-                .filter(|c| c.supplier.is_none() && c.author.is_none())
-                .count();
-            if transitive_without_supplier > 0 {
-                let pct = (transitive_without_supplier * 100) / total.max(1);
-                if pct > 30 {
+            let direct_ids = sbom.direct_dependency_ids();
+            let mut direct_missing: Vec<String> = Vec::new();
+            let mut transitive_missing: Vec<String> = Vec::new();
+            for comp in sbom.components.values() {
+                if comp.supplier.is_some() || comp.author.is_some() {
+                    continue;
+                }
+                if direct_ids.contains(&comp.canonical_id) {
+                    direct_missing.push(comp.name.clone());
+                } else {
+                    transitive_missing.push(comp.name.clone());
+                }
+            }
+
+            if !direct_missing.is_empty() {
+                let severity = if matches!(self.level, ComplianceLevel::CraPhase2) {
+                    ViolationSeverity::Error
+                } else {
+                    ViolationSeverity::Warning
+                };
+                let n = direct_missing.len();
+                violations.push(Violation {
+                    severity,
+                    category: ViolationCategory::SupplierInfo,
+                    message: format!(
+                        "[CRA Annex I, Part III / [PRE-7-RQ-03]] {n} direct dependencies missing supplier (mandatory): {}",
+                        truncate_list(&direct_missing, 5)
+                    ),
+                    element: None,
+                    requirement: "CRA Annex I, Part III / prEN 40000-1-3 [PRE-7-RQ-03]: Direct dependency supplier (mandatory)"
+                        .to_string(),
+                    standard_refs: Vec::new(),
+                });
+            }
+
+            let transitive_n = transitive_missing.len();
+            if transitive_n > 0 {
+                let denom = total.max(1);
+                let pct = (transitive_n * 100) / denom;
+                let severity = if matches!(self.level, ComplianceLevel::CraPhase2) && pct > 30 {
+                    ViolationSeverity::Warning
+                } else {
+                    ViolationSeverity::Info
+                };
+                violations.push(Violation {
+                    severity,
+                    category: ViolationCategory::SupplierInfo,
+                    message: format!(
+                        "[CRA Annex I, Part III / [PRE-7-RQ-03]] {transitive_n}/{denom} transitive dependencies ({pct}%) missing supplier (recommended): {}",
+                        truncate_list(&transitive_missing, 5)
+                    ),
+                    element: None,
+                    requirement: "CRA Annex I, Part III / prEN 40000-1-3 [PRE-7-RQ-03]: Transitive dependency supplier (recommended)"
+                        .to_string(),
+                    standard_refs: Vec::new(),
+                });
+            }
+        }
+
+        // B4b: prEN 40000-1-3 [PRE-7-RQ-07-RE] — vendor hash carry-through
+        // Vendor-supplied components (those with supplier/author and a non-synthetic
+        // identifier) must carry the upstream-supplied cryptographic hash through
+        // into the SBOM. Synthetic / format-specific IDs are excluded because they
+        // typically aren't tied to an upstream artefact at all.
+        {
+            let metrics = crate::quality::HashQualityMetrics::from_sbom(sbom);
+            if let Some(coverage) = metrics.vendor_hash_coverage() {
+                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                let pct = (coverage * 100.0).round() as usize;
+                let (severity, threshold_msg) = match self.level {
+                    ComplianceLevel::CraPhase2 if coverage < 0.50 => {
+                        (ViolationSeverity::Error, "below 50% threshold")
+                    }
+                    ComplianceLevel::CraPhase2 if coverage < 0.80 => {
+                        (ViolationSeverity::Warning, "below 80% threshold")
+                    }
+                    ComplianceLevel::CraPhase1 if coverage < 0.50 => {
+                        (ViolationSeverity::Warning, "below 50% threshold")
+                    }
+                    _ => (ViolationSeverity::Info, ""),
+                };
+                if !threshold_msg.is_empty() {
                     violations.push(Violation {
-                        severity: ViolationSeverity::Warning,
-                        category: ViolationCategory::SupplierInfo,
+                        severity,
+                        category: ViolationCategory::IntegrityInfo,
                         message: format!(
-                            "[CRA Annex I, Part III] {transitive_without_supplier}/{total} components ({pct}%) \
-                            missing supplier information for supply chain transparency"
+                            "[CRA Annex I, Part II / [PRE-7-RQ-07-RE]] Only {}/{} vendor-supplied components ({pct}%) carry an upstream hash — {threshold_msg}",
+                            metrics.vendor_components_with_hash, metrics.vendor_components_total
                         ),
                         element: None,
-                        requirement: "CRA Annex I, Part III: Supply chain transparency".to_string(),
+                        requirement: "CRA Annex I Part II / prEN 40000-1-3 [PRE-7-RQ-07-RE]: Vendor hash carry-through".to_string(),
+                        standard_refs: Vec::new(),
                     });
                 }
             }
@@ -1192,7 +1691,48 @@ impl ComplianceChecker {
                     .to_string(),
                 element: None,
                 requirement: "CRA Annex III: Document signature/integrity".to_string(),
+                standard_refs: Vec::new(),
             });
+        }
+
+        // B5b: Art. 13(2) — Documented risk-assessment reference
+        // The CRA requires manufacturers to perform and document a risk
+        // assessment. The SBOM (or sidecar) must reference it; absence is a
+        // soft Warning under CraPhase2 (Annex V technical-doc requirement).
+        if matches!(self.level, ComplianceLevel::CraPhase2) {
+            let has_ref_in_sbom = sbom.components.values().any(|comp| {
+                comp.external_refs
+                    .iter()
+                    .any(|r| matches!(r.ref_type, crate::model::ExternalRefType::RiskAssessment))
+            }) || sbom.document.creators.iter().any(|c| {
+                // Some SBOMs encode the methodology in the creator comment
+                c.name.to_lowercase().contains("risk assessment")
+            });
+            let sidecar_has_ref = self
+                .sidecar
+                .as_ref()
+                .is_some_and(|s| s.risk_assessment_url.is_some());
+            if !has_ref_in_sbom && !sidecar_has_ref {
+                violations.push(Violation {
+                    severity: ViolationSeverity::Warning,
+                    category: ViolationCategory::DocumentMetadata,
+                    message: "[CRA Art. 13(2)] No documented risk assessment referenced — add an externalReference of type 'risk-assessment' or supply riskAssessmentUrl in the CRA sidecar".to_string(),
+                    element: None,
+                    requirement: "CRA Art. 13(2): Documented risk assessment".to_string(),
+                    standard_refs: Vec::new(),
+                });
+            }
+        }
+
+        // B5c: Art. 14 reporting-readiness
+        // Manufacturers must operate channels to:
+        // - 24-hour early-warn ENISA / CSIRT for actively-exploited vulnerabilities (14(1))
+        // - 72-hour incident report (14(2))
+        // - Route through the ENISA single reporting platform (14(7))
+        // Obligations apply from 11 September 2026; before that, missing
+        // channels surface as Info ("prepare ahead"); after that, Warning.
+        if self.level.is_cra() {
+            self.check_article_14_readiness_at(chrono::Utc::now(), violations);
         }
 
         // B6: Art. 13(8) / Art. 13(11) — Component lifecycle / EOL detection
@@ -1215,6 +1755,7 @@ impl ComplianceChecker {
                 ),
                 element: None,
                 requirement: "CRA Art. 13(8): Support period / lifecycle management".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1236,6 +1777,7 @@ impl ComplianceChecker {
                 ),
                 element: None,
                 requirement: "CRA Art. 13(11): Component lifecycle monitoring".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1264,6 +1806,7 @@ impl ComplianceChecker {
                     element: None,
                     requirement: "CRA Art. 13(6): SPDX 3.0 Security profile conformance"
                         .to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
 
@@ -1291,7 +1834,213 @@ impl ComplianceChecker {
                     element: None,
                     requirement: "CRA Art. 13(5): SPDX 3.0 SimpleLicensing profile conformance"
                         .to_string(),
+                    standard_refs: Vec::new(),
                 });
+            }
+        }
+    }
+
+    /// CRA Article 14 reporting-readiness check.
+    ///
+    /// Verifies the manufacturer has documented channels for the obligations
+    /// that apply from 11 September 2026:
+    /// - 14(1) 24-hour early warning to ENISA/CSIRTs on actively-exploited vulns
+    /// - 14(2) 72-hour incident report
+    /// - 14(7) routing through the ENISA single reporting platform
+    ///
+    /// Pre-deadline: missing channels surface as Info (preparation guidance).
+    /// Post-deadline: missing channels become Warning. The CRA never demands
+    /// the channel reside *inside* the SBOM — most manufacturers will set
+    /// these via `CraSidecarMetadata`.
+    /// Internal entry point taking an explicit `now` so tests can pin it.
+    fn check_article_14_readiness_at(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+        violations: &mut Vec<Violation>,
+    ) {
+        // Article 14 reporting-obligation deadline.
+        // CRA enters into force 2024-12-10; reporting obligations apply
+        // 21 months later on 2026-09-11.
+        let deadline: chrono::DateTime<chrono::Utc> =
+            chrono::DateTime::parse_from_rfc3339("2026-09-11T00:00:00Z")
+                .expect("hard-coded deadline literal is RFC-3339")
+                .into();
+        let art_14_active = now >= deadline;
+        let post_deadline_severity = if art_14_active {
+            ViolationSeverity::Warning
+        } else {
+            ViolationSeverity::Info
+        };
+
+        let sidecar = self.sidecar.as_ref();
+
+        let psirt_present = sidecar.is_some_and(|s| s.psirt_url.is_some());
+        if !psirt_present {
+            let prefix = if art_14_active {
+                "[CRA Art. 14] PSIRT URL missing — required to handle external vulnerability reports"
+            } else {
+                "[CRA Art. 14] PSIRT URL missing — Article 14 obligations begin 2026-09-11; document the PSIRT channel ahead of the deadline"
+            };
+            violations.push(Violation {
+                severity: post_deadline_severity,
+                category: ViolationCategory::SecurityInfo,
+                message: prefix.to_string(),
+                element: None,
+                requirement: "CRA Art. 14: PSIRT contact for external vulnerability reports"
+                    .to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        let ew_present = sidecar.is_some_and(|s| s.early_warning_contact.is_some());
+        if !ew_present {
+            let msg = if art_14_active {
+                "[CRA Art. 14(1)] 24-hour early-warning channel missing — required when an actively-exploited vulnerability is identified"
+            } else {
+                "[CRA Art. 14(1)] 24-hour early-warning channel missing — document the ENISA/CSIRT contact before 2026-09-11"
+            };
+            violations.push(Violation {
+                severity: post_deadline_severity,
+                category: ViolationCategory::SecurityInfo,
+                message: msg.to_string(),
+                element: None,
+                requirement: "CRA Art. 14(1): 24-hour early-warning channel".to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        let ir_present = sidecar.is_some_and(|s| s.incident_report_contact.is_some());
+        if !ir_present {
+            let msg = if art_14_active {
+                "[CRA Art. 14(2)] 72-hour incident-report channel missing — required for severe incidents impacting product security"
+            } else {
+                "[CRA Art. 14(2)] 72-hour incident-report channel missing — document this contact before 2026-09-11"
+            };
+            violations.push(Violation {
+                severity: post_deadline_severity,
+                category: ViolationCategory::SecurityInfo,
+                message: msg.to_string(),
+                element: None,
+                requirement: "CRA Art. 14(2): 72-hour incident-report channel".to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // ENISA single reporting platform (Art. 14(7)) — the official URL is
+        // not yet published. We accept any sidecar identifier as a forward-
+        // compatible placeholder and only surface as Info regardless of date.
+        let enisa_present = sidecar.is_some_and(|s| s.enisa_reporting_platform_id.is_some());
+        if !enisa_present {
+            violations.push(Violation {
+                severity: ViolationSeverity::Info,
+                category: ViolationCategory::SecurityInfo,
+                message: "[CRA Art. 14(7)] No ENISA single reporting platform identifier — track ENISA publication and add `enisaReportingPlatformId` to the CRA sidecar when available"
+                    .to_string(),
+                element: None,
+                requirement: "CRA Art. 14(7): ENISA single reporting platform".to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+    }
+
+    /// Hardware-SBOM (HBOM) compliance check.
+    ///
+    /// Implements CRA prEN 40000-1-3 `[PRE-8-RQ-02]`: hardware components must
+    /// carry producer, component name, unique identifier, and firmware version
+    /// where applicable. Operates on components classified as
+    /// `Device`, `Firmware`, or `DeviceDriver`. The check is silent when the
+    /// SBOM contains no hardware components, so software-only SBOMs are
+    /// unaffected.
+    fn check_hardware_components(&self, sbom: &NormalizedSbom, violations: &mut Vec<Violation>) {
+        use crate::model::{ComponentType, IdSource};
+
+        let is_hardware_kind = |t: &ComponentType| {
+            matches!(
+                t,
+                ComponentType::Device | ComponentType::Firmware | ComponentType::DeviceDriver
+            )
+        };
+
+        let hardware_components: Vec<_> = sbom
+            .components
+            .values()
+            .filter(|c| is_hardware_kind(&c.component_type))
+            .collect();
+
+        if hardware_components.is_empty() {
+            return;
+        }
+
+        for comp in hardware_components {
+            // 1) Producer (supplier or author) must be set
+            if comp.supplier.is_none() && comp.author.is_none() {
+                violations.push(Violation {
+                    severity: ViolationSeverity::Error,
+                    category: ViolationCategory::SupplierInfo,
+                    message: format!(
+                        "[CRA prEN 40000-1-3 [PRE-8-RQ-02]] Hardware component '{}' missing producer (supplier or author)",
+                        comp.name
+                    ),
+                    element: Some(comp.name.clone()),
+                    requirement: "CRA prEN 40000-1-3 [PRE-8-RQ-02]: Hardware producer".to_string(),
+                    standard_refs: Vec::new(),
+                });
+            }
+
+            // 2) Identifier must be a real (non-synthetic / non-format-specific) one
+            if matches!(
+                comp.canonical_id.source(),
+                IdSource::Synthetic | IdSource::FormatSpecific
+            ) {
+                violations.push(Violation {
+                    severity: ViolationSeverity::Error,
+                    category: ViolationCategory::ComponentIdentification,
+                    message: format!(
+                        "[CRA prEN 40000-1-3 [PRE-8-RQ-02]] Hardware component '{}' missing unique identifier (PURL/CPE/SWHID/SWID)",
+                        comp.name
+                    ),
+                    element: Some(comp.name.clone()),
+                    requirement: "CRA prEN 40000-1-3 [PRE-8-RQ-02]: Hardware identifier".to_string(),
+                    standard_refs: Vec::new(),
+                });
+            }
+
+            // 3) Firmware components must carry a version (the firmware version itself).
+            if matches!(comp.component_type, ComponentType::Firmware) && comp.version.is_none() {
+                violations.push(Violation {
+                    severity: ViolationSeverity::Error,
+                    category: ViolationCategory::ComponentIdentification,
+                    message: format!(
+                        "[CRA prEN 40000-1-3 [PRE-8-RQ-02]] Firmware component '{}' missing firmware version",
+                        comp.name
+                    ),
+                    element: Some(comp.name.clone()),
+                    requirement: "CRA prEN 40000-1-3 [PRE-8-RQ-02]: Firmware version".to_string(),
+                    standard_refs: Vec::new(),
+                });
+            }
+
+            // 4) Devices: should declare a version, OR depend on a Firmware component.
+            if matches!(comp.component_type, ComponentType::Device) && comp.version.is_none() {
+                let has_firmware_dep = sbom.edges.iter().any(|e| {
+                    e.from == comp.canonical_id
+                        && sbom.components.get(&e.to).is_some_and(|child| {
+                            matches!(child.component_type, ComponentType::Firmware)
+                        })
+                });
+                if !has_firmware_dep {
+                    violations.push(Violation {
+                        severity: ViolationSeverity::Warning,
+                        category: ViolationCategory::ComponentIdentification,
+                        message: format!(
+                            "[CRA prEN 40000-1-3 [PRE-8-RQ-02]] Device component '{}' has no version and no associated firmware component",
+                            comp.name
+                        ),
+                        element: Some(comp.name.clone()),
+                        requirement: "CRA prEN 40000-1-3 [PRE-8-RQ-02]: Device firmware association".to_string(),
+                        standard_refs: Vec::new(),
+                    });
+                }
             }
         }
     }
@@ -1310,6 +2059,7 @@ impl ComplianceChecker {
                         .to_string(),
                 element: None,
                 requirement: "NIST SSDF PS.1: Provenance — creator identification".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1326,6 +2076,7 @@ impl ComplianceChecker {
                     .to_string(),
                 element: None,
                 requirement: "NIST SSDF PS.1: Provenance — tool identification".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1350,6 +2101,7 @@ impl ComplianceChecker {
                 ),
                 element: None,
                 requirement: "NIST SSDF PS.2: Build integrity — component hashes".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1367,6 +2119,7 @@ impl ComplianceChecker {
                     .to_string(),
                 element: None,
                 requirement: "NIST SSDF PO.1: Source code provenance — VCS references".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1387,6 +2140,7 @@ impl ComplianceChecker {
                     .to_string(),
                 element: None,
                 requirement: "NIST SSDF PO.3: Build provenance — build metadata".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1399,6 +2153,7 @@ impl ComplianceChecker {
                     .to_string(),
                 element: None,
                 requirement: "NIST SSDF PW.4: Dependency management — relationships".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1426,6 +2181,7 @@ impl ComplianceChecker {
                     .to_string(),
                 element: None,
                 requirement: "NIST SSDF PW.6: Vulnerability information".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1449,6 +2205,7 @@ impl ComplianceChecker {
                 element: None,
                 requirement: "NIST SSDF RV.1: Component identification — unique identifiers"
                     .to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1467,6 +2224,7 @@ impl ComplianceChecker {
                 ),
                 element: None,
                 requirement: "NIST SSDF PS.3: Supplier identification".to_string(),
+                standard_refs: Vec::new(),
             });
         }
     }
@@ -1500,6 +2258,7 @@ impl ComplianceChecker {
                 ),
                 element: None,
                 requirement: "EO 14028 Sec 4(e): Machine-readable SBOM format".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1517,6 +2276,7 @@ impl ComplianceChecker {
                     .to_string(),
                 element: None,
                 requirement: "EO 14028 Sec 4(e): Automated SBOM generation".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1528,6 +2288,7 @@ impl ComplianceChecker {
                 message: "SBOM must identify its creator (vendor or tool)".to_string(),
                 element: None,
                 requirement: "EO 14028 Sec 4(e): SBOM creator identification".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1551,6 +2312,7 @@ impl ComplianceChecker {
                 ),
                 element: None,
                 requirement: "EO 14028 Sec 4(e): Component unique identification".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1563,6 +2325,7 @@ impl ComplianceChecker {
                     .to_string(),
                 element: None,
                 requirement: "EO 14028 Sec 4(e): Dependency relationships".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1581,6 +2344,7 @@ impl ComplianceChecker {
                 ),
                 element: None,
                 requirement: "EO 14028 Sec 4(e): Component version".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1597,6 +2361,7 @@ impl ComplianceChecker {
                 message: format!("{without_hash}/{total} components missing cryptographic hashes"),
                 element: None,
                 requirement: "EO 14028 Sec 4(e): Component integrity verification".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1619,6 +2384,7 @@ impl ComplianceChecker {
                     .to_string(),
                 element: None,
                 requirement: "EO 14028 Sec 4(g): Vulnerability disclosure process".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1639,6 +2405,7 @@ impl ComplianceChecker {
                     ),
                     element: None,
                     requirement: "EO 14028 Sec 4(e): Supplier identification".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
         }
@@ -1667,6 +2434,7 @@ impl ComplianceChecker {
                 message: format!("CycloneDX {version} is outdated, consider upgrading to 1.7+"),
                 element: None,
                 requirement: "Current CycloneDX version".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1680,6 +2448,7 @@ impl ComplianceChecker {
                     message: format!("Component '{}' may be missing bom-ref", comp.name),
                     element: Some(comp.name.clone()),
                     requirement: "CycloneDX: bom-ref for dependency tracking".to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
         }
@@ -1697,6 +2466,7 @@ impl ComplianceChecker {
                 message: format!("Unknown SPDX version: {version}"),
                 element: None,
                 requirement: "Valid SPDX version".to_string(),
+                standard_refs: Vec::new(),
             });
         }
 
@@ -1725,6 +2495,7 @@ impl ComplianceChecker {
                     ),
                     element: Some(comp.name.clone()),
                     requirement: expected.to_string(),
+                    standard_refs: Vec::new(),
                 });
             }
         }
@@ -1771,6 +2542,7 @@ impl ComplianceChecker {
                                         ),
                                         element: Some(comp.name.clone()),
                                         requirement: "CNSA 2.0 PQC Migration".to_string(),
+                                        standard_refs: Vec::new(),
                                     });
                             } else if !is_symmetric_or_hash && ql < 5 {
                                 violations.push(Violation {
@@ -1782,6 +2554,7 @@ impl ComplianceChecker {
                                     ),
                                     element: Some(comp.name.clone()),
                                     requirement: "CNSA 2.0 Level 5".to_string(),
+                                    standard_refs: Vec::new(),
                                 });
                             }
                         }
@@ -1802,6 +2575,7 @@ impl ComplianceChecker {
                                     ),
                                     element: Some(comp.name.clone()),
                                     requirement: "CNSA 2.0 Symmetric".to_string(),
+                                    standard_refs: Vec::new(),
                                 });
                             }
 
@@ -1819,6 +2593,7 @@ impl ComplianceChecker {
                                     ),
                                     element: Some(comp.name.clone()),
                                     requirement: "CNSA 2.0 Hash".to_string(),
+                                    standard_refs: Vec::new(),
                                 });
                             }
 
@@ -1836,6 +2611,7 @@ impl ComplianceChecker {
                                     ),
                                     element: Some(comp.name.clone()),
                                     requirement: "CNSA 2.0 KEM".to_string(),
+                                    standard_refs: Vec::new(),
                                 });
                             }
 
@@ -1853,6 +2629,7 @@ impl ComplianceChecker {
                                     ),
                                     element: Some(comp.name.clone()),
                                     requirement: "CNSA 2.0 Signature".to_string(),
+                                    standard_refs: Vec::new(),
                                 });
                             }
 
@@ -1870,6 +2647,7 @@ impl ComplianceChecker {
                                     ),
                                     element: Some(comp.name.clone()),
                                     requirement: "CNSA 2.0 PQC Migration".to_string(),
+                                    standard_refs: Vec::new(),
                                 });
                             }
                         }
@@ -1901,12 +2679,194 @@ impl ComplianceChecker {
                                 ),
                                 element: Some(comp.name.clone()),
                                 requirement: "CNSA 2.0 Certificate".to_string(),
+                                standard_refs: Vec::new(),
                             });
                         }
                     }
                 }
                 _ => {}
             }
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
+    // BSI TR-03183-2 (German national SBOM guideline)
+    // ════════════════════════════════════════════════════════════════════
+
+    /// BSI TR-03183-2 compliance checks.
+    ///
+    /// TR-03183-2 is the German Federal Office for Information Security's
+    /// SBOM technical guideline, free and ENISA-cited. It is functionally
+    /// equivalent to the CRA Annex I Part II SBOM obligations but stricter
+    /// than NTIA Minimum on hashes and identifiers.
+    ///
+    /// Reference: BSI TR-03183-2 v2.0.0 §5 (mandatory) and §6 (recommended).
+    fn check_bsi_tr_03183_2(&self, sbom: &NormalizedSbom, violations: &mut Vec<Violation>) {
+        use crate::model::{CreatorType, HashAlgorithm};
+
+        // §5.1 — Author/creator identification (mandatory)
+        if sbom.document.creators.is_empty() {
+            violations.push(Violation {
+                severity: ViolationSeverity::Error,
+                category: ViolationCategory::DocumentMetadata,
+                message: "[BSI TR-03183-2 §5.1] SBOM author/creator missing".to_string(),
+                element: None,
+                requirement: "BSI TR-03183-2 §5.1: Author/creator identification".to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // §5.1 — At least one tool creator (mandatory)
+        let has_tool_creator = sbom
+            .document
+            .creators
+            .iter()
+            .any(|c| c.creator_type == CreatorType::Tool);
+        if !has_tool_creator {
+            violations.push(Violation {
+                severity: ViolationSeverity::Error,
+                category: ViolationCategory::DocumentMetadata,
+                message: "[BSI TR-03183-2 §5.1] SBOM must identify the generation tool".to_string(),
+                element: None,
+                requirement: "BSI TR-03183-2 §5.1: Tool identification".to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // §5.2 — ISO-8601 timestamp (mandatory).
+        // Our `DocumentMetadata::created` is `DateTime<Utc>`, always ISO-8601
+        // when serialised; the practical risk is the `created` field being
+        // unset in the source SBOM. NormalizedSbom default is Utc::now(), so
+        // we look for tell-tale unix-epoch / very-old fallback values.
+        let created = sbom.document.created;
+        if created.timestamp() <= 0 {
+            violations.push(Violation {
+                severity: ViolationSeverity::Error,
+                category: ViolationCategory::DocumentMetadata,
+                message: "[BSI TR-03183-2 §5.2] SBOM created timestamp missing or invalid"
+                    .to_string(),
+                element: None,
+                requirement: "BSI TR-03183-2 §5.2: ISO-8601 timestamp".to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // §5.3 — Component name (mandatory) — already enforced globally;
+        //         we add a BSI-specific message only if many components are
+        //         missing names (extreme case).
+
+        // §5.3 — Component identifier: PURL or other recognised ID (mandatory).
+        // Stricter than CRA: BSI requires a PURL where the ecosystem applies.
+        for comp in sbom.components.values() {
+            if !comp.identifiers.has_cra_identifier() {
+                violations.push(Violation {
+                    severity: ViolationSeverity::Error,
+                    category: ViolationCategory::ComponentIdentification,
+                    message: format!(
+                        "[BSI TR-03183-2 §5.3] Component '{}' missing unique identifier (PURL/CPE/SWHID/SWID)",
+                        comp.name
+                    ),
+                    element: Some(comp.name.clone()),
+                    requirement: "BSI TR-03183-2 §5.3: Component identifier".to_string(),
+                    standard_refs: Vec::new(),
+                });
+            }
+        }
+
+        // §5.4 — Cryptographic hash (SHA-256 or stronger) — mandatory.
+        let strong = |a: &HashAlgorithm| {
+            matches!(
+                a,
+                HashAlgorithm::Sha256
+                    | HashAlgorithm::Sha384
+                    | HashAlgorithm::Sha512
+                    | HashAlgorithm::Sha3_256
+                    | HashAlgorithm::Sha3_384
+                    | HashAlgorithm::Sha3_512
+                    | HashAlgorithm::Blake2b256
+                    | HashAlgorithm::Blake2b384
+                    | HashAlgorithm::Blake2b512
+                    | HashAlgorithm::Blake3
+            )
+        };
+        for comp in sbom.components.values() {
+            let has_strong_hash = comp.hashes.iter().any(|h| strong(&h.algorithm));
+            if !has_strong_hash {
+                violations.push(Violation {
+                    severity: ViolationSeverity::Error,
+                    category: ViolationCategory::IntegrityInfo,
+                    message: format!(
+                        "[BSI TR-03183-2 §5.4] Component '{}' missing SHA-256+ cryptographic hash",
+                        comp.name
+                    ),
+                    element: Some(comp.name.clone()),
+                    requirement: "BSI TR-03183-2 §5.4: Component cryptographic hash (SHA-256+)"
+                        .to_string(),
+                    standard_refs: Vec::new(),
+                });
+            }
+        }
+
+        // §5.5 — Dependencies (mandatory): explicit relationship graph required.
+        if sbom.edges.is_empty() && sbom.components.len() > 1 {
+            violations.push(Violation {
+                severity: ViolationSeverity::Error,
+                category: ViolationCategory::DependencyInfo,
+                message: "[BSI TR-03183-2 §5.5] SBOM declares multiple components but no dependency relationships"
+                    .to_string(),
+                element: None,
+                requirement: "BSI TR-03183-2 §5.5: Dependency relationships".to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // §6 — Recommended: license information per component
+        let total = sbom.components.len();
+        let without_license = sbom
+            .components
+            .values()
+            .filter(|c| c.licenses.declared.is_empty() && c.licenses.concluded.is_none())
+            .count();
+        if without_license > 0 {
+            let pct = (without_license * 100) / total.max(1);
+            violations.push(Violation {
+                severity: if pct > 50 {
+                    ViolationSeverity::Warning
+                } else {
+                    ViolationSeverity::Info
+                },
+                category: ViolationCategory::LicenseInfo,
+                message: format!(
+                    "[BSI TR-03183-2 §6] {without_license}/{total} components ({pct}%) missing license information"
+                ),
+                element: None,
+                requirement: "BSI TR-03183-2 §6: Component license (recommended)".to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // §6 — Recommended: supplier per component
+        let without_supplier = sbom
+            .components
+            .values()
+            .filter(|c| c.supplier.is_none() && c.author.is_none())
+            .count();
+        if without_supplier > 0 {
+            let pct = (without_supplier * 100) / total.max(1);
+            violations.push(Violation {
+                severity: if pct > 50 {
+                    ViolationSeverity::Warning
+                } else {
+                    ViolationSeverity::Info
+                },
+                category: ViolationCategory::SupplierInfo,
+                message: format!(
+                    "[BSI TR-03183-2 §6] {without_supplier}/{total} components ({pct}%) missing supplier information"
+                ),
+                element: None,
+                requirement: "BSI TR-03183-2 §6: Component supplier (recommended)".to_string(),
+                standard_refs: Vec::new(),
+            });
         }
     }
 
@@ -1945,6 +2905,7 @@ impl ComplianceChecker {
                         ),
                         element: Some(comp.name.clone()),
                         requirement: "IR 8547: quantum-vulnerable".to_string(),
+                        standard_refs: Vec::new(),
                     });
                 }
 
@@ -1956,6 +2917,7 @@ impl ComplianceChecker {
                         message: format!("'{}' missing nistQuantumSecurityLevel field", comp.name),
                         element: Some(comp.name.clone()),
                         requirement: "IR 8547: quantum assessment required".to_string(),
+                        standard_refs: Vec::new(),
                     });
                 }
 
@@ -1972,6 +2934,7 @@ impl ComplianceChecker {
                             ),
                             element: Some(comp.name.clone()),
                             requirement: "SP 800-131A: disallowed".to_string(),
+                            standard_refs: Vec::new(),
                         });
                     }
                 }
@@ -1987,6 +2950,7 @@ impl ComplianceChecker {
                         ),
                         element: Some(comp.name.clone()),
                         requirement: "SP 800-131A Rev 3: ECB disallowed".to_string(),
+                        standard_refs: Vec::new(),
                     });
                 }
 
@@ -2003,6 +2967,7 @@ impl ComplianceChecker {
                             ),
                             element: Some(comp.name.clone()),
                             requirement: "FIPS 203/204/205: approved".to_string(),
+                            standard_refs: Vec::new(),
                         });
                     }
                 }
@@ -2018,6 +2983,7 @@ impl ComplianceChecker {
                         ),
                         element: Some(comp.name.clone()),
                         requirement: "IR 8547: recommended transition".to_string(),
+                        standard_refs: Vec::new(),
                     });
                 }
             }
@@ -2042,6 +3008,7 @@ impl ComplianceChecker {
                         ),
                         element: Some(comp.name.clone()),
                         requirement: "NIST: minimum key size".to_string(),
+                        standard_refs: Vec::new(),
                     });
                 }
             }
@@ -2056,6 +3023,19 @@ impl Default for ComplianceChecker {
 }
 
 /// Simple email format validation (checks basic structure, not full RFC 5322)
+/// Render a slice of names as a comma-separated list, truncated with
+/// "…and N more" once `max` items are emitted. Keeps long-tail violation
+/// messages bounded for terminal/SARIF output.
+fn truncate_list(items: &[String], max: usize) -> String {
+    if items.len() <= max {
+        items.join(", ")
+    } else {
+        let head = items[..max].join(", ");
+        let rest = items.len() - max;
+        format!("{head}, …and {rest} more")
+    }
+}
+
 fn is_valid_email_format(email: &str) -> bool {
     // Basic checks: contains @, has local and domain parts, no spaces
     if email.contains(' ') || email.is_empty() {
@@ -2137,6 +3117,7 @@ mod tests {
                 message: "Error 1".to_string(),
                 element: None,
                 requirement: "Test".to_string(),
+                standard_refs: Vec::new(),
             },
             Violation {
                 severity: ViolationSeverity::Warning,
@@ -2144,6 +3125,7 @@ mod tests {
                 message: "Warning 1".to_string(),
                 element: None,
                 requirement: "Test".to_string(),
+                standard_refs: Vec::new(),
             },
             Violation {
                 severity: ViolationSeverity::Info,
@@ -2151,6 +3133,7 @@ mod tests {
                 message: "Info 1".to_string(),
                 element: None,
                 requirement: "Test".to_string(),
+                standard_refs: Vec::new(),
             },
         ];
 
@@ -2241,6 +3224,806 @@ mod tests {
                 .iter()
                 .any(|v| v.severity == ViolationSeverity::Info && v.message.contains("approved")),
             "PQC should report ML-DSA-65 as approved"
+        );
+    }
+
+    fn make_violation(req: &str) -> Violation {
+        Violation {
+            severity: ViolationSeverity::Warning,
+            category: ViolationCategory::DocumentMetadata,
+            message: req.to_string(),
+            element: None,
+            requirement: req.to_string(),
+            standard_refs: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn standard_refs_extracts_cra_article() {
+        let v = make_violation("CRA Art. 13(4): Machine-readable SBOM format");
+        let refs = v.derive_standard_refs();
+        assert!(
+            refs.iter()
+                .any(|r| r.standard == StandardKind::CraArticle && r.id == "Art. 13(4)"),
+            "expected CRA Art. 13(4); got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn standard_refs_infers_pren_id_from_art_13_4() {
+        let v = make_violation("CRA Art. 13(4): Machine-readable SBOM format");
+        let refs = v.derive_standard_refs();
+        assert!(
+            refs.iter()
+                .any(|r| r.standard == StandardKind::Pren40000_1_3 && r.id == "PRE-7-RQ-04"),
+            "expected prEN PRE-7-RQ-04; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn standard_refs_extracts_explicit_pren_id() {
+        let v = make_violation(
+            "CRA Annex I / prEN 40000-1-3 [PRE-7-RQ-07]: Unique component identifier",
+        );
+        let refs = v.derive_standard_refs();
+        assert!(
+            refs.iter()
+                .any(|r| r.standard == StandardKind::Pren40000_1_3 && r.id == "PRE-7-RQ-07"),
+            "expected explicit PRE-7-RQ-07; got {refs:?}"
+        );
+        // Should not double-list it
+        let pren_count = refs
+            .iter()
+            .filter(|r| r.standard == StandardKind::Pren40000_1_3 && r.id == "PRE-7-RQ-07")
+            .count();
+        assert_eq!(pren_count, 1, "PRE-7-RQ-07 should appear exactly once");
+    }
+
+    #[test]
+    fn standard_refs_extracts_annex_i_part_iii() {
+        let v = make_violation("CRA Annex I, Part III: Supply chain transparency");
+        let refs = v.derive_standard_refs();
+        assert!(
+            refs.iter()
+                .any(|r| r.standard == StandardKind::CraAnnex && r.id == "Annex I Part III"),
+            "expected Annex I Part III; got {refs:?}"
+        );
+        assert!(
+            refs.iter()
+                .any(|r| r.standard == StandardKind::Pren40000_1_3 && r.id == "PRE-7-RQ-01"),
+            "expected PRE-7-RQ-01; got {refs:?}"
+        );
+        assert!(
+            refs.iter()
+                .any(|r| r.standard == StandardKind::Pren40000_1_3 && r.id == "PRE-7-RQ-03"),
+            "expected PRE-7-RQ-03; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn standard_refs_recognises_csaf_in_art_13_7() {
+        let v = make_violation("CRA Art. 13(7): Coordinated vulnerability disclosure policy");
+        let refs = v.derive_standard_refs();
+        assert!(
+            refs.iter()
+                .any(|r| r.standard == StandardKind::Pren40000_1_3 && r.id == "RLS-2-RQ-03-RE"),
+            "expected RLS-2-RQ-03-RE; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn standard_refs_handles_nist_ssdf_practice() {
+        let v = make_violation("NIST SSDF PS.2: Build integrity — component hashes");
+        let refs = v.derive_standard_refs();
+        assert!(
+            refs.iter()
+                .any(|r| r.standard == StandardKind::NistSsdf && r.id == "PS.2"),
+            "expected NIST SSDF PS.2; got {refs:?}"
+        );
+    }
+
+    #[test]
+    fn check_populates_standard_refs_for_cra_violations() {
+        let sbom = NormalizedSbom::default();
+        let checker = ComplianceChecker::new(ComplianceLevel::CraPhase2);
+        let result = checker.check(&sbom);
+        let cra_violations: Vec<_> = result
+            .violations
+            .iter()
+            .filter(|v| v.requirement.to_lowercase().contains("cra"))
+            .collect();
+        assert!(
+            !cra_violations.is_empty(),
+            "empty SBOM should produce some CRA violations"
+        );
+        for v in &cra_violations {
+            assert!(
+                !v.standard_refs.is_empty(),
+                "CRA violation {:?} should have standard_refs populated",
+                v.requirement
+            );
+        }
+    }
+
+    #[test]
+    fn sidecar_supplies_security_contact_downgrades_art_13_6() {
+        use crate::model::CraSidecarMetadata;
+        let sbom = NormalizedSbom::default();
+
+        // Without sidecar: Art. 13(6) is a Warning
+        let bare = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        let art_13_6_warning = bare.violations.iter().find(|v| {
+            v.requirement.contains("Art. 13(6)") && v.severity == ViolationSeverity::Warning
+        });
+        assert!(
+            art_13_6_warning.is_some(),
+            "Without sidecar, Art. 13(6) should be a Warning"
+        );
+
+        // With sidecar that supplies security_contact: same finding becomes Info
+        let sidecar = CraSidecarMetadata {
+            security_contact: Some("security@example.com".to_string()),
+            ..Default::default()
+        };
+        let withsc = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+            .with_sidecar(sidecar)
+            .check(&sbom);
+        let art_13_6_info = withsc.violations.iter().find(|v| {
+            v.requirement.contains("Art. 13(6)") && v.severity == ViolationSeverity::Info
+        });
+        assert!(
+            art_13_6_info.is_some(),
+            "With sidecar, Art. 13(6) should be downgraded to Info"
+        );
+        assert!(
+            !withsc
+                .violations
+                .iter()
+                .any(|v| v.requirement.contains("Art. 13(6)")
+                    && v.severity == ViolationSeverity::Warning),
+            "With sidecar, no Warning-level Art. 13(6) violation should remain"
+        );
+    }
+
+    #[test]
+    fn sidecar_supplies_product_name_downgrades_art_13_12() {
+        use crate::model::CraSidecarMetadata;
+        let sbom = NormalizedSbom::default(); // no document name
+
+        let sidecar = CraSidecarMetadata {
+            product_name: Some("Demo Product".to_string()),
+            ..Default::default()
+        };
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+            .with_sidecar(sidecar)
+            .check(&sbom);
+        let downgraded = result.violations.iter().find(|v| {
+            v.requirement.contains("Art. 13(12)") && v.severity == ViolationSeverity::Info
+        });
+        assert!(
+            downgraded.is_some(),
+            "Sidecar product_name should downgrade Art. 13(12) to Info"
+        );
+    }
+
+    #[test]
+    fn sidecar_supplies_manufacturer_downgrades_art_13_15() {
+        use crate::model::CraSidecarMetadata;
+        let sbom = NormalizedSbom::default();
+        let sidecar = CraSidecarMetadata {
+            manufacturer_name: Some("Demo Corp".to_string()),
+            ..Default::default()
+        };
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+            .with_sidecar(sidecar)
+            .check(&sbom);
+        let downgraded = result.violations.iter().find(|v| {
+            v.requirement.contains("Art. 13(15)") && v.severity == ViolationSeverity::Info
+        });
+        assert!(
+            downgraded.is_some(),
+            "Sidecar manufacturer_name should downgrade Art. 13(15) to Info"
+        );
+    }
+
+    #[test]
+    fn sidecar_supplies_cvd_url_downgrades_art_13_7() {
+        use crate::model::CraSidecarMetadata;
+        let sbom = NormalizedSbom::default();
+        let sidecar = CraSidecarMetadata {
+            vulnerability_disclosure_url: Some("https://example.com/security".to_string()),
+            ..Default::default()
+        };
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+            .with_sidecar(sidecar)
+            .check(&sbom);
+        let downgraded = result.violations.iter().find(|v| {
+            v.requirement.contains("Art. 13(7)") && v.severity == ViolationSeverity::Info
+        });
+        assert!(
+            downgraded.is_some(),
+            "Sidecar CVD URL should downgrade Art. 13(7) to Info"
+        );
+    }
+
+    fn vendor_component(name: &str, with_hash: bool) -> crate::model::Component {
+        use crate::model::{Component, Hash, HashAlgorithm, Organization};
+        let mut c = Component::new(name.to_string(), name.to_string())
+            .with_purl(format!("pkg:cargo/{name}@1.0.0"));
+        c.supplier = Some(Organization::new("VendorCorp".to_string()));
+        if with_hash {
+            c.hashes.push(Hash::new(
+                HashAlgorithm::Sha256,
+                "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+            ));
+        }
+        c
+    }
+
+    fn hw_component(
+        name: &str,
+        kind: crate::model::ComponentType,
+        with_purl: bool,
+        with_supplier: bool,
+        version: Option<&str>,
+    ) -> crate::model::Component {
+        use crate::model::{Component, Organization};
+        let mut c = Component::new(name.to_string(), name.to_string());
+        c.component_type = kind;
+        if with_purl {
+            c = c.with_purl(format!("pkg:generic/{name}"));
+        }
+        if with_supplier {
+            c.supplier = Some(Organization::new("HardwareCorp".to_string()));
+        }
+        if let Some(v) = version {
+            c = c.with_version(v.to_string());
+        }
+        c
+    }
+
+    #[test]
+    fn hardware_check_skipped_for_software_only_sbom() {
+        let mut sbom = NormalizedSbom::default();
+        let c = vendor_component("software", true);
+        sbom.components.insert(c.canonical_id.clone(), c);
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        assert!(
+            !result
+                .violations
+                .iter()
+                .any(|v| v.requirement.contains("PRE-8-RQ-02")),
+            "Software-only SBOM should produce no PRE-8-RQ-02 violations"
+        );
+    }
+
+    #[test]
+    fn hardware_check_passes_for_complete_firmware() {
+        use crate::model::ComponentType;
+        let mut sbom = NormalizedSbom::default();
+        let c = hw_component(
+            "router-fw",
+            ComponentType::Firmware,
+            true,
+            true,
+            Some("1.2.3"),
+        );
+        sbom.components.insert(c.canonical_id.clone(), c);
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        assert!(
+            !result
+                .violations
+                .iter()
+                .any(|v| v.requirement.contains("PRE-8-RQ-02")),
+            "Complete firmware component should pass [PRE-8-RQ-02]"
+        );
+    }
+
+    #[test]
+    fn hardware_check_flags_firmware_without_version() {
+        use crate::model::ComponentType;
+        let mut sbom = NormalizedSbom::default();
+        let c = hw_component("router-fw", ComponentType::Firmware, true, true, None);
+        sbom.components.insert(c.canonical_id.clone(), c);
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        assert!(
+            result.violations.iter().any(|v| {
+                v.requirement.contains("Firmware version") && v.severity == ViolationSeverity::Error
+            }),
+            "Firmware without version should produce an Error"
+        );
+    }
+
+    #[test]
+    fn hardware_check_flags_missing_producer() {
+        use crate::model::ComponentType;
+        let mut sbom = NormalizedSbom::default();
+        let c = hw_component("router", ComponentType::Device, true, false, Some("1.0"));
+        sbom.components.insert(c.canonical_id.clone(), c);
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        assert!(
+            result.violations.iter().any(|v| {
+                v.requirement.contains("Hardware producer")
+                    && v.severity == ViolationSeverity::Error
+            }),
+            "Hardware without producer should produce an Error"
+        );
+    }
+
+    #[test]
+    fn hardware_check_flags_synthetic_identifier() {
+        use crate::model::{Component, ComponentType, Organization};
+        let mut sbom = NormalizedSbom::default();
+        let mut c = Component::new("router".to_string(), "router".to_string())
+            .with_version("1.0".to_string());
+        c.component_type = ComponentType::Device;
+        c.supplier = Some(Organization::new("HardwareCorp".to_string()));
+        // Note: no PURL/CPE/SWHID/SWID → falls back to synthetic
+        sbom.components.insert(c.canonical_id.clone(), c);
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        assert!(
+            result.violations.iter().any(|v| {
+                v.requirement.contains("Hardware identifier")
+                    && v.severity == ViolationSeverity::Error
+            }),
+            "Hardware with synthetic ID should produce an Error"
+        );
+    }
+
+    #[test]
+    fn hardware_check_device_with_firmware_dep_passes() {
+        use crate::model::{ComponentType, DependencyEdge, DependencyType};
+        let mut sbom = NormalizedSbom::default();
+        let device = hw_component("router", ComponentType::Device, true, true, None);
+        let firmware = hw_component(
+            "router-fw",
+            ComponentType::Firmware,
+            true,
+            true,
+            Some("1.2.3"),
+        );
+        let device_id = device.canonical_id.clone();
+        let firmware_id = firmware.canonical_id.clone();
+        sbom.components.insert(device_id.clone(), device);
+        sbom.components.insert(firmware_id.clone(), firmware);
+        sbom.edges.push(DependencyEdge::new(
+            device_id,
+            firmware_id,
+            DependencyType::DependsOn,
+        ));
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        assert!(
+            !result
+                .violations
+                .iter()
+                .any(|v| { v.requirement.contains("Device firmware association") }),
+            "Device with firmware dependency should not trigger version warning"
+        );
+    }
+
+    #[test]
+    fn vendor_hash_coverage_full() {
+        use crate::quality::HashQualityMetrics;
+        let mut sbom = NormalizedSbom::default();
+        for n in ["a", "b", "c", "d", "e"] {
+            let c = vendor_component(n, true);
+            sbom.components.insert(c.canonical_id.clone(), c);
+        }
+        let m = HashQualityMetrics::from_sbom(&sbom);
+        assert_eq!(m.vendor_components_total, 5);
+        assert_eq!(m.vendor_components_with_hash, 5);
+        assert_eq!(m.vendor_hash_coverage(), Some(1.0));
+    }
+
+    #[test]
+    fn vendor_hash_coverage_partial_triggers_warning() {
+        let mut sbom = NormalizedSbom::default();
+        // 7 with hashes, 3 without → 70% < 80% → Warning under CraPhase2
+        for n in ["a", "b", "c", "d", "e", "f", "g"] {
+            let c = vendor_component(n, true);
+            sbom.components.insert(c.canonical_id.clone(), c);
+        }
+        for n in ["h", "i", "j"] {
+            let c = vendor_component(n, false);
+            sbom.components.insert(c.canonical_id.clone(), c);
+        }
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        let v = result.violations.iter().find(|v| {
+            v.requirement.contains("PRE-7-RQ-07-RE") && v.severity == ViolationSeverity::Warning
+        });
+        assert!(
+            v.is_some(),
+            "70% vendor-hash coverage should produce a Warning under CraPhase2"
+        );
+    }
+
+    #[test]
+    fn vendor_hash_coverage_below_50_triggers_error() {
+        let mut sbom = NormalizedSbom::default();
+        // 4 with hashes, 6 without → 40% < 50% → Error under CraPhase2
+        for n in ["a", "b", "c", "d"] {
+            let c = vendor_component(n, true);
+            sbom.components.insert(c.canonical_id.clone(), c);
+        }
+        for n in ["e", "f", "g", "h", "i", "j"] {
+            let c = vendor_component(n, false);
+            sbom.components.insert(c.canonical_id.clone(), c);
+        }
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        let v = result.violations.iter().find(|v| {
+            v.requirement.contains("PRE-7-RQ-07-RE") && v.severity == ViolationSeverity::Error
+        });
+        assert!(
+            v.is_some(),
+            "40% vendor-hash coverage should produce an Error under CraPhase2"
+        );
+    }
+
+    #[test]
+    fn vendor_hash_coverage_no_vendor_components_no_violation() {
+        // SBOM with only synthetic-ID components — no vendor classification, no violation
+        let mut sbom = NormalizedSbom::default();
+        use crate::model::Component;
+        for n in ["a", "b", "c"] {
+            let c = Component::new(n.to_string(), n.to_string());
+            sbom.components.insert(c.canonical_id.clone(), c);
+        }
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        assert!(
+            !result
+                .violations
+                .iter()
+                .any(|v| v.requirement.contains("PRE-7-RQ-07-RE")),
+            "No vendor components → no [PRE-7-RQ-07-RE] violation"
+        );
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // P2 tests
+    // ──────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn art_13_2_warns_when_no_risk_assessment_referenced() {
+        let sbom = NormalizedSbom::default();
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        let v = result.violations.iter().find(|v| {
+            v.requirement.contains("Art. 13(2)") && v.severity == ViolationSeverity::Warning
+        });
+        assert!(v.is_some(), "Empty SBOM should produce Art. 13(2) Warning");
+    }
+
+    #[test]
+    fn art_13_2_silenced_by_sidecar_risk_assessment_url() {
+        use crate::model::CraSidecarMetadata;
+        let sbom = NormalizedSbom::default();
+        let sidecar = CraSidecarMetadata {
+            risk_assessment_url: Some("https://example.com/ra.pdf".to_string()),
+            ..Default::default()
+        };
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+            .with_sidecar(sidecar)
+            .check(&sbom);
+        assert!(
+            !result
+                .violations
+                .iter()
+                .any(|v| v.requirement.contains("Art. 13(2)")),
+            "Sidecar risk_assessment_url should suppress Art. 13(2) violation"
+        );
+    }
+
+    #[test]
+    fn article_14_pre_deadline_emits_info_only() {
+        // The check uses the wall clock; today's date in tests will be
+        // before/after 2026-09-11 depending on when tests run. We assert
+        // the *existence* of the readiness violations rather than exact
+        // severity, then verify with-sidecar suppresses.
+        let sbom = NormalizedSbom::default();
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        let art14_count = result
+            .violations
+            .iter()
+            .filter(|v| v.requirement.contains("Art. 14"))
+            .count();
+        assert!(
+            art14_count >= 4,
+            "Art. 14 readiness should produce ≥4 violations (PSIRT, 14(1), 14(2), 14(7)); got {art14_count}"
+        );
+    }
+
+    /// Pre-deadline (mocked clock 2026-04-26): all four channels missing.
+    /// PSIRT/14(1)/14(2) surface as Info; 14(7) (ENISA platform) is always Info.
+    /// Total: 4 Infos, 0 Warnings, 0 Errors at Art. 14 level.
+    #[test]
+    fn article_14_pre_deadline_mocked_clock_emits_4_infos() {
+        let checker = ComplianceChecker::new(ComplianceLevel::CraPhase2);
+        let mut violations = Vec::new();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-04-26T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        checker.check_article_14_readiness_at(now, &mut violations);
+
+        let infos = violations
+            .iter()
+            .filter(|v| v.severity == ViolationSeverity::Info && v.requirement.contains("Art. 14"))
+            .count();
+        let warnings = violations
+            .iter()
+            .filter(|v| {
+                v.severity == ViolationSeverity::Warning && v.requirement.contains("Art. 14")
+            })
+            .count();
+        assert_eq!(
+            infos, 4,
+            "Pre-deadline expects 4 Info-level Art. 14 findings; got {infos} (full list: {violations:?})"
+        );
+        assert_eq!(
+            warnings, 0,
+            "Pre-deadline expects 0 Warning-level Art. 14 findings"
+        );
+    }
+
+    /// Post-deadline (mocked clock 2026-12-01): same SBOM-less state, but
+    /// PSIRT/14(1)/14(2) become Warnings; 14(7) stays Info.
+    /// Total: 1 Info, 3 Warnings.
+    #[test]
+    fn article_14_post_deadline_mocked_clock_emits_3_warnings_1_info() {
+        let checker = ComplianceChecker::new(ComplianceLevel::CraPhase2);
+        let mut violations = Vec::new();
+        let now = chrono::DateTime::parse_from_rfc3339("2026-12-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&chrono::Utc);
+        checker.check_article_14_readiness_at(now, &mut violations);
+
+        let infos = violations
+            .iter()
+            .filter(|v| v.severity == ViolationSeverity::Info && v.requirement.contains("Art. 14"))
+            .count();
+        let warnings = violations
+            .iter()
+            .filter(|v| {
+                v.severity == ViolationSeverity::Warning && v.requirement.contains("Art. 14")
+            })
+            .count();
+        assert_eq!(
+            warnings, 3,
+            "Post-deadline expects 3 Warning-level Art. 14 findings (PSIRT/14(1)/14(2)); got {warnings} (full: {violations:?})"
+        );
+        assert_eq!(
+            infos, 1,
+            "Post-deadline expects 1 Info-level Art. 14 finding (Art. 14(7) ENISA platform stays Info regardless of date)"
+        );
+    }
+
+    #[test]
+    fn article_14_sidecar_suppresses_psirt_warning() {
+        use crate::model::CraSidecarMetadata;
+        let sbom = NormalizedSbom::default();
+        let sidecar = CraSidecarMetadata {
+            psirt_url: Some("https://example.com/psirt".to_string()),
+            early_warning_contact: Some("psirt@example.com".to_string()),
+            incident_report_contact: Some("ir@example.com".to_string()),
+            ..Default::default()
+        };
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+            .with_sidecar(sidecar)
+            .check(&sbom);
+        // PSIRT, 14(1), 14(2) suppressed; 14(7) (ENISA platform) remains as Info.
+        let art_14_psirt = result
+            .violations
+            .iter()
+            .any(|v| v.requirement.contains("Art. 14: PSIRT"));
+        let art_14_1 = result
+            .violations
+            .iter()
+            .any(|v| v.requirement.contains("Art. 14(1)"));
+        let art_14_2 = result
+            .violations
+            .iter()
+            .any(|v| v.requirement.contains("Art. 14(2)"));
+        assert!(
+            !art_14_psirt,
+            "Sidecar psirt_url should suppress PSIRT check"
+        );
+        assert!(
+            !art_14_1,
+            "Sidecar early_warning_contact should suppress 14(1)"
+        );
+        assert!(
+            !art_14_2,
+            "Sidecar incident_report_contact should suppress 14(2)"
+        );
+    }
+
+    #[test]
+    fn direct_dep_missing_supplier_is_error_under_cra_phase2() {
+        use crate::model::{Component, DependencyEdge, DependencyType};
+        let mut sbom = NormalizedSbom::default();
+        // Primary "app" with one direct dep "lib" missing supplier.
+        let app = Component::new("app".to_string(), "app".to_string())
+            .with_purl("pkg:cargo/app@1.0".to_string());
+        let lib = Component::new("lib".to_string(), "lib".to_string())
+            .with_purl("pkg:cargo/lib@1.0".to_string());
+        let app_id = app.canonical_id.clone();
+        let lib_id = lib.canonical_id.clone();
+        sbom.primary_component_id = Some(app_id.clone());
+        sbom.components.insert(app_id.clone(), app);
+        sbom.components.insert(lib_id.clone(), lib);
+        sbom.edges.push(DependencyEdge::new(
+            app_id,
+            lib_id,
+            DependencyType::DependsOn,
+        ));
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        let v = result.violations.iter().find(|v| {
+            v.requirement.contains("Direct dependency supplier")
+                && v.severity == ViolationSeverity::Error
+        });
+        assert!(
+            v.is_some(),
+            "Direct dep without supplier should produce an Error under CraPhase2"
+        );
+    }
+
+    #[test]
+    fn transitive_dep_missing_supplier_is_softer_than_direct() {
+        use crate::model::{Component, DependencyEdge, DependencyType, Organization};
+        let mut sbom = NormalizedSbom::default();
+        // app → lib (with supplier) → deep (no supplier)
+        let mut app = Component::new("app".to_string(), "app".to_string())
+            .with_purl("pkg:cargo/app@1.0".to_string());
+        app.supplier = Some(Organization::new("AppCorp".to_string()));
+        let mut lib = Component::new("lib".to_string(), "lib".to_string())
+            .with_purl("pkg:cargo/lib@1.0".to_string());
+        lib.supplier = Some(Organization::new("LibCorp".to_string()));
+        let deep = Component::new("deep".to_string(), "deep".to_string())
+            .with_purl("pkg:cargo/deep@1.0".to_string());
+        let app_id = app.canonical_id.clone();
+        let lib_id = lib.canonical_id.clone();
+        let deep_id = deep.canonical_id.clone();
+        sbom.primary_component_id = Some(app_id.clone());
+        sbom.components.insert(app_id.clone(), app);
+        sbom.components.insert(lib_id.clone(), lib);
+        sbom.components.insert(deep_id.clone(), deep);
+        sbom.edges.push(DependencyEdge::new(
+            app_id,
+            lib_id.clone(),
+            DependencyType::DependsOn,
+        ));
+        sbom.edges.push(DependencyEdge::new(
+            lib_id,
+            deep_id,
+            DependencyType::DependsOn,
+        ));
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+        let direct_err = result.violations.iter().any(|v| {
+            v.requirement.contains("Direct dependency supplier")
+                && v.severity == ViolationSeverity::Error
+        });
+        let transitive = result
+            .violations
+            .iter()
+            .find(|v| v.requirement.contains("Transitive dependency supplier"));
+        assert!(
+            !direct_err,
+            "No direct deps lack a supplier; should not error"
+        );
+        assert!(transitive.is_some(), "Transitive dep should be reported");
+        assert_ne!(
+            transitive.unwrap().severity,
+            ViolationSeverity::Error,
+            "Transitive supplier missing should never be Error (it's recommended, not mandatory)"
+        );
+    }
+
+    #[test]
+    fn bsi_tr_03183_2_empty_sbom_emits_errors() {
+        let sbom = NormalizedSbom::default();
+        let result = ComplianceChecker::new(ComplianceLevel::BsiTr03183_2).check(&sbom);
+        assert!(
+            result
+                .violations
+                .iter()
+                .any(|v| v.requirement.contains("BSI TR-03183-2 §5.1")
+                    && v.severity == ViolationSeverity::Error),
+            "Empty SBOM should fail BSI §5.1"
+        );
+    }
+
+    #[test]
+    fn bsi_tr_03183_2_flags_missing_strong_hash() {
+        use crate::model::{Component, Hash, HashAlgorithm};
+        let mut sbom = NormalizedSbom::default();
+        let mut c = Component::new("lib".to_string(), "lib".to_string())
+            .with_purl("pkg:cargo/lib@1.0".to_string());
+        // Add only a weak hash
+        c.hashes.push(Hash::new(HashAlgorithm::Md5, "0".repeat(32)));
+        sbom.add_component(c);
+        let result = ComplianceChecker::new(ComplianceLevel::BsiTr03183_2).check(&sbom);
+        assert!(
+            result.violations.iter().any(|v| {
+                v.requirement.contains("BSI TR-03183-2 §5.4")
+                    && v.severity == ViolationSeverity::Error
+            }),
+            "Component without SHA-256+ hash should fail BSI §5.4"
+        );
+    }
+
+    #[test]
+    fn bsi_tr_03183_2_passes_for_complete_component() {
+        use crate::model::{
+            Component, Creator, CreatorType, DependencyEdge, DependencyType, Hash, HashAlgorithm,
+            LicenseExpression, Organization,
+        };
+        let mut sbom = NormalizedSbom::default();
+        sbom.document.creators.push(Creator {
+            creator_type: CreatorType::Tool,
+            name: "sbom-tools".to_string(),
+            email: None,
+        });
+        let mut a = Component::new("a".to_string(), "a".to_string())
+            .with_purl("pkg:cargo/a@1.0".to_string())
+            .with_version("1.0".to_string());
+        a.hashes
+            .push(Hash::new(HashAlgorithm::Sha256, "f".repeat(64)));
+        a.supplier = Some(Organization::new("SupplierA".to_string()));
+        a.licenses
+            .add_declared(LicenseExpression::new("MIT".to_string()));
+        let mut b = Component::new("b".to_string(), "b".to_string())
+            .with_purl("pkg:cargo/b@1.0".to_string())
+            .with_version("1.0".to_string());
+        b.hashes
+            .push(Hash::new(HashAlgorithm::Sha256, "0".repeat(64)));
+        b.supplier = Some(Organization::new("SupplierB".to_string()));
+        b.licenses
+            .add_declared(LicenseExpression::new("MIT".to_string()));
+        let a_id = a.canonical_id.clone();
+        let b_id = b.canonical_id.clone();
+        sbom.components.insert(a_id.clone(), a);
+        sbom.components.insert(b_id.clone(), b);
+        sbom.edges
+            .push(DependencyEdge::new(a_id, b_id, DependencyType::DependsOn));
+
+        let result = ComplianceChecker::new(ComplianceLevel::BsiTr03183_2).check(&sbom);
+        let errors: Vec<_> = result
+            .violations
+            .iter()
+            .filter(|v| v.severity == ViolationSeverity::Error)
+            .collect();
+        assert!(
+            errors.is_empty(),
+            "Complete BSI-compliant SBOM should produce no Errors; got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn bsi_tr_03183_2_in_compliance_level_all() {
+        assert_eq!(ComplianceLevel::all().len(), 12);
+        assert!(ComplianceLevel::all().contains(&ComplianceLevel::BsiTr03183_2));
+    }
+
+    #[test]
+    fn sidecar_does_not_override_present_sbom_field() {
+        use crate::model::{CraSidecarMetadata, Creator, CreatorType};
+        let mut sbom = NormalizedSbom::default();
+        sbom.document.creators.push(Creator {
+            creator_type: CreatorType::Organization,
+            name: "SbomDeclaredCorp".to_string(),
+            email: None,
+        });
+        let sidecar = CraSidecarMetadata {
+            manufacturer_name: Some("SidecarCorp".to_string()),
+            ..Default::default()
+        };
+        let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+            .with_sidecar(sidecar)
+            .check(&sbom);
+        // No Art. 13(15) violation at all because SBOM provides org
+        assert!(
+            !result.violations.iter().any(|v| v
+                .requirement
+                .contains("Art. 13(15): Manufacturer identification")),
+            "When SBOM provides manufacturer, no Art. 13(15) violation should be emitted"
         );
     }
 }

--- a/src/quality/compliance.rs
+++ b/src/quality/compliance.rs
@@ -925,7 +925,9 @@ impl ComplianceChecker {
             (ClassCheck::EuccReference, C::ImportantClass2) => Some(ViolationSeverity::Info),
             (ClassCheck::EuccReference, C::Critical) => Some(ViolationSeverity::Error),
 
-            (ClassCheck::Psirt, C::Default | C::ImportantClass1) => Some(ViolationSeverity::Warning),
+            (ClassCheck::Psirt, C::Default | C::ImportantClass1) => {
+                Some(ViolationSeverity::Warning)
+            }
             (ClassCheck::Psirt, C::ImportantClass2 | C::Critical) => Some(ViolationSeverity::Error),
 
             (ClassCheck::ModuleAttestation, C::Default) => None,
@@ -1035,54 +1037,45 @@ impl ComplianceChecker {
     /// the external references manufacturers are expected to attach to
     /// satisfy Annex VIII; the `satisfied` flag is computed by scanning the
     /// SBOM's `external_refs` and the attached sidecar.
-    fn build_conformity_summary(
-        &self,
-        sbom: &NormalizedSbom,
-    ) -> ConformityAssessmentSummary {
+    fn build_conformity_summary(&self, sbom: &NormalizedSbom) -> ConformityAssessmentSummary {
         use crate::model::{ConformityRoute, ExternalRefType};
         let class = self.effective_product_class();
         let route = self.effective_route();
 
         let any_ext = |needles: &[ExternalRefType]| -> bool {
             sbom.components.values().any(|c| {
-                c.external_refs
-                    .iter()
-                    .any(|r| needles.iter().any(|n| std::mem::discriminant(&r.ref_type) == std::mem::discriminant(n)))
+                c.external_refs.iter().any(|r| {
+                    needles
+                        .iter()
+                        .any(|n| std::mem::discriminant(&r.ref_type) == std::mem::discriminant(n))
+                })
             })
         };
         let any_ext_url_contains = |types: &[ExternalRefType], substr: &str| -> bool {
             sbom.components.values().any(|c| {
                 c.external_refs.iter().any(|r| {
-                    types.iter().any(|t| std::mem::discriminant(&r.ref_type) == std::mem::discriminant(t))
+                    types
+                        .iter()
+                        .any(|t| std::mem::discriminant(&r.ref_type) == std::mem::discriminant(t))
                         && r.url.to_lowercase().contains(substr)
                 })
             })
         };
 
-        let doc_or_ce = any_ext(&[
-            ExternalRefType::Attestation,
-            ExternalRefType::Certification,
-        ]) || self
-            .sidecar
-            .as_ref()
-            .is_some_and(|s| s.ce_marking_reference.is_some());
+        let doc_or_ce = any_ext(&[ExternalRefType::Attestation, ExternalRefType::Certification])
+            || self
+                .sidecar
+                .as_ref()
+                .is_some_and(|s| s.ce_marking_reference.is_some());
 
-        let attestation_present = any_ext(&[
-            ExternalRefType::Attestation,
-            ExternalRefType::Certification,
-        ]);
+        let attestation_present =
+            any_ext(&[ExternalRefType::Attestation, ExternalRefType::Certification]);
 
         let eucc_present = any_ext_url_contains(
-            &[
-                ExternalRefType::Certification,
-                ExternalRefType::Attestation,
-            ],
+            &[ExternalRefType::Certification, ExternalRefType::Attestation],
             "eucc",
         ) || any_ext_url_contains(
-            &[
-                ExternalRefType::Certification,
-                ExternalRefType::Attestation,
-            ],
+            &[ExternalRefType::Certification, ExternalRefType::Attestation],
             "common-criteria",
         );
 
@@ -1142,10 +1135,7 @@ impl ComplianceChecker {
         // Article 14 channels are required at all conformity routes once the
         // 2026-09-11 deadline applies; surface as evidence rows for
         // notified-body checklists.
-        let psirt = self
-            .sidecar
-            .as_ref()
-            .is_some_and(|s| s.psirt_url.is_some());
+        let psirt = self.sidecar.as_ref().is_some_and(|s| s.psirt_url.is_some());
         evidence.push(ConformityEvidence {
             label: "PSIRT contact (Art. 14)".to_string(),
             detail: "Public PSIRT URL for receiving external vulnerability reports.".to_string(),
@@ -2078,12 +2068,14 @@ impl ComplianceChecker {
                         ComplianceLevel::CraPhase2 if coverage < 0.50 => {
                             (ViolationSeverity::Error, "below 50% threshold".to_string())
                         }
-                        ComplianceLevel::CraPhase2 if coverage < 0.80 => {
-                            (ViolationSeverity::Warning, "below 80% threshold".to_string())
-                        }
-                        ComplianceLevel::CraPhase1 if coverage < 0.50 => {
-                            (ViolationSeverity::Warning, "below 50% threshold".to_string())
-                        }
+                        ComplianceLevel::CraPhase2 if coverage < 0.80 => (
+                            ViolationSeverity::Warning,
+                            "below 80% threshold".to_string(),
+                        ),
+                        ComplianceLevel::CraPhase1 if coverage < 0.50 => (
+                            ViolationSeverity::Warning,
+                            "below 50% threshold".to_string(),
+                        ),
                         _ => (ViolationSeverity::Info, String::new()),
                     }
                 };

--- a/src/quality/compliance.rs
+++ b/src/quality/compliance.rs
@@ -262,12 +262,17 @@ pub struct StandardRef {
 }
 
 impl StandardRef {
+    /// Construct a `StandardRef` and auto-populate `help_uri` with a stable
+    /// canonical URL for the standard, when one is known. Pass through
+    /// `with_uri()` to override.
     #[must_use]
     pub fn new(standard: StandardKind, id: impl Into<String>) -> Self {
+        let id = id.into();
+        let help_uri = standard.canonical_help_uri(&id);
         Self {
             standard,
-            id: id.into(),
-            help_uri: None,
+            id,
+            help_uri,
         }
     }
 
@@ -275,6 +280,55 @@ impl StandardRef {
     pub fn with_uri(mut self, uri: impl Into<String>) -> Self {
         self.help_uri = Some(uri.into());
         self
+    }
+}
+
+impl StandardKind {
+    /// Stable canonical URL for the standard / regulation that hosts the
+    /// referenced clause. Returns `None` for `Other` (no canonical home) and
+    /// for `Pren40000_1_3` because the draft EN is paywalled and CEN's URLs
+    /// are not stable; CRA-P5.1 will revisit once the standard is finalised.
+    ///
+    /// The returned URL is the *standard's* root, not a per-clause anchor —
+    /// EUR-Lex and most national standards bodies do not publish stable
+    /// per-article fragments. Per-article precision lives in the
+    /// `StandardRef::id` (e.g., "Art. 13(4)") rather than the URL.
+    #[must_use]
+    pub fn canonical_help_uri(self, _id: &str) -> Option<String> {
+        let url = match self {
+            // CRA Regulation (EU) 2024/2847 — EUR-Lex ELI is the canonical home.
+            Self::CraArticle | Self::CraAnnex => {
+                "https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng"
+            }
+            // prEN 40000-1-3 is in development; no stable public URL yet.
+            Self::Pren40000_1_3 => return None,
+            // BSI TR-03183-2 (English landing page).
+            Self::BsiTr03183_2 => {
+                "https://www.bsi.bund.de/EN/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/Technische-Richtlinien/TR-nach-Thema-sortiert/tr03183/TR-03183_node.html"
+            }
+            // NIST SP 800-218 SSDF — DOI is the most stable handle.
+            Self::NistSsdf => "https://doi.org/10.6028/NIST.SP.800-218",
+            // EO 14028 — Federal Register short-form.
+            Self::Eo14028 => "https://www.federalregister.gov/d/2021-10460",
+            // FDA premarket cybersecurity guidance.
+            Self::FdaPremarket => {
+                "https://www.fda.gov/regulatory-information/search-fda-guidance-documents/cybersecurity-medical-devices-quality-system-considerations-and-content-premarket-submissions"
+            }
+            // NTIA SBOM Minimum Elements report.
+            Self::NtiaMinimum => {
+                "https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf"
+            }
+            // CSAF v2.0 OASIS standard.
+            Self::Csaf2 => "https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html",
+            // CNSA 2.0 fact sheet.
+            Self::Cnsa2 => {
+                "https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF"
+            }
+            // NIST PQC project landing page.
+            Self::NistPqc => "https://csrc.nist.gov/projects/post-quantum-cryptography",
+            Self::Other => return None,
+        };
+        Some(url.to_string())
     }
 }
 

--- a/src/quality/compliance.rs
+++ b/src/quality/compliance.rs
@@ -59,6 +59,11 @@ pub enum ComplianceLevel {
     /// BSI TR-03183-2 (German national CRA-aligned SBOM technical guideline).
     /// Free, ENISA-cited; stricter than NTIA on hashes and identifiers.
     BsiTr03183_2,
+    /// CRA Article 24 — Open-source software steward profile (lighter
+    /// obligations than CraPhase1/2). SBOM, vulnerability handling process,
+    /// and CVD policy are still required; manufacturer email, EU DoC, and
+    /// conformity-assessment-module gating are NOT.
+    CraOssSteward,
     /// Comprehensive compliance (all recommended fields)
     Comprehensive,
 }
@@ -79,6 +84,7 @@ impl ComplianceLevel {
             Self::Cnsa2 => "CNSA 2.0",
             Self::NistPqc => "NIST PQC Readiness",
             Self::BsiTr03183_2 => "BSI TR-03183-2",
+            Self::CraOssSteward => "CRA OSS Steward (Art. 24)",
             Self::Comprehensive => "Comprehensive",
         }
     }
@@ -98,6 +104,7 @@ impl ComplianceLevel {
             Self::Cnsa2 => "CNSA2",
             Self::NistPqc => "PQC",
             Self::BsiTr03183_2 => "BSI",
+            Self::CraOssSteward => "OSS",
             Self::Comprehensive => "Full",
         }
     }
@@ -131,6 +138,9 @@ impl ComplianceLevel {
             Self::BsiTr03183_2 => {
                 "BSI TR-03183-2 — German national SBOM guideline (free, ENISA-cited): mandatory hashes, identifiers, ISO-8601 timestamps"
             }
+            Self::CraOssSteward => {
+                "CRA Article 24 — Open-source software steward (lighter than full manufacturer obligations): SBOM + CVD policy + vuln-handling required, no DoC/module/manufacturer-email enforcement"
+            }
             Self::Comprehensive => "All recommended fields and best practices",
         }
     }
@@ -150,14 +160,20 @@ impl ComplianceLevel {
             Self::Cnsa2,
             Self::NistPqc,
             Self::BsiTr03183_2,
+            Self::CraOssSteward,
             Self::Comprehensive,
         ]
     }
 
-    /// Whether this level is a CRA check (either phase)
+    /// Whether this level is a CRA check. Includes the lighter Article 24
+    /// open-source steward profile, since stewards still operate under the
+    /// regulation (just with reduced obligations).
     #[must_use]
     pub const fn is_cra(&self) -> bool {
-        matches!(self, Self::CraPhase1 | Self::CraPhase2)
+        matches!(
+            self,
+            Self::CraPhase1 | Self::CraPhase2 | Self::CraOssSteward
+        )
     }
 
     /// Get CRA phase, if applicable
@@ -869,6 +885,9 @@ impl ComplianceChecker {
             }
             ComplianceLevel::BsiTr03183_2 => {
                 self.check_bsi_tr_03183_2(sbom, &mut violations);
+            }
+            ComplianceLevel::CraOssSteward => {
+                self.check_cra_oss_steward(sbom, &mut violations);
             }
             _ => {
                 // Check document-level requirements
@@ -3152,6 +3171,99 @@ impl ComplianceChecker {
     }
 
     // ════════════════════════════════════════════════════════════════════
+    // CRA Article 24 — Open-source software steward profile
+    // ════════════════════════════════════════════════════════════════════
+    //
+    // Stewards (e.g., Eclipse Foundation, Apache, Linux Foundation) supply
+    // software under the CRA but with reduced obligations:
+    //
+    // | Obligation                        | Manufacturer (Phase1/2) | Steward (Art. 24) |
+    // |-----------------------------------|-------------------------|-------------------|
+    // | SBOM                              | Required                | Required          |
+    // | Vulnerability handling process    | Required (Annex I II)   | Required          |
+    // | Coordinated disclosure policy     | Required (Art. 13(7))   | Required          |
+    // | Manufacturer email contact        | Required (Art. 13(15))  | NOT required      |
+    // | EU Declaration of Conformity      | Required                | NOT required      |
+    // | Conformity-assessment module      | Required                | NOT applied       |
+    // | Article 14 reporting channels     | Required                | NOT applied       |
+    // | Vendor-hash carry-through         | Required (Phase 2)      | Recommended only  |
+    //
+    // The check below runs the must-have subset and skips the rest.
+
+    fn check_cra_oss_steward(&self, sbom: &NormalizedSbom, violations: &mut Vec<Violation>) {
+        // -- Must-haves (Article 24 floor) ----------------------------------
+
+        // SBOM completeness — basic structural requirements (re-uses the
+        // standard component check; manufacturer-only sub-checks are gated
+        // off because we don't run check_cra_gaps for stewards).
+        self.check_components(sbom, violations);
+        self.check_dependencies(sbom, violations);
+
+        // Vulnerability-handling process (Annex I Part II): require either
+        // a vulnerability-disclosure URL on the document or a SecurityContact
+        // / Advisories external reference on at least one component, OR
+        // sidecar-supplied PSIRT URL.
+        let has_vuln_handling = sbom.components.values().any(|c| {
+            c.external_refs.iter().any(|r| {
+                matches!(
+                    r.ref_type,
+                    crate::model::ExternalRefType::SecurityContact
+                        | crate::model::ExternalRefType::Advisories
+                        | crate::model::ExternalRefType::VulnerabilityAssertion
+                )
+            })
+        }) || self
+            .sidecar
+            .as_ref()
+            .is_some_and(|s| s.psirt_url.is_some() || s.vulnerability_disclosure_url.is_some());
+        if !has_vuln_handling {
+            violations.push(Violation {
+                severity: ViolationSeverity::Error,
+                category: ViolationCategory::SecurityInfo,
+                message: "[CRA Art. 24 / Annex I Part II] OSS steward must operate a vulnerability-handling process — declare a SecurityContact / Advisories external reference, or set psirt_url / vulnerability_disclosure_url in the sidecar".to_string(),
+                element: None,
+                requirement: "CRA Art. 24: Vulnerability-handling process (steward floor)"
+                    .to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // Coordinated vulnerability disclosure policy (Art. 13(7)): require
+        // either an Advisories reference or sidecar-supplied
+        // coordinated_disclosure_policy_url.
+        let has_cvd_policy = sbom.components.values().any(|c| {
+            c.external_refs
+                .iter()
+                .any(|r| matches!(r.ref_type, crate::model::ExternalRefType::Advisories))
+        }) || self
+            .sidecar
+            .as_ref()
+            .is_some_and(|s| s.coordinated_disclosure_policy_url.is_some());
+        if !has_cvd_policy {
+            violations.push(Violation {
+                severity: ViolationSeverity::Warning,
+                category: ViolationCategory::SecurityInfo,
+                message: "[CRA Art. 13(7)] OSS steward should publish a coordinated vulnerability disclosure (CVD) policy — add an Advisories external reference or set coordinated_disclosure_policy_url in the sidecar".to_string(),
+                element: None,
+                requirement: "CRA Art. 13(7): Coordinated vulnerability disclosure policy"
+                    .to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // Format-specific (CycloneDX/SPDX integrity, e.g., bomFormat field)
+        self.check_format_specific(sbom, violations);
+
+        // -- Explicitly NOT enforced ----------------------------------------
+        // - Manufacturer email contact (Art. 13(15))
+        // - EU Declaration of Conformity reference (Annex VII)
+        // - Conformity-assessment module attestation
+        // - Article 14 reporting channels (24h / 72h / ENISA)
+        // - Hardware component requirements
+        // - Vendor-hash carry-through threshold
+    }
+
+    // ════════════════════════════════════════════════════════════════════
     // NIST PQC Readiness checks
     // ════════════════════════════════════════════════════════════════════
 
@@ -4279,8 +4391,9 @@ mod tests {
 
     #[test]
     fn bsi_tr_03183_2_in_compliance_level_all() {
-        assert_eq!(ComplianceLevel::all().len(), 12);
+        assert_eq!(ComplianceLevel::all().len(), 13);
         assert!(ComplianceLevel::all().contains(&ComplianceLevel::BsiTr03183_2));
+        assert!(ComplianceLevel::all().contains(&ComplianceLevel::CraOssSteward));
     }
 
     #[test]

--- a/src/quality/compliance.rs
+++ b/src/quality/compliance.rs
@@ -64,6 +64,12 @@ pub enum ComplianceLevel {
     /// and CVD policy are still required; manufacturer email, EU DoC, and
     /// conformity-assessment-module gating are NOT.
     CraOssSteward,
+    /// EUCC Substantial assurance level (Reg. (EU) 2024/482) — reference-only
+    /// profile for Annex IV products. Verifies that the SBOM/sidecar carries
+    /// a Common-Criteria Protection-Profile reference, Target-of-Evaluation
+    /// reference, ITSEF identifier, and a valid-until date. Does not perform
+    /// a Common-Criteria evaluation itself.
+    EuccSubstantial,
     /// Comprehensive compliance (all recommended fields)
     Comprehensive,
 }
@@ -85,6 +91,7 @@ impl ComplianceLevel {
             Self::NistPqc => "NIST PQC Readiness",
             Self::BsiTr03183_2 => "BSI TR-03183-2",
             Self::CraOssSteward => "CRA OSS Steward (Art. 24)",
+            Self::EuccSubstantial => "EUCC Substantial (Reg. 2024/482)",
             Self::Comprehensive => "Comprehensive",
         }
     }
@@ -105,6 +112,7 @@ impl ComplianceLevel {
             Self::NistPqc => "PQC",
             Self::BsiTr03183_2 => "BSI",
             Self::CraOssSteward => "OSS",
+            Self::EuccSubstantial => "EUCC",
             Self::Comprehensive => "Full",
         }
     }
@@ -141,6 +149,9 @@ impl ComplianceLevel {
             Self::CraOssSteward => {
                 "CRA Article 24 — Open-source software steward (lighter than full manufacturer obligations): SBOM + CVD policy + vuln-handling required, no DoC/module/manufacturer-email enforcement"
             }
+            Self::EuccSubstantial => {
+                "EUCC Substantial (Reg. (EU) 2024/482) — reference-only check for Common-Criteria Protection Profile, Target of Evaluation, ITSEF, and certificate valid-until date"
+            }
             Self::Comprehensive => "All recommended fields and best practices",
         }
     }
@@ -161,6 +172,7 @@ impl ComplianceLevel {
             Self::NistPqc,
             Self::BsiTr03183_2,
             Self::CraOssSteward,
+            Self::EuccSubstantial,
             Self::Comprehensive,
         ]
     }
@@ -975,6 +987,9 @@ impl ComplianceChecker {
             }
             ComplianceLevel::CraOssSteward => {
                 self.check_cra_oss_steward(sbom, &mut violations);
+            }
+            ComplianceLevel::EuccSubstantial => {
+                self.check_eucc_substantial(sbom, &mut violations);
             }
             _ => {
                 // Check document-level requirements
@@ -2270,6 +2285,40 @@ impl ComplianceChecker {
             self.check_class_eucc_reference(sbom, violations);
             self.check_class_module_attestation(sbom, violations);
         }
+
+        // CRA-P5.5: prEN 40000-1-2/1-4 controls-assertion sanity checks.
+        // Only fires when the sidecar provides an annex_i_part_i_controls
+        // block; otherwise the section is silently skipped.
+        self.check_controls_assertion(violations);
+    }
+
+    /// Cross-check the sidecar `annex_i_part_i_controls` block. A control
+    /// claimed `satisfied = true` without an `evidence_url` produces a
+    /// Warning (un-evidenced claim); claimed `satisfied = false` is fine
+    /// (manufacturer is being honest about a gap).
+    fn check_controls_assertion(&self, violations: &mut Vec<Violation>) {
+        let Some(sidecar) = self.sidecar.as_ref() else {
+            return;
+        };
+        if sidecar.annex_i_part_i_controls.is_empty() {
+            return;
+        }
+        for (id, claim) in &sidecar.annex_i_part_i_controls {
+            if claim.satisfied && claim.evidence_url.is_none() {
+                violations.push(Violation {
+                    severity: ViolationSeverity::Warning,
+                    category: ViolationCategory::DocumentMetadata,
+                    message: format!(
+                        "[CRA Annex I Part I {id}] Sidecar claims control satisfied but provides no `evidence_url` — un-evidenced claims should be reviewed before submission"
+                    ),
+                    element: None,
+                    requirement: format!(
+                        "CRA Annex I Part I {id}: controls-assertion evidence (prEN 40000-1-2)"
+                    ),
+                    standard_refs: Vec::new(),
+                });
+            }
+        }
     }
 
     /// EUCC (Common Criteria) certificate / Target-of-Evaluation reference.
@@ -3486,6 +3535,130 @@ impl ComplianceChecker {
     }
 
     // ════════════════════════════════════════════════════════════════════
+    // EUCC Substantial (CRA-P5.4 reference profile)
+    // ════════════════════════════════════════════════════════════════════
+    //
+    // Reference-only profile for CRA Annex IV / EUCC products. Verifies
+    // that the SBOM (or sidecar) carries the four pieces of evidence
+    // notified-body auditors expect to see in a Common Criteria
+    // submission. Does NOT perform a Common Criteria evaluation —
+    // that's out of scope for SBOM tooling.
+
+    fn check_eucc_substantial(&self, sbom: &NormalizedSbom, violations: &mut Vec<Violation>) {
+        let sidecar = self.sidecar.as_ref();
+
+        // 1. Common Criteria Protection Profile reference
+        let pp_present = sidecar
+            .and_then(|s| s.eucc_protection_profile_id.as_deref())
+            .is_some_and(|s| !s.is_empty());
+        if !pp_present {
+            violations.push(Violation {
+                severity: ViolationSeverity::Error,
+                category: ViolationCategory::DocumentMetadata,
+                message: "[EUCC] Missing Common Criteria Protection Profile reference — set sidecar `eucc_protection_profile_id`".to_string(),
+                element: None,
+                requirement: "EUCC Substantial: Protection Profile reference".to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // 2. Target of Evaluation reference
+        let toe_present = sidecar
+            .and_then(|s| s.eucc_target_of_evaluation.as_deref())
+            .is_some_and(|s| !s.is_empty());
+        if !toe_present {
+            violations.push(Violation {
+                severity: ViolationSeverity::Error,
+                category: ViolationCategory::DocumentMetadata,
+                message: "[EUCC] Missing Target of Evaluation reference — set sidecar `eucc_target_of_evaluation`".to_string(),
+                element: None,
+                requirement: "EUCC Substantial: Target of Evaluation reference".to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // 3. ITSEF (lab) identifier
+        let itsef_present = sidecar
+            .and_then(|s| s.eucc_itsef_identifier.as_deref())
+            .is_some_and(|s| !s.is_empty());
+        if !itsef_present {
+            violations.push(Violation {
+                severity: ViolationSeverity::Error,
+                category: ViolationCategory::DocumentMetadata,
+                message: "[EUCC] Missing ITSEF (IT Security Evaluation Facility) identifier — set sidecar `eucc_itsef_identifier`".to_string(),
+                element: None,
+                requirement: "EUCC Substantial: ITSEF identifier".to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // 4. Valid-until date
+        match sidecar.and_then(|s| s.eucc_valid_until) {
+            None => {
+                violations.push(Violation {
+                    severity: ViolationSeverity::Error,
+                    category: ViolationCategory::DocumentMetadata,
+                    message: "[EUCC] Missing certificate valid-until date — set sidecar `eucc_valid_until`".to_string(),
+                    element: None,
+                    requirement: "EUCC Substantial: certificate valid-until date".to_string(),
+                    standard_refs: Vec::new(),
+                });
+            }
+            Some(until) if until <= chrono::Utc::now() => {
+                violations.push(Violation {
+                    severity: ViolationSeverity::Error,
+                    category: ViolationCategory::DocumentMetadata,
+                    message: format!(
+                        "[EUCC] EUCC certificate has expired (valid-until {})",
+                        until.format("%Y-%m-%d")
+                    ),
+                    element: None,
+                    requirement: "EUCC Substantial: certificate validity".to_string(),
+                    standard_refs: Vec::new(),
+                });
+            }
+            Some(until) if until <= chrono::Utc::now() + chrono::Duration::days(180) => {
+                violations.push(Violation {
+                    severity: ViolationSeverity::Warning,
+                    category: ViolationCategory::DocumentMetadata,
+                    message: format!(
+                        "[EUCC] EUCC certificate expires within 180 days ({})",
+                        until.format("%Y-%m-%d")
+                    ),
+                    element: None,
+                    requirement: "EUCC Substantial: certificate validity".to_string(),
+                    standard_refs: Vec::new(),
+                });
+            }
+            Some(_) => {}
+        }
+
+        // 5. EUCC Certification external ref (recommended) — checked
+        // structurally; satisfied when any component carries a Certification
+        // ref whose URL contains "eucc" or "common-criteria".
+        let eucc_ref_present = sbom.components.values().any(|c| {
+            c.external_refs.iter().any(|r| {
+                let url = r.url.to_lowercase();
+                matches!(
+                    r.ref_type,
+                    crate::model::ExternalRefType::Certification
+                        | crate::model::ExternalRefType::Attestation
+                ) && (url.contains("eucc") || url.contains("common-criteria"))
+            })
+        });
+        if !eucc_ref_present {
+            violations.push(Violation {
+                severity: ViolationSeverity::Warning,
+                category: ViolationCategory::DocumentMetadata,
+                message: "[EUCC] No Certification/Attestation external reference points at an EUCC URL (recommended)".to_string(),
+                element: None,
+                requirement: "EUCC Substantial: Certification external reference".to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+    }
+
+    // ════════════════════════════════════════════════════════════════════
     // NIST PQC Readiness checks
     // ════════════════════════════════════════════════════════════════════
 
@@ -4613,9 +4786,10 @@ mod tests {
 
     #[test]
     fn bsi_tr_03183_2_in_compliance_level_all() {
-        assert_eq!(ComplianceLevel::all().len(), 13);
+        assert_eq!(ComplianceLevel::all().len(), 14);
         assert!(ComplianceLevel::all().contains(&ComplianceLevel::BsiTr03183_2));
         assert!(ComplianceLevel::all().contains(&ComplianceLevel::CraOssSteward));
+        assert!(ComplianceLevel::all().contains(&ComplianceLevel::EuccSubstantial));
     }
 
     #[test]

--- a/src/quality/compliance.rs
+++ b/src/quality/compliance.rs
@@ -691,6 +691,38 @@ pub struct ComplianceResult {
     pub warning_count: usize,
     /// Info count
     pub info_count: usize,
+    /// CRA Annex VIII conformity-assessment summary (CRA-P4.3). Populated
+    /// only when the level is a CRA profile *and* a product class has been
+    /// pinned (explicitly or via sidecar). `None` otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conformity_summary: Option<ConformityAssessmentSummary>,
+}
+
+/// Per-route checklist of evidence the CRA Annex VIII conformity-assessment
+/// procedure expects. Surfaced in markdown / HTML / SARIF / TUI reports so
+/// notified bodies and auditors see the route + the missing evidence in
+/// one glance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConformityAssessmentSummary {
+    /// CRA Annex III/IV product class
+    pub product_class: crate::model::CraProductClass,
+    /// Resolved Annex VIII conformity route
+    pub route: crate::model::ConformityRoute,
+    /// Per-evidence checklist entries (≥1 element)
+    pub evidence: Vec<ConformityEvidence>,
+}
+
+/// One row of the conformity-evidence checklist. `satisfied = true` means
+/// the SBOM (or sidecar) carries the expected reference; `false` means it
+/// is missing and the manufacturer should attach it before submitting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConformityEvidence {
+    /// Short label (e.g., "EU Declaration of Conformity")
+    pub label: String,
+    /// Longer description of the evidence
+    pub detail: String,
+    /// Whether the SBOM/sidecar already provides this evidence
+    pub satisfied: bool,
 }
 
 impl ComplianceResult {
@@ -714,6 +746,7 @@ impl ComplianceResult {
             is_compliant: error_count == 0,
             level,
             violations,
+            conformity_summary: None,
             error_count,
             warning_count,
             info_count,
@@ -974,7 +1007,142 @@ impl ComplianceChecker {
             }
         }
 
-        ComplianceResult::new(self.level, violations)
+        let mut result = ComplianceResult::new(self.level, violations);
+        // Attach the CRA Annex VIII conformity summary when a product class
+        // has been pinned and the level is a CRA profile.
+        if self.level.is_cra() && self.has_explicit_product_class() {
+            result.conformity_summary = Some(self.build_conformity_summary(sbom));
+        }
+        result
+    }
+
+    /// Build the per-route evidence checklist (CRA-P4.3). Each route lists
+    /// the external references manufacturers are expected to attach to
+    /// satisfy Annex VIII; the `satisfied` flag is computed by scanning the
+    /// SBOM's `external_refs` and the attached sidecar.
+    fn build_conformity_summary(
+        &self,
+        sbom: &NormalizedSbom,
+    ) -> ConformityAssessmentSummary {
+        use crate::model::{ConformityRoute, ExternalRefType};
+        let class = self.effective_product_class();
+        let route = self.effective_route();
+
+        let any_ext = |needles: &[ExternalRefType]| -> bool {
+            sbom.components.values().any(|c| {
+                c.external_refs
+                    .iter()
+                    .any(|r| needles.iter().any(|n| std::mem::discriminant(&r.ref_type) == std::mem::discriminant(n)))
+            })
+        };
+        let any_ext_url_contains = |types: &[ExternalRefType], substr: &str| -> bool {
+            sbom.components.values().any(|c| {
+                c.external_refs.iter().any(|r| {
+                    types.iter().any(|t| std::mem::discriminant(&r.ref_type) == std::mem::discriminant(t))
+                        && r.url.to_lowercase().contains(substr)
+                })
+            })
+        };
+
+        let doc_or_ce = any_ext(&[
+            ExternalRefType::Attestation,
+            ExternalRefType::Certification,
+        ]) || self
+            .sidecar
+            .as_ref()
+            .is_some_and(|s| s.ce_marking_reference.is_some());
+
+        let attestation_present = any_ext(&[
+            ExternalRefType::Attestation,
+            ExternalRefType::Certification,
+        ]);
+
+        let eucc_present = any_ext_url_contains(
+            &[
+                ExternalRefType::Certification,
+                ExternalRefType::Attestation,
+            ],
+            "eucc",
+        ) || any_ext_url_contains(
+            &[
+                ExternalRefType::Certification,
+                ExternalRefType::Attestation,
+            ],
+            "common-criteria",
+        );
+
+        let mut evidence: Vec<ConformityEvidence> = Vec::new();
+        evidence.push(ConformityEvidence {
+            label: "EU Declaration of Conformity".to_string(),
+            detail: "Annex V — manufacturer's signed declaration. Provide via Attestation/Certification external ref or sidecar ceMarkingReference.".to_string(),
+            satisfied: doc_or_ce,
+        });
+
+        match route {
+            ConformityRoute::ModuleA => {
+                evidence.push(ConformityEvidence {
+                    label: "Internal-control technical file".to_string(),
+                    detail: "Module A — manufacturer holds the technical file at their premises. No external attestation required.".to_string(),
+                    satisfied: true,
+                });
+            }
+            ConformityRoute::ModuleBC => {
+                evidence.push(ConformityEvidence {
+                    label: "EU-type examination certificate (Module B)".to_string(),
+                    detail: "Notified-body certificate of EU-type examination — Attestation/Certification external ref.".to_string(),
+                    satisfied: attestation_present,
+                });
+                evidence.push(ConformityEvidence {
+                    label: "Production conformity statement (Module C)".to_string(),
+                    detail: "Manufacturer's declaration that production conforms to the type examined under Module B.".to_string(),
+                    satisfied: doc_or_ce,
+                });
+            }
+            ConformityRoute::ModuleH => {
+                evidence.push(ConformityEvidence {
+                    label: "Quality-management-system certification (Module H)".to_string(),
+                    detail: "Notified-body QMS certification (typically ISO 9001 / ISO/IEC 27001 family) — Certification external ref.".to_string(),
+                    satisfied: attestation_present,
+                });
+                evidence.push(ConformityEvidence {
+                    label: "QMS surveillance plan".to_string(),
+                    detail: "Notified-body surveillance / re-assessment record — referenced via Attestation external ref.".to_string(),
+                    satisfied: attestation_present,
+                });
+            }
+            ConformityRoute::Eucc => {
+                evidence.push(ConformityEvidence {
+                    label: "EUCC / Common Criteria certificate".to_string(),
+                    detail: "Common Criteria certificate from an EUCC-accredited ITSEF — Certification external ref whose URL references EUCC or common-criteria.".to_string(),
+                    satisfied: eucc_present,
+                });
+                evidence.push(ConformityEvidence {
+                    label: "Target of Evaluation reference".to_string(),
+                    detail: "Reference to the ToE (and Protection Profile, when applicable) that the EUCC certificate covers.".to_string(),
+                    satisfied: eucc_present,
+                });
+            }
+        }
+
+        // Article 14 channels are required at all conformity routes once the
+        // 2026-09-11 deadline applies; surface as evidence rows for
+        // notified-body checklists.
+        let psirt = self
+            .sidecar
+            .as_ref()
+            .is_some_and(|s| s.psirt_url.is_some());
+        evidence.push(ConformityEvidence {
+            label: "PSIRT contact (Art. 14)".to_string(),
+            detail: "Public PSIRT URL for receiving external vulnerability reports.".to_string(),
+            satisfied: psirt,
+        });
+
+        let _ = class; // already encoded into the route; keep on the summary
+        ConformityAssessmentSummary {
+            product_class: class,
+            route,
+            evidence,
+        }
     }
 
     fn check_document_metadata(&self, sbom: &NormalizedSbom, violations: &mut Vec<Violation>) {

--- a/src/quality/compliance.rs
+++ b/src/quality/compliance.rs
@@ -669,6 +669,33 @@ impl ComplianceResult {
     }
 }
 
+/// Calibration check identifiers for `ComplianceChecker::class_severity()`.
+///
+/// Each variant corresponds to a row in the CRA-P3.2 calibration table —
+/// the severity that a given finding should produce *given* the product
+/// class (Default → Critical) and conformity-assessment route. `None`
+/// from `class_severity()` means "this check is not applicable for the
+/// given class" (typically Default doesn't carry EUCC/attestation
+/// expectations).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ClassCheck {
+    /// Vendor-supplied hash coverage below threshold ([PRE-7-RQ-07-RE]).
+    VendorHashCoverage,
+    /// EOL component present in SBOM.
+    EolComponents,
+    /// Dependency cycles detected.
+    Cycles,
+    /// Annex VII Declaration-of-Conformity reference missing.
+    DocReference,
+    /// EUCC (Common Criteria) reference missing.
+    EuccReference,
+    /// PSIRT URL / 24h / 72h / ENISA channel missing (Art. 14).
+    Psirt,
+    /// Conformity-assessment-module attestation reference missing
+    /// (only meaningful on Module B+C / H / EUCC routes).
+    ModuleAttestation,
+}
+
 /// Compliance checker for SBOMs
 #[derive(Debug, Clone)]
 pub struct ComplianceChecker {
@@ -679,6 +706,10 @@ pub struct ComplianceChecker {
     /// carry. When set, document-metadata checks consult the sidecar before
     /// emitting "missing" violations.
     sidecar: Option<crate::model::CraSidecarMetadata>,
+    /// Optional CRA Annex III/IV product class. Drives severity calibration
+    /// for `class_severity()` (vendor-hash, EOL, cycles, DoC, EUCC, PSIRT,
+    /// attestation). When `None`, behaves as `CraProductClass::Default`.
+    product_class: Option<crate::model::CraProductClass>,
 }
 
 impl ComplianceChecker {
@@ -688,6 +719,7 @@ impl ComplianceChecker {
         Self {
             level,
             sidecar: None,
+            product_class: None,
         }
     }
 
@@ -701,6 +733,120 @@ impl ComplianceChecker {
     pub fn with_sidecar(mut self, sidecar: crate::model::CraSidecarMetadata) -> Self {
         self.sidecar = Some(sidecar);
         self
+    }
+
+    /// Set the CRA Annex III/IV product class explicitly.
+    ///
+    /// Sidecar `productClass` (when set on the attached sidecar) wins over
+    /// this; resolve via [`Self::effective_product_class`].
+    #[must_use]
+    pub const fn with_product_class(mut self, class: crate::model::CraProductClass) -> Self {
+        self.product_class = Some(class);
+        self
+    }
+
+    /// Resolve the effective product class:
+    /// 1. sidecar `productClass` if present,
+    /// 2. otherwise `with_product_class` value,
+    /// 3. otherwise `CraProductClass::Default`.
+    #[must_use]
+    pub fn effective_product_class(&self) -> crate::model::CraProductClass {
+        self.sidecar
+            .as_ref()
+            .and_then(|s| s.product_class)
+            .or(self.product_class)
+            .unwrap_or(crate::model::CraProductClass::Default)
+    }
+
+    /// Resolve the effective conformity-assessment route. Falls back to
+    /// `CraProductClass::default_route()` when the sidecar doesn't pin one.
+    #[must_use]
+    pub fn effective_route(&self) -> crate::model::ConformityRoute {
+        self.sidecar
+            .as_ref()
+            .and_then(|s| s.conformity_assessment_route)
+            .unwrap_or_else(|| self.effective_product_class().default_route())
+    }
+
+    /// CRA-P3.2 calibration table — severity for a given check at the
+    /// effective product class. Returns `None` when the check does not
+    /// apply for that class (e.g., EUCC reference at `Default`).
+    #[must_use]
+    pub fn class_severity(&self, check: ClassCheck) -> Option<ViolationSeverity> {
+        use crate::model::CraProductClass as C;
+        let class = self.effective_product_class();
+        match (check, class) {
+            // Vendor-hash coverage threshold escalation handled by
+            // `vendor_hash_thresholds()`; this row reflects the *severity*
+            // emitted when the threshold is breached.
+            (ClassCheck::VendorHashCoverage, C::Default | C::ImportantClass1) => {
+                Some(ViolationSeverity::Warning)
+            }
+            (ClassCheck::VendorHashCoverage, C::ImportantClass2 | C::Critical) => {
+                Some(ViolationSeverity::Error)
+            }
+
+            (ClassCheck::EolComponents, C::Default | C::ImportantClass1) => {
+                Some(ViolationSeverity::Warning)
+            }
+            (ClassCheck::EolComponents, C::ImportantClass2 | C::Critical) => {
+                Some(ViolationSeverity::Error)
+            }
+
+            (ClassCheck::Cycles, C::Default | C::ImportantClass1) => {
+                Some(ViolationSeverity::Warning)
+            }
+            (ClassCheck::Cycles, C::ImportantClass2 | C::Critical) => {
+                Some(ViolationSeverity::Error)
+            }
+
+            (ClassCheck::DocReference, C::Default) => Some(ViolationSeverity::Info),
+            (ClassCheck::DocReference, C::ImportantClass1) => Some(ViolationSeverity::Warning),
+            (ClassCheck::DocReference, C::ImportantClass2 | C::Critical) => {
+                Some(ViolationSeverity::Error)
+            }
+
+            (ClassCheck::EuccReference, C::Default | C::ImportantClass1) => None,
+            (ClassCheck::EuccReference, C::ImportantClass2) => Some(ViolationSeverity::Info),
+            (ClassCheck::EuccReference, C::Critical) => Some(ViolationSeverity::Error),
+
+            (ClassCheck::Psirt, C::Default | C::ImportantClass1) => Some(ViolationSeverity::Warning),
+            (ClassCheck::Psirt, C::ImportantClass2 | C::Critical) => Some(ViolationSeverity::Error),
+
+            (ClassCheck::ModuleAttestation, C::Default) => None,
+            (ClassCheck::ModuleAttestation, C::ImportantClass1) => Some(ViolationSeverity::Warning),
+            (ClassCheck::ModuleAttestation, C::ImportantClass2 | C::Critical) => {
+                Some(ViolationSeverity::Error)
+            }
+        }
+    }
+
+    /// Vendor-hash coverage threshold (single-stage) below which a violation
+    /// fires. The severity is `class_severity(VendorHashCoverage)`. Values:
+    /// Default 50%, Important-1 80%, Important-2 80%, Critical 100%.
+    #[must_use]
+    pub fn vendor_hash_threshold(&self) -> f64 {
+        use crate::model::CraProductClass as C;
+        match self.effective_product_class() {
+            C::Default => 0.50,
+            C::ImportantClass1 | C::ImportantClass2 => 0.80,
+            C::Critical => 1.00,
+        }
+    }
+
+    /// Whether a CRA product class has been explicitly configured (either
+    /// via `with_product_class()` or the attached sidecar). Used by the
+    /// per-check calibration to decide whether to override phase-based
+    /// defaults — when no class is set, existing phase-driven behavior is
+    /// preserved verbatim for backwards compatibility.
+    #[must_use]
+    pub fn has_explicit_product_class(&self) -> bool {
+        self.product_class.is_some()
+            || self
+                .sidecar
+                .as_ref()
+                .and_then(|s| s.product_class)
+                .is_some()
     }
 
     /// Check an SBOM for compliance
@@ -1054,10 +1200,16 @@ impl ComplianceChecker {
                 .as_ref()
                 .is_some_and(|s| s.ce_marking_reference.is_some());
             if !has_conformity_ref && !sidecar_has_doc_ref {
+                let severity = self
+                    .class_severity(ClassCheck::DocReference)
+                    .unwrap_or(ViolationSeverity::Info);
                 violations.push(Violation {
-                    severity: ViolationSeverity::Info,
+                    severity,
                     category: ViolationCategory::DocumentMetadata,
-                    message: "[CRA Annex VII] Consider including a reference to the EU Declaration of Conformity (attestation or certification external reference)".to_string(),
+                    message: format!(
+                        "[CRA Annex VII] Missing reference to the EU Declaration of Conformity (attestation or certification external reference) for product class {}",
+                        self.effective_product_class().label()
+                    ),
                     element: None,
                     requirement: "CRA Annex VII: EU Declaration of Conformity reference".to_string(),
                     standard_refs: Vec::new(),
@@ -1642,17 +1794,42 @@ impl ComplianceChecker {
             if let Some(coverage) = metrics.vendor_hash_coverage() {
                 #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
                 let pct = (coverage * 100.0).round() as usize;
-                let (severity, threshold_msg) = match self.level {
-                    ComplianceLevel::CraPhase2 if coverage < 0.50 => {
-                        (ViolationSeverity::Error, "below 50% threshold")
+
+                // Class-driven calibration overrides phase-based defaults
+                // when the operator pinned a CRA product class. Otherwise,
+                // fall through to the original Phase1/Phase2 thresholds for
+                // backwards compatibility.
+                let (severity, threshold_msg) = if self.has_explicit_product_class() {
+                    let threshold = self.vendor_hash_threshold();
+                    if coverage < threshold {
+                        let sev = self
+                            .class_severity(ClassCheck::VendorHashCoverage)
+                            .unwrap_or(ViolationSeverity::Warning);
+                        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+                        let thr_pct = (threshold * 100.0).round() as usize;
+                        (
+                            sev,
+                            format!(
+                                "below {thr_pct}% threshold for product class {}",
+                                self.effective_product_class().label()
+                            ),
+                        )
+                    } else {
+                        (ViolationSeverity::Info, String::new())
                     }
-                    ComplianceLevel::CraPhase2 if coverage < 0.80 => {
-                        (ViolationSeverity::Warning, "below 80% threshold")
+                } else {
+                    match self.level {
+                        ComplianceLevel::CraPhase2 if coverage < 0.50 => {
+                            (ViolationSeverity::Error, "below 50% threshold".to_string())
+                        }
+                        ComplianceLevel::CraPhase2 if coverage < 0.80 => {
+                            (ViolationSeverity::Warning, "below 80% threshold".to_string())
+                        }
+                        ComplianceLevel::CraPhase1 if coverage < 0.50 => {
+                            (ViolationSeverity::Warning, "below 50% threshold".to_string())
+                        }
+                        _ => (ViolationSeverity::Info, String::new()),
                     }
-                    ComplianceLevel::CraPhase1 if coverage < 0.50 => {
-                        (ViolationSeverity::Warning, "below 50% threshold")
-                    }
-                    _ => (ViolationSeverity::Info, ""),
                 };
                 if !threshold_msg.is_empty() {
                     violations.push(Violation {
@@ -1747,8 +1924,14 @@ impl ComplianceChecker {
             })
             .count();
         if eol_count > 0 {
+            let severity = if self.has_explicit_product_class() {
+                self.class_severity(ClassCheck::EolComponents)
+                    .unwrap_or(ViolationSeverity::Warning)
+            } else {
+                ViolationSeverity::Warning
+            };
             violations.push(Violation {
-                severity: ViolationSeverity::Warning,
+                severity,
                 category: ViolationCategory::SecurityInfo,
                 message: format!(
                     "[CRA Art. 13(8)] {eol_count} component(s) have reached end-of-life and no longer receive security updates"
@@ -1838,6 +2021,96 @@ impl ComplianceChecker {
                 });
             }
         }
+
+        // CRA-P3.2: Class-conditional EUCC and Module-attestation references
+        // (only fire when the operator pinned a product class — preserves
+        // pre-P3.2 behavior for callers that didn't opt in).
+        if self.has_explicit_product_class() {
+            self.check_class_eucc_reference(sbom, violations);
+            self.check_class_module_attestation(sbom, violations);
+        }
+    }
+
+    /// EUCC (Common Criteria) certificate / Target-of-Evaluation reference.
+    ///
+    /// `ImportantClass2` → Info if missing (recommended); `Critical` → Error
+    /// if missing (Annex IV mandates EUCC). Lower classes: skipped.
+    fn check_class_eucc_reference(&self, sbom: &NormalizedSbom, violations: &mut Vec<Violation>) {
+        let Some(severity) = self.class_severity(ClassCheck::EuccReference) else {
+            return;
+        };
+        let has_eucc_ref = sbom.components.values().any(|comp| {
+            comp.external_refs.iter().any(|r| {
+                let url_lower = r.url.to_lowercase();
+                matches!(
+                    r.ref_type,
+                    crate::model::ExternalRefType::Certification
+                        | crate::model::ExternalRefType::Attestation
+                ) && (url_lower.contains("eucc")
+                    || url_lower.contains("common-criteria")
+                    || url_lower.contains("commoncriteria"))
+            })
+        });
+        if !has_eucc_ref {
+            violations.push(Violation {
+                severity,
+                category: ViolationCategory::DocumentMetadata,
+                message: format!(
+                    "[CRA Annex IV / EUCC] Product class {} requires (or strongly recommends) a reference to a Common Criteria / EUCC certificate or Target of Evaluation",
+                    self.effective_product_class().label()
+                ),
+                element: None,
+                requirement: "CRA Annex IV: EUCC reference (Common Criteria certificate)"
+                    .to_string(),
+                standard_refs: Vec::new(),
+            });
+        }
+    }
+
+    /// Conformity-assessment-module attestation reference.
+    ///
+    /// Module B+C / H / EUCC routes require an attestation external reference
+    /// (notified-body certificate, QA-system certification, EUCC certificate).
+    /// Module A (self-assessment) is skipped. Severity scales with class.
+    fn check_class_module_attestation(
+        &self,
+        sbom: &NormalizedSbom,
+        violations: &mut Vec<Violation>,
+    ) {
+        use crate::model::ConformityRoute as R;
+        let Some(severity) = self.class_severity(ClassCheck::ModuleAttestation) else {
+            return;
+        };
+        let route = self.effective_route();
+        if matches!(route, R::ModuleA) {
+            return; // Module A self-assessment doesn't require external attestation
+        }
+        let has_attestation = sbom.components.values().any(|comp| {
+            comp.external_refs.iter().any(|r| {
+                matches!(
+                    r.ref_type,
+                    crate::model::ExternalRefType::Attestation
+                        | crate::model::ExternalRefType::Certification
+                )
+            })
+        });
+        if !has_attestation {
+            violations.push(Violation {
+                severity,
+                category: ViolationCategory::DocumentMetadata,
+                message: format!(
+                    "[CRA Annex VIII / {}] No attestation or certification external reference found — required for the {} conformity route",
+                    route.label(),
+                    route.label()
+                ),
+                element: None,
+                requirement: format!(
+                    "CRA Annex VIII: {} attestation reference",
+                    route.label()
+                ),
+                standard_refs: Vec::new(),
+            });
+        }
     }
 
     /// CRA Article 14 reporting-readiness check.
@@ -1866,8 +2139,16 @@ impl ComplianceChecker {
                 .expect("hard-coded deadline literal is RFC-3339")
                 .into();
         let art_14_active = now >= deadline;
+        // Severity escalation by product class: when class is explicitly set
+        // and ≥ ImportantClass2, post-deadline missing channels become Errors
+        // rather than Warnings ([CRA-P3.2 calibration]).
         let post_deadline_severity = if art_14_active {
-            ViolationSeverity::Warning
+            if self.has_explicit_product_class() {
+                self.class_severity(ClassCheck::Psirt)
+                    .unwrap_or(ViolationSeverity::Warning)
+            } else {
+                ViolationSeverity::Warning
+            }
         } else {
             ViolationSeverity::Info
         };

--- a/src/quality/metrics.rs
+++ b/src/quality/metrics.rs
@@ -202,6 +202,15 @@ pub struct HashQualityMetrics {
     pub algorithm_distribution: BTreeMap<String, usize>,
     /// Total hash entries across all components
     pub total_hashes: usize,
+    /// Vendor-supplied components — supplier or author set AND a non-synthetic
+    /// canonical identifier (PURL/CPE/SWHID/SWID).
+    /// Tracks how many such "upstream" components exist, used to verify
+    /// CRA prEN 40000-1-3 `[PRE-7-RQ-07-RE]` (carry-through of vendor hashes).
+    pub vendor_components_total: usize,
+    /// Vendor components that carry at least one hash entry.
+    pub vendor_components_with_hash: usize,
+    /// Vendor components that carry at least one strong hash (SHA-256+).
+    pub vendor_components_with_strong_hash: usize,
 }
 
 impl HashQualityMetrics {
@@ -213,8 +222,23 @@ impl HashQualityMetrics {
         let mut with_weak_only = 0;
         let mut distribution: BTreeMap<String, usize> = BTreeMap::new();
         let mut total_hashes = 0;
+        let mut vendor_total = 0;
+        let mut vendor_with_hash = 0;
+        let mut vendor_with_strong = 0;
 
         for comp in sbom.components.values() {
+            // Vendor-component classification (independent of hash presence)
+            let is_vendor = (comp.supplier.is_some() || comp.author.is_some())
+                && !matches!(
+                    comp.canonical_id.source(),
+                    crate::model::IdSource::Synthetic
+                        | crate::model::IdSource::FormatSpecific
+                        | crate::model::IdSource::NameVersion
+                );
+            if is_vendor {
+                vendor_total += 1;
+            }
+
             if comp.hashes.is_empty() {
                 continue;
             }
@@ -240,6 +264,13 @@ impl HashQualityMetrics {
             } else if has_weak {
                 with_weak_only += 1;
             }
+
+            if is_vendor {
+                vendor_with_hash += 1;
+                if has_strong {
+                    vendor_with_strong += 1;
+                }
+            }
         }
 
         Self {
@@ -248,6 +279,36 @@ impl HashQualityMetrics {
             components_with_weak_only: with_weak_only,
             algorithm_distribution: distribution,
             total_hashes,
+            vendor_components_total: vendor_total,
+            vendor_components_with_hash: vendor_with_hash,
+            vendor_components_with_strong_hash: vendor_with_strong,
+        }
+    }
+
+    /// Vendor-hash coverage (fraction of vendor-supplied components carrying
+    /// at least one hash). Returns `None` when there are no vendor components,
+    /// so the caller can suppress the violation rather than divide by zero.
+    #[must_use]
+    pub fn vendor_hash_coverage(&self) -> Option<f64> {
+        if self.vendor_components_total == 0 {
+            None
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            Some(self.vendor_components_with_hash as f64 / self.vendor_components_total as f64)
+        }
+    }
+
+    /// Vendor strong-hash coverage (fraction with at least one SHA-256+ hash).
+    #[must_use]
+    pub fn vendor_strong_hash_coverage(&self) -> Option<f64> {
+        if self.vendor_components_total == 0 {
+            None
+        } else {
+            #[allow(clippy::cast_precision_loss)]
+            Some(
+                self.vendor_components_with_strong_hash as f64
+                    / self.vendor_components_total as f64,
+            )
         }
     }
 
@@ -1929,6 +1990,9 @@ mod tests {
             components_with_weak_only: 0,
             algorithm_distribution: BTreeMap::new(),
             total_hashes: 0,
+            vendor_components_total: 0,
+            vendor_components_with_hash: 0,
+            vendor_components_with_strong_hash: 0,
         };
         assert_eq!(metrics.quality_score(0), 0.0);
     }
@@ -1941,6 +2005,9 @@ mod tests {
             components_with_weak_only: 0,
             algorithm_distribution: BTreeMap::new(),
             total_hashes: 10,
+            vendor_components_total: 0,
+            vendor_components_with_hash: 0,
+            vendor_components_with_strong_hash: 0,
         };
         assert_eq!(metrics.quality_score(10), 100.0);
     }
@@ -1953,6 +2020,9 @@ mod tests {
             components_with_weak_only: 10,
             algorithm_distribution: BTreeMap::new(),
             total_hashes: 10,
+            vendor_components_total: 0,
+            vendor_components_with_hash: 0,
+            vendor_components_with_strong_hash: 0,
         };
         // 60 (any) + 0 (strong) - 10 (weak penalty) = 50
         assert_eq!(metrics.quality_score(10), 50.0);

--- a/src/quality/mod.rs
+++ b/src/quality/mod.rs
@@ -33,8 +33,8 @@ mod metrics;
 mod scorer;
 
 pub use compliance::{
-    ComplianceChecker, ComplianceLevel, ComplianceResult, Violation, ViolationCategory,
-    ViolationSeverity,
+    ComplianceChecker, ComplianceLevel, ComplianceResult, CraPhase, StandardKind, StandardRef,
+    Violation, ViolationCategory, ViolationSeverity,
 };
 pub use metrics::{
     AuditabilityMetrics, CompletenessMetrics, ComplexityFactors, ComplexityLevel,

--- a/src/quality/mod.rs
+++ b/src/quality/mod.rs
@@ -33,8 +33,9 @@ mod metrics;
 mod scorer;
 
 pub use compliance::{
-    ClassCheck, ComplianceChecker, ComplianceLevel, ComplianceResult, CraPhase, StandardKind,
-    StandardRef, Violation, ViolationCategory, ViolationSeverity,
+    ClassCheck, ComplianceChecker, ComplianceLevel, ComplianceResult, ConformityAssessmentSummary,
+    ConformityEvidence, CraPhase, StandardKind, StandardRef, Violation, ViolationCategory,
+    ViolationSeverity,
 };
 pub use metrics::{
     AuditabilityMetrics, CompletenessMetrics, ComplexityFactors, ComplexityLevel,

--- a/src/quality/mod.rs
+++ b/src/quality/mod.rs
@@ -33,8 +33,8 @@ mod metrics;
 mod scorer;
 
 pub use compliance::{
-    ComplianceChecker, ComplianceLevel, ComplianceResult, CraPhase, StandardKind, StandardRef,
-    Violation, ViolationCategory, ViolationSeverity,
+    ClassCheck, ComplianceChecker, ComplianceLevel, ComplianceResult, CraPhase, StandardKind,
+    StandardRef, Violation, ViolationCategory, ViolationSeverity,
 };
 pub use metrics::{
     AuditabilityMetrics, CompletenessMetrics, ComplexityFactors, ComplexityLevel,

--- a/src/quality/scorer.rs
+++ b/src/quality/scorer.rs
@@ -420,10 +420,7 @@ impl QualityScorer {
     /// calibration when the embedded compliance check runs under
     /// `ScoringProfile::Cra`). Sidecar `productClass` overrides this.
     #[must_use]
-    pub const fn with_cra_product_class(
-        mut self,
-        class: crate::model::CraProductClass,
-    ) -> Self {
+    pub const fn with_cra_product_class(mut self, class: crate::model::CraProductClass) -> Self {
         self.cra_product_class = Some(class);
         self
     }

--- a/src/quality/scorer.rs
+++ b/src/quality/scorer.rs
@@ -30,6 +30,9 @@ pub enum ScoringProfile {
     LicenseCompliance,
     /// EU Cyber Resilience Act - emphasizes supply chain transparency and security disclosure
     Cra,
+    /// BSI TR-03183-2 (German national CRA-aligned SBOM technical guideline).
+    /// Stricter than CRA on hashes and identifiers; uses CRA-style weights.
+    BsiTr03183_2,
     /// Comprehensive - all aspects equally weighted
     Comprehensive,
     /// CBOM - cryptographic BOM focus (algorithm strength, PQC readiness, key/cert lifecycle)
@@ -45,6 +48,7 @@ impl ScoringProfile {
             Self::Standard | Self::LicenseCompliance => ComplianceLevel::Standard,
             Self::Security => ComplianceLevel::NtiaMinimum,
             Self::Cra => ComplianceLevel::CraPhase2,
+            Self::BsiTr03183_2 => ComplianceLevel::BsiTr03183_2,
             Self::Comprehensive => ComplianceLevel::Comprehensive,
             Self::Cbom => ComplianceLevel::Comprehensive,
         }
@@ -104,6 +108,18 @@ impl ScoringProfile {
                 dependencies: 0.12,
                 integrity: 0.12,
                 provenance: 0.15,
+                lifecycle: 0.08,
+            },
+            // BSI TR-03183-2 emphasises identifiers and integrity (mandatory hashes)
+            // even more than CRA, while still tracking provenance/dependencies.
+            Self::BsiTr03183_2 => ScoringWeights {
+                completeness: 0.10,
+                identifiers: 0.22,
+                licenses: 0.08,
+                vulnerabilities: 0.10,
+                dependencies: 0.12,
+                integrity: 0.18,
+                provenance: 0.12,
                 lifecycle: 0.08,
             },
             Self::Comprehensive => ScoringWeights {
@@ -365,6 +381,10 @@ pub struct QualityScorer {
     profile: ScoringProfile,
     /// Completeness weights
     completeness_weights: CompletenessWeights,
+    /// Optional CRA sidecar metadata; when set, the embedded compliance check
+    /// (used to drive recommendations under `ScoringProfile::Cra`) consults
+    /// the sidecar for fields the SBOM doesn't carry.
+    cra_sidecar: Option<crate::model::CraSidecarMetadata>,
 }
 
 impl QualityScorer {
@@ -374,6 +394,7 @@ impl QualityScorer {
         Self {
             profile,
             completeness_weights: CompletenessWeights::default(),
+            cra_sidecar: None,
         }
     }
 
@@ -381,6 +402,13 @@ impl QualityScorer {
     #[must_use]
     pub const fn with_completeness_weights(mut self, weights: CompletenessWeights) -> Self {
         self.completeness_weights = weights;
+        self
+    }
+
+    /// Attach CRA sidecar metadata for the embedded compliance check.
+    #[must_use]
+    pub fn with_cra_sidecar(mut self, sidecar: crate::model::CraSidecarMetadata) -> Self {
+        self.cra_sidecar = Some(sidecar);
         self
     }
 
@@ -477,8 +505,11 @@ impl QualityScorer {
             total_components,
         );
 
-        // Run compliance check
-        let compliance_checker = ComplianceChecker::new(self.profile.compliance_level());
+        // Run compliance check (with sidecar if configured)
+        let compliance_checker = match self.cra_sidecar.clone() {
+            Some(sc) => ComplianceChecker::new(self.profile.compliance_level()).with_sidecar(sc),
+            None => ComplianceChecker::new(self.profile.compliance_level()),
+        };
         let compliance = compliance_checker.check(sbom);
 
         // Generate recommendations

--- a/src/quality/scorer.rs
+++ b/src/quality/scorer.rs
@@ -385,6 +385,9 @@ pub struct QualityScorer {
     /// (used to drive recommendations under `ScoringProfile::Cra`) consults
     /// the sidecar for fields the SBOM doesn't carry.
     cra_sidecar: Option<crate::model::CraSidecarMetadata>,
+    /// Optional CRA Annex III/IV product class. Sidecar `productClass` (when
+    /// present on `cra_sidecar`) wins over this value at check time.
+    cra_product_class: Option<crate::model::CraProductClass>,
 }
 
 impl QualityScorer {
@@ -395,6 +398,7 @@ impl QualityScorer {
             profile,
             completeness_weights: CompletenessWeights::default(),
             cra_sidecar: None,
+            cra_product_class: None,
         }
     }
 
@@ -409,6 +413,18 @@ impl QualityScorer {
     #[must_use]
     pub fn with_cra_sidecar(mut self, sidecar: crate::model::CraSidecarMetadata) -> Self {
         self.cra_sidecar = Some(sidecar);
+        self
+    }
+
+    /// Set the CRA Annex III/IV product class explicitly (for severity
+    /// calibration when the embedded compliance check runs under
+    /// `ScoringProfile::Cra`). Sidecar `productClass` overrides this.
+    #[must_use]
+    pub const fn with_cra_product_class(
+        mut self,
+        class: crate::model::CraProductClass,
+    ) -> Self {
+        self.cra_product_class = Some(class);
         self
     }
 
@@ -505,11 +521,14 @@ impl QualityScorer {
             total_components,
         );
 
-        // Run compliance check (with sidecar if configured)
-        let compliance_checker = match self.cra_sidecar.clone() {
-            Some(sc) => ComplianceChecker::new(self.profile.compliance_level()).with_sidecar(sc),
-            None => ComplianceChecker::new(self.profile.compliance_level()),
-        };
+        // Run compliance check (with sidecar + product class if configured)
+        let mut compliance_checker = ComplianceChecker::new(self.profile.compliance_level());
+        if let Some(sc) = self.cra_sidecar.clone() {
+            compliance_checker = compliance_checker.with_sidecar(sc);
+        }
+        if let Some(c) = self.cra_product_class {
+            compliance_checker = compliance_checker.with_product_class(c);
+        }
         let compliance = compliance_checker.check(sbom);
 
         // Generate recommendations

--- a/src/reports/csaf.rs
+++ b/src/reports/csaf.rs
@@ -52,19 +52,13 @@ impl Default for CsafEmitOptions {
 }
 
 /// Emit a CSAF v2.0 VEX document from `sbom` as pretty-printed JSON.
-pub fn emit_csaf(
-    sbom: &NormalizedSbom,
-    options: &CsafEmitOptions,
-) -> Result<String, ReportError> {
+pub fn emit_csaf(sbom: &NormalizedSbom, options: &CsafEmitOptions) -> Result<String, ReportError> {
     let doc = build_csaf_document(sbom, options);
-    serde_json::to_string_pretty(&doc)
-        .map_err(|e| ReportError::SerializationError(e.to_string()))
+    serde_json::to_string_pretty(&doc).map_err(|e| ReportError::SerializationError(e.to_string()))
 }
 
 fn build_csaf_document(sbom: &NormalizedSbom, opt: &CsafEmitOptions) -> CsafDocOut {
-    let now_rfc3339 = chrono::Utc::now()
-        .format("%Y-%m-%dT%H:%M:%SZ")
-        .to_string();
+    let now_rfc3339 = chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string();
 
     // Build product_tree and a (component_id) → product_id index.
     let mut product_index: BTreeMap<String, String> = BTreeMap::new();
@@ -150,13 +144,20 @@ fn build_csaf_document(sbom: &NormalizedSbom, opt: &CsafEmitOptions) -> CsafDocO
             .document
             .name
             .clone()
-            .or_else(|| sbom.primary_component_id.as_ref().map(|c| c.value().to_string()))
+            .or_else(|| {
+                sbom.primary_component_id
+                    .as_ref()
+                    .map(|c| c.value().to_string())
+            })
             .unwrap_or_else(|| "SBOM".to_string());
         format!("VEX advisory for {primary}")
     });
 
     let document_id = opt.document_id.clone().unwrap_or_else(|| {
-        format!("sbom-tools-vex-{}", chrono::Utc::now().format("%Y%m%d%H%M%S"))
+        format!(
+            "sbom-tools-vex-{}",
+            chrono::Utc::now().format("%Y%m%d%H%M%S")
+        )
     });
 
     CsafDocOut {
@@ -197,9 +198,7 @@ fn build_csaf_document(sbom: &NormalizedSbom, opt: &CsafEmitOptions) -> CsafDocO
                 },
             },
         },
-        product_tree: CsafProductTreeOut {
-            full_product_names,
-        },
+        product_tree: CsafProductTreeOut { full_product_names },
         vulnerabilities,
     }
 }
@@ -400,8 +399,7 @@ mod tests {
         .iter()
         .enumerate()
         {
-            let mut c =
-                Component::new(format!("c{i}"), format!("c{i}@1.0"));
+            let mut c = Component::new(format!("c{i}"), format!("c{i}@1.0"));
             c.identifiers.purl = Some(format!("pkg:cargo/c{i}@1.0"));
             let mut v =
                 VulnerabilityRef::new("CVE-2024-99999".to_string(), VulnerabilitySource::Cve);
@@ -441,8 +439,7 @@ mod tests {
     fn emit_skips_components_without_purl() {
         let mut sbom = NormalizedSbom::default();
         let mut c = Component::new("noident".to_string(), "noident".to_string());
-        let mut v =
-            VulnerabilityRef::new("CVE-2024-12345".to_string(), VulnerabilitySource::Cve);
+        let mut v = VulnerabilityRef::new("CVE-2024-12345".to_string(), VulnerabilitySource::Cve);
         v.vex_status = Some(VexStatus::new(VexState::Affected));
         c.vulnerabilities.push(v);
         sbom.add_component(c);

--- a/src/reports/csaf.rs
+++ b/src/reports/csaf.rs
@@ -1,0 +1,465 @@
+//! CSAF v2.0 (ISO/IEC 20153:2025) advisory emitter.
+//!
+//! Produces a valid CSAF VEX document from an SBOM whose components carry
+//! `VexStatus` values (typically applied by `VexEnricher`). Closes the
+//! round-trip with [`crate::enrichment::vex::csaf`]: ingest a CSAF
+//! advisory → enrich SBOM → emit CSAF that yields the same VEX states
+//! when re-ingested.
+//!
+//! Mapping internal model → CSAF v2.0:
+//!
+//! - One product entry per SBOM component that carries a PURL (resolved
+//!   to `product_tree.full_product_names[].product_identification_helper.purl`).
+//! - One vulnerability entry per CVE/identifier; `product_status` lists
+//!   reflect the corresponding `VexState`:
+//!     - `Affected` → `known_affected`
+//!     - `NotAffected` → `known_not_affected`
+//!     - `Fixed` → `fixed`
+//!     - `UnderInvestigation` → `under_investigation`
+//!
+//! See <https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html>.
+
+use crate::model::{NormalizedSbom, VexState};
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+use super::ReportError;
+
+/// Configuration for the CSAF emitter. Operators that don't supply a
+/// publisher / title fall back to sbom-tools defaults so the output is
+/// still a valid CSAF document.
+#[derive(Debug, Clone)]
+pub struct CsafEmitOptions {
+    pub document_id: Option<String>,
+    pub publisher_name: Option<String>,
+    pub publisher_namespace: Option<String>,
+    pub publisher_category: Option<String>,
+    pub title: Option<String>,
+    pub category: Option<String>,
+}
+
+impl Default for CsafEmitOptions {
+    fn default() -> Self {
+        Self {
+            document_id: None,
+            publisher_name: None,
+            publisher_namespace: None,
+            publisher_category: None,
+            title: None,
+            category: None,
+        }
+    }
+}
+
+/// Emit a CSAF v2.0 VEX document from `sbom` as pretty-printed JSON.
+pub fn emit_csaf(
+    sbom: &NormalizedSbom,
+    options: &CsafEmitOptions,
+) -> Result<String, ReportError> {
+    let doc = build_csaf_document(sbom, options);
+    serde_json::to_string_pretty(&doc)
+        .map_err(|e| ReportError::SerializationError(e.to_string()))
+}
+
+fn build_csaf_document(sbom: &NormalizedSbom, opt: &CsafEmitOptions) -> CsafDocOut {
+    let now_rfc3339 = chrono::Utc::now()
+        .format("%Y-%m-%dT%H:%M:%SZ")
+        .to_string();
+
+    // Build product_tree and a (component_id) → product_id index.
+    let mut product_index: BTreeMap<String, String> = BTreeMap::new();
+    let mut full_product_names: Vec<CsafProductOut> = Vec::new();
+
+    let mut counter: usize = 0;
+    for (id, comp) in &sbom.components {
+        let Some(purl) = comp.identifiers.purl.as_ref() else {
+            continue;
+        };
+        counter += 1;
+        let pid = format!("CSAFPID-{counter:04}");
+        let display = match comp.version.as_deref() {
+            Some(v) => format!("{} {}", comp.name, v),
+            None => comp.name.clone(),
+        };
+        full_product_names.push(CsafProductOut {
+            product_id: pid.clone(),
+            name: display,
+            product_identification_helper: Some(CsafProductHelperOut {
+                purl: Some(purl.clone()),
+            }),
+        });
+        product_index.insert(id.value().to_string(), pid);
+    }
+
+    // Group vulnerability statuses by (vuln_id) → buckets.
+    let mut buckets: BTreeMap<String, ProductStatusBuckets> = BTreeMap::new();
+    for (id, comp) in &sbom.components {
+        let Some(pid) = product_index.get(id.value()) else {
+            continue;
+        };
+        for vuln in &comp.vulnerabilities {
+            let Some(vex) = vuln.vex_status.as_ref() else {
+                continue;
+            };
+            let entry = buckets.entry(vuln.id.clone()).or_default();
+            match vex.status {
+                VexState::Affected => entry.known_affected.push(pid.clone()),
+                VexState::NotAffected => entry.known_not_affected.push(pid.clone()),
+                VexState::Fixed => entry.fixed.push(pid.clone()),
+                VexState::UnderInvestigation => entry.under_investigation.push(pid.clone()),
+            }
+        }
+    }
+
+    let vulnerabilities: Vec<CsafVulnOut> = buckets
+        .into_iter()
+        .map(|(vuln_id, status)| {
+            let (cve, ids) = if vuln_id.starts_with("CVE-") {
+                (Some(vuln_id), Vec::new())
+            } else {
+                (
+                    None,
+                    vec![CsafVulnIdOut {
+                        system_name: identifier_system(&vuln_id).to_string(),
+                        text: vuln_id,
+                    }],
+                )
+            };
+            CsafVulnOut {
+                cve,
+                ids,
+                product_status: status.into_serializable(),
+            }
+        })
+        .collect();
+
+    let publisher_name = opt
+        .publisher_name
+        .clone()
+        .or_else(|| {
+            sbom.document
+                .creators
+                .iter()
+                .find(|c| matches!(c.creator_type, crate::model::CreatorType::Organization))
+                .map(|c| c.name.clone())
+        })
+        .unwrap_or_else(|| "sbom-tools".to_string());
+
+    let title = opt.title.clone().unwrap_or_else(|| {
+        let primary = sbom
+            .document
+            .name
+            .clone()
+            .or_else(|| sbom.primary_component_id.as_ref().map(|c| c.value().to_string()))
+            .unwrap_or_else(|| "SBOM".to_string());
+        format!("VEX advisory for {primary}")
+    });
+
+    let document_id = opt.document_id.clone().unwrap_or_else(|| {
+        format!("sbom-tools-vex-{}", chrono::Utc::now().format("%Y%m%d%H%M%S"))
+    });
+
+    CsafDocOut {
+        document: CsafHeaderOut {
+            csaf_version: "2.0".to_string(),
+            category: opt
+                .category
+                .clone()
+                .unwrap_or_else(|| "csaf_vex".to_string()),
+            publisher: CsafPublisherOut {
+                category: opt
+                    .publisher_category
+                    .clone()
+                    .unwrap_or_else(|| "vendor".to_string()),
+                name: publisher_name,
+                namespace: opt
+                    .publisher_namespace
+                    .clone()
+                    .unwrap_or_else(|| "https://example.invalid".to_string()),
+            },
+            title,
+            tracking: CsafTrackingOut {
+                id: document_id,
+                version: "1".to_string(),
+                status: "final".to_string(),
+                initial_release_date: now_rfc3339.clone(),
+                current_release_date: now_rfc3339.clone(),
+                revision_history: vec![CsafRevisionOut {
+                    number: "1".to_string(),
+                    date: now_rfc3339.clone(),
+                    summary: "Initial publication".to_string(),
+                }],
+                generator: CsafGeneratorOut {
+                    engine: CsafEngineOut {
+                        name: "sbom-tools".to_string(),
+                        version: env!("CARGO_PKG_VERSION").to_string(),
+                    },
+                },
+            },
+        },
+        product_tree: CsafProductTreeOut {
+            full_product_names,
+        },
+        vulnerabilities,
+    }
+}
+
+fn identifier_system(id: &str) -> &'static str {
+    if id.starts_with("GHSA-") {
+        "GHSA"
+    } else if id.starts_with("RUSTSEC-") {
+        "RUSTSEC"
+    } else if id.starts_with("OSV-") {
+        "OSV"
+    } else if id.starts_with("CVE-") {
+        "CVE"
+    } else {
+        "vendor"
+    }
+}
+
+#[derive(Default)]
+struct ProductStatusBuckets {
+    known_affected: Vec<String>,
+    known_not_affected: Vec<String>,
+    fixed: Vec<String>,
+    under_investigation: Vec<String>,
+}
+
+impl ProductStatusBuckets {
+    fn into_serializable(self) -> CsafProductStatusOut {
+        CsafProductStatusOut {
+            known_affected: self.known_affected,
+            known_not_affected: self.known_not_affected,
+            fixed: self.fixed,
+            under_investigation: self.under_investigation,
+        }
+    }
+}
+
+// ============================================================================
+// CSAF v2.0 serde structs (output side)
+// ============================================================================
+
+#[derive(Serialize)]
+struct CsafDocOut {
+    document: CsafHeaderOut,
+    product_tree: CsafProductTreeOut,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    vulnerabilities: Vec<CsafVulnOut>,
+}
+
+#[derive(Serialize)]
+struct CsafHeaderOut {
+    category: String,
+    csaf_version: String,
+    publisher: CsafPublisherOut,
+    title: String,
+    tracking: CsafTrackingOut,
+}
+
+#[derive(Serialize)]
+struct CsafPublisherOut {
+    category: String,
+    name: String,
+    namespace: String,
+}
+
+#[derive(Serialize)]
+struct CsafTrackingOut {
+    id: String,
+    initial_release_date: String,
+    current_release_date: String,
+    version: String,
+    status: String,
+    revision_history: Vec<CsafRevisionOut>,
+    generator: CsafGeneratorOut,
+}
+
+#[derive(Serialize)]
+struct CsafRevisionOut {
+    number: String,
+    date: String,
+    summary: String,
+}
+
+#[derive(Serialize)]
+struct CsafGeneratorOut {
+    engine: CsafEngineOut,
+}
+
+#[derive(Serialize)]
+struct CsafEngineOut {
+    name: String,
+    version: String,
+}
+
+#[derive(Serialize)]
+struct CsafProductTreeOut {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    full_product_names: Vec<CsafProductOut>,
+}
+
+#[derive(Serialize)]
+struct CsafProductOut {
+    product_id: String,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    product_identification_helper: Option<CsafProductHelperOut>,
+}
+
+#[derive(Serialize)]
+struct CsafProductHelperOut {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    purl: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CsafVulnOut {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cve: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    ids: Vec<CsafVulnIdOut>,
+    product_status: CsafProductStatusOut,
+}
+
+#[derive(Serialize)]
+struct CsafVulnIdOut {
+    system_name: String,
+    text: String,
+}
+
+#[derive(Serialize)]
+struct CsafProductStatusOut {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    known_affected: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    known_not_affected: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    fixed: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    under_investigation: Vec<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{
+        Component, NormalizedSbom, VexStatus, VulnerabilityRef, VulnerabilitySource,
+    };
+
+    fn sbom_with(purl: &str, name: &str, vuln: &str, state: VexState) -> NormalizedSbom {
+        let mut sbom = NormalizedSbom::default();
+        let mut c = Component::new(name.to_string(), name.to_string());
+        c.identifiers.purl = Some(purl.to_string());
+        let mut v = VulnerabilityRef::new(vuln.to_string(), VulnerabilitySource::Cve);
+        v.vex_status = Some(VexStatus::new(state));
+        c.vulnerabilities.push(v);
+        sbom.add_component(c);
+        sbom
+    }
+
+    #[test]
+    fn emit_minimal_csaf_document() {
+        let sbom = sbom_with(
+            "pkg:cargo/example@1.0.0",
+            "example",
+            "CVE-2024-12345",
+            VexState::Affected,
+        );
+        let csaf = emit_csaf(&sbom, &CsafEmitOptions::default()).expect("emit");
+        let json: serde_json::Value = serde_json::from_str(&csaf).expect("valid JSON");
+        assert_eq!(json["document"]["csaf_version"], "2.0");
+        assert_eq!(json["document"]["category"], "csaf_vex");
+        let products = json["product_tree"]["full_product_names"]
+            .as_array()
+            .unwrap();
+        assert_eq!(products.len(), 1);
+        assert_eq!(
+            products[0]["product_identification_helper"]["purl"],
+            "pkg:cargo/example@1.0.0"
+        );
+        let vulns = json["vulnerabilities"].as_array().unwrap();
+        assert_eq!(vulns.len(), 1);
+        assert_eq!(vulns[0]["cve"], "CVE-2024-12345");
+        let affected = vulns[0]["product_status"]["known_affected"]
+            .as_array()
+            .unwrap();
+        assert_eq!(affected.len(), 1);
+    }
+
+    #[test]
+    fn emit_groups_states_by_product_status() {
+        let mut sbom = NormalizedSbom::default();
+        for (i, state) in [
+            VexState::Affected,
+            VexState::NotAffected,
+            VexState::Fixed,
+            VexState::UnderInvestigation,
+        ]
+        .iter()
+        .enumerate()
+        {
+            let mut c =
+                Component::new(format!("c{i}"), format!("c{i}@1.0"));
+            c.identifiers.purl = Some(format!("pkg:cargo/c{i}@1.0"));
+            let mut v =
+                VulnerabilityRef::new("CVE-2024-99999".to_string(), VulnerabilitySource::Cve);
+            v.vex_status = Some(VexStatus::new(state.clone()));
+            c.vulnerabilities.push(v);
+            sbom.add_component(c);
+        }
+        let csaf = emit_csaf(&sbom, &CsafEmitOptions::default()).expect("emit");
+        let json: serde_json::Value = serde_json::from_str(&csaf).unwrap();
+        let status = &json["vulnerabilities"][0]["product_status"];
+        assert_eq!(status["known_affected"].as_array().unwrap().len(), 1);
+        assert_eq!(status["known_not_affected"].as_array().unwrap().len(), 1);
+        assert_eq!(status["fixed"].as_array().unwrap().len(), 1);
+        assert_eq!(status["under_investigation"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn emit_uses_ids_for_non_cve_identifiers() {
+        let sbom = sbom_with(
+            "pkg:cargo/example@1.0.0",
+            "example",
+            "GHSA-aaaa-bbbb-cccc",
+            VexState::Affected,
+        );
+        // The internal model defaults VulnerabilityRef::new to CVE source,
+        // but emit logic keys off the `vuln_id` string itself (CVE prefix).
+        let csaf = emit_csaf(&sbom, &CsafEmitOptions::default()).expect("emit");
+        let json: serde_json::Value = serde_json::from_str(&csaf).unwrap();
+        let vuln = &json["vulnerabilities"][0];
+        assert!(vuln["cve"].is_null(), "non-CVE id must not surface as cve");
+        let ids = vuln["ids"].as_array().unwrap();
+        assert_eq!(ids[0]["system_name"], "GHSA");
+        assert_eq!(ids[0]["text"], "GHSA-aaaa-bbbb-cccc");
+    }
+
+    #[test]
+    fn emit_skips_components_without_purl() {
+        let mut sbom = NormalizedSbom::default();
+        let mut c = Component::new("noident".to_string(), "noident".to_string());
+        let mut v =
+            VulnerabilityRef::new("CVE-2024-12345".to_string(), VulnerabilitySource::Cve);
+        v.vex_status = Some(VexStatus::new(VexState::Affected));
+        c.vulnerabilities.push(v);
+        sbom.add_component(c);
+
+        let csaf = emit_csaf(&sbom, &CsafEmitOptions::default()).expect("emit");
+        let json: serde_json::Value = serde_json::from_str(&csaf).unwrap();
+        assert!(
+            json["product_tree"]["full_product_names"]
+                .as_array()
+                .map_or(true, |a| a.is_empty()),
+            "components without PURL must not appear in product_tree"
+        );
+        // No products → no product_status entries → no vulnerabilities surfaced
+        assert!(
+            json["vulnerabilities"]
+                .as_array()
+                .map_or(true, |a| a.is_empty())
+        );
+    }
+}

--- a/src/reports/csaf.rs
+++ b/src/reports/csaf.rs
@@ -28,7 +28,7 @@ use super::ReportError;
 /// Configuration for the CSAF emitter. Operators that don't supply a
 /// publisher / title fall back to sbom-tools defaults so the output is
 /// still a valid CSAF document.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CsafEmitOptions {
     pub document_id: Option<String>,
     pub publisher_name: Option<String>,
@@ -36,19 +36,6 @@ pub struct CsafEmitOptions {
     pub publisher_category: Option<String>,
     pub title: Option<String>,
     pub category: Option<String>,
-}
-
-impl Default for CsafEmitOptions {
-    fn default() -> Self {
-        Self {
-            document_id: None,
-            publisher_name: None,
-            publisher_namespace: None,
-            publisher_category: None,
-            title: None,
-            category: None,
-        }
-    }
 }
 
 /// Emit a CSAF v2.0 VEX document from `sbom` as pretty-printed JSON.

--- a/src/reports/html.rs
+++ b/src/reports/html.rs
@@ -657,6 +657,7 @@ fn write_cra_compliance_diff_html(
     writeln!(html, "        </tbody>")?;
     writeln!(html, "    </table>")?;
 
+    write_conformity_assessment_html(html, new)?;
     write_reporting_channels_html(html, new)?;
 
     if !new.violations.is_empty() {
@@ -694,6 +695,7 @@ fn write_cra_compliance_view_html(
         result.error_count, result.warning_count
     )?;
 
+    write_conformity_assessment_html(html, result)?;
     write_reporting_channels_html(html, result)?;
 
     if !result.violations.is_empty() {
@@ -705,6 +707,48 @@ fn write_cra_compliance_view_html(
         html,
         "<a href=\"#top\" class=\"back-to-top\">Back to top</a>"
     )
+}
+
+/// Render a "Conformity assessment" subsection (CRA-P4.3) when a product
+/// class has been pinned. Surfaces the resolved Annex VIII route and a
+/// per-route evidence checklist. Mirrors the Markdown variant.
+fn write_conformity_assessment_html(
+    html: &mut String,
+    result: &ComplianceResult,
+) -> std::fmt::Result {
+    let Some(summary) = result.conformity_summary.as_ref() else {
+        return Ok(());
+    };
+    writeln!(html, "    <h3>Conformity Assessment (CRA Annex VIII)</h3>")?;
+    writeln!(
+        html,
+        "    <p><strong>Product class:</strong> {}<br><strong>Conformity route:</strong> {}</p>",
+        crate::reports::escape::escape_html(summary.product_class.name()),
+        crate::reports::escape::escape_html(summary.route.name())
+    )?;
+    writeln!(html, "    <table>")?;
+    writeln!(
+        html,
+        "        <thead><tr><th>Evidence</th><th>Status</th><th>Detail</th></tr></thead>"
+    )?;
+    writeln!(html, "        <tbody>")?;
+    for ev in &summary.evidence {
+        let status = if ev.satisfied {
+            "<span class=\"present\">Present</span>"
+        } else {
+            "<span class=\"missing\">Missing</span>"
+        };
+        writeln!(
+            html,
+            "            <tr><td>{}</td><td>{}</td><td>{}</td></tr>",
+            crate::reports::escape::escape_html(&ev.label),
+            status,
+            crate::reports::escape::escape_html(&ev.detail)
+        )?;
+    }
+    writeln!(html, "        </tbody>")?;
+    writeln!(html, "    </table>")?;
+    Ok(())
 }
 
 /// Render a "Reporting channels" subsection (CRA Art. 14 readiness).

--- a/src/reports/html.rs
+++ b/src/reports/html.rs
@@ -657,6 +657,8 @@ fn write_cra_compliance_diff_html(
     writeln!(html, "        </tbody>")?;
     writeln!(html, "    </table>")?;
 
+    write_reporting_channels_html(html, new)?;
+
     if !new.violations.is_empty() {
         writeln!(html, "    <h3>Violations (New SBOM)</h3>")?;
         write_violation_table_html(html, &new.violations)?;
@@ -692,6 +694,8 @@ fn write_cra_compliance_view_html(
         result.error_count, result.warning_count
     )?;
 
+    write_reporting_channels_html(html, result)?;
+
     if !result.violations.is_empty() {
         write_violation_table_html(html, &result.violations)?;
     }
@@ -701,6 +705,91 @@ fn write_cra_compliance_view_html(
         html,
         "<a href=\"#top\" class=\"back-to-top\">Back to top</a>"
     )
+}
+
+/// Render a "Reporting channels" subsection (CRA Art. 14 readiness).
+/// Same logic as the Markdown variant — see `markdown.rs::write_reporting_channels_md`.
+fn write_reporting_channels_html(html: &mut String, result: &ComplianceResult) -> std::fmt::Result {
+    if !result.level.is_cra() {
+        return Ok(());
+    }
+
+    let psirt = channel_status_html(result, "Art. 14: PSIRT");
+    let early = channel_status_html(result, "Art. 14(1)");
+    let incident = channel_status_html(result, "Art. 14(2)");
+    let enisa = channel_status_html(result, "Art. 14(7)");
+
+    writeln!(html, "    <h3>Reporting Channels (CRA Art. 14)</h3>")?;
+    writeln!(html, "    <table>")?;
+    writeln!(
+        html,
+        "        <thead><tr><th>Channel</th><th>Status</th></tr></thead>"
+    )?;
+    writeln!(html, "        <tbody>")?;
+    writeln!(
+        html,
+        "            <tr><td>PSIRT contact</td><td>{}</td></tr>",
+        psirt.html()
+    )?;
+    writeln!(
+        html,
+        "            <tr><td>24-hour early warning (Art. 14(1))</td><td>{}</td></tr>",
+        early.html()
+    )?;
+    writeln!(
+        html,
+        "            <tr><td>72-hour incident report (Art. 14(2))</td><td>{}</td></tr>",
+        incident.html()
+    )?;
+    writeln!(
+        html,
+        "            <tr><td>ENISA single reporting platform (Art. 14(7))</td><td>{}</td></tr>",
+        enisa.html()
+    )?;
+    writeln!(html, "        </tbody>")?;
+    writeln!(html, "    </table>")?;
+    writeln!(
+        html,
+        "    <p><em>Article 14 reporting obligations apply from 11 September 2026. \
+         Channels marked 'Missing (pre-deadline)' surface as Info; \
+         after the deadline they become Warnings.</em></p>"
+    )?;
+    Ok(())
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChannelStatusHtml {
+    Documented,
+    MissingPreDeadline,
+    MissingPostDeadline,
+}
+
+impl ChannelStatusHtml {
+    fn html(self) -> &'static str {
+        match self {
+            Self::Documented => "<span class=\"badge badge-low\">Documented</span>",
+            Self::MissingPreDeadline => {
+                "<span class=\"badge badge-medium\">Missing (pre-deadline 2026-09-11)</span>"
+            }
+            Self::MissingPostDeadline => "<span class=\"badge badge-critical\">Missing</span>",
+        }
+    }
+}
+
+fn channel_status_html(result: &ComplianceResult, needle: &str) -> ChannelStatusHtml {
+    match result
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains(needle))
+    {
+        None => ChannelStatusHtml::Documented,
+        Some(v) => match v.severity {
+            ViolationSeverity::Warning | ViolationSeverity::Error => {
+                ChannelStatusHtml::MissingPostDeadline
+            }
+            ViolationSeverity::Info => ChannelStatusHtml::MissingPreDeadline,
+        },
+    }
 }
 
 /// Aggregate violations by (severity, category, requirement) to reduce noise.
@@ -747,6 +836,7 @@ fn aggregate_violations_html(
                     )
                 }
             };
+            let standard_refs = format_standard_refs_html(&group[0].standard_refs);
             AggregatedViolationHtml {
                 severity: group[0].severity,
                 category: group[0].category.name(),
@@ -754,9 +844,23 @@ fn aggregate_violations_html(
                 message,
                 remediation: group[0].remediation_guidance(),
                 count: group.len(),
+                standard_refs,
             }
         })
         .collect()
+}
+
+/// Render `standard_refs` as a comma-separated cell of `<kind>: <id>` tokens.
+fn format_standard_refs_html(refs: &[crate::quality::StandardRef]) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    for (i, r) in refs.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        let _ = write!(out, "{}: {}", r.standard.label(), r.id);
+    }
+    out
 }
 
 struct AggregatedViolationHtml<'a> {
@@ -766,6 +870,7 @@ struct AggregatedViolationHtml<'a> {
     message: String,
     remediation: &'static str,
     count: usize,
+    standard_refs: String,
 }
 
 /// Write an HTML table of compliance violations (aggregated, with collapsible remediation).
@@ -779,6 +884,7 @@ fn write_violation_table_html(
     writeln!(html, "            <tr>")?;
     writeln!(html, "                <th>Severity</th>")?;
     writeln!(html, "                <th>Category</th>")?;
+    writeln!(html, "                <th>Standard refs</th>")?;
     writeln!(html, "                <th>Requirement</th>")?;
     writeln!(html, "                <th>Message</th>")?;
     writeln!(html, "                <th>Remediation</th>")?;
@@ -806,6 +912,11 @@ fn write_violation_table_html(
             "                <td><span class=\"badge {badge_class}\">{label}</span>{count_suffix}</td>"
         )?;
         writeln!(html, "                <td>{}</td>", escape_html(v.category))?;
+        writeln!(
+            html,
+            "                <td>{}</td>",
+            escape_html(&v.standard_refs)
+        )?;
         writeln!(
             html,
             "                <td>{}</td>",

--- a/src/reports/markdown.rs
+++ b/src/reports/markdown.rs
@@ -807,6 +807,8 @@ fn write_cra_compliance_diff(
     )?;
     writeln!(md)?;
 
+    // Conformity assessment (CRA Annex VIII) — only when product class pinned
+    write_conformity_assessment_md(md, new)?;
     // Reporting channels (CRA Art. 14) — derived from new SBOM violations
     write_reporting_channels_md(md, new)?;
 
@@ -838,12 +840,40 @@ fn write_cra_compliance_view(md: &mut String, result: &ComplianceResult) -> std:
         result.error_count, result.warning_count
     )?;
 
+    write_conformity_assessment_md(md, result)?;
     write_reporting_channels_md(md, result)?;
 
     if !result.violations.is_empty() {
         write_violation_table(md, &result.violations)?;
     }
 
+    Ok(())
+}
+
+/// Render a "Conformity assessment" subsection (CRA-P4.3) when a product
+/// class has been pinned. Surfaces the resolved Annex VIII route and a
+/// per-route evidence checklist.
+fn write_conformity_assessment_md(
+    md: &mut String,
+    result: &ComplianceResult,
+) -> std::fmt::Result {
+    let Some(summary) = result.conformity_summary.as_ref() else {
+        return Ok(());
+    };
+    writeln!(md, "### Conformity Assessment (CRA Annex VIII)\n")?;
+    writeln!(md, "- **Product class:** {}", summary.product_class.name())?;
+    writeln!(md, "- **Conformity route:** {}\n", summary.route.name())?;
+    writeln!(md, "| Evidence | Status | Detail |")?;
+    writeln!(md, "|----------|--------|--------|")?;
+    for ev in &summary.evidence {
+        let status = if ev.satisfied {
+            "✅ Present"
+        } else {
+            "❌ Missing"
+        };
+        writeln!(md, "| {} | {} | {} |", ev.label, status, ev.detail)?;
+    }
+    writeln!(md)?;
     Ok(())
 }
 

--- a/src/reports/markdown.rs
+++ b/src/reports/markdown.rs
@@ -807,6 +807,9 @@ fn write_cra_compliance_diff(
     )?;
     writeln!(md)?;
 
+    // Reporting channels (CRA Art. 14) — derived from new SBOM violations
+    write_reporting_channels_md(md, new)?;
+
     // Show new SBOM violations if any
     if !new.violations.is_empty() {
         writeln!(md, "### Violations (New SBOM)\n")?;
@@ -835,11 +838,94 @@ fn write_cra_compliance_view(md: &mut String, result: &ComplianceResult) -> std:
         result.error_count, result.warning_count
     )?;
 
+    write_reporting_channels_md(md, result)?;
+
     if !result.violations.is_empty() {
         write_violation_table(md, &result.violations)?;
     }
 
     Ok(())
+}
+
+/// Render a "Reporting channels" subsection (CRA Art. 14 readiness).
+///
+/// We can't see the raw sidecar from here, so the status of each channel is
+/// derived from the violation pattern produced by `check_article_14_readiness`:
+/// - violation absent → channel documented (only meaningful for CRA levels)
+/// - violation at Info → pre-deadline, channel still missing
+/// - violation at Warning → post-deadline, channel missing
+///
+/// Skipped entirely for non-CRA levels.
+fn write_reporting_channels_md(md: &mut String, result: &ComplianceResult) -> std::fmt::Result {
+    if !result.level.is_cra() {
+        return Ok(());
+    }
+
+    let psirt = channel_status(result, "Art. 14: PSIRT");
+    let early = channel_status(result, "Art. 14(1)");
+    let incident = channel_status(result, "Art. 14(2)");
+    let enisa = channel_status(result, "Art. 14(7)");
+
+    writeln!(md, "### Reporting Channels (CRA Art. 14)\n")?;
+    writeln!(md, "| Channel | Status |")?;
+    writeln!(md, "|---------|--------|")?;
+    writeln!(md, "| PSIRT contact | {} |", psirt.label())?;
+    writeln!(
+        md,
+        "| 24-hour early warning (Art. 14(1)) | {} |",
+        early.label()
+    )?;
+    writeln!(
+        md,
+        "| 72-hour incident report (Art. 14(2)) | {} |",
+        incident.label()
+    )?;
+    writeln!(
+        md,
+        "| ENISA single reporting platform (Art. 14(7)) | {} |",
+        enisa.label()
+    )?;
+    writeln!(md)?;
+    writeln!(
+        md,
+        "_Article 14 reporting obligations apply from 11 September 2026. \
+         Channels marked 'Missing (pre-deadline)' surface as Info; \
+         after the deadline they become Warnings._\n"
+    )?;
+    Ok(())
+}
+
+fn channel_status(result: &ComplianceResult, needle: &str) -> ChannelStatus {
+    match result
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains(needle))
+    {
+        None => ChannelStatus::Documented,
+        Some(v) => match v.severity {
+            ViolationSeverity::Warning | ViolationSeverity::Error => {
+                ChannelStatus::MissingPostDeadline
+            }
+            ViolationSeverity::Info => ChannelStatus::MissingPreDeadline,
+        },
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ChannelStatus {
+    Documented,
+    MissingPreDeadline,
+    MissingPostDeadline,
+}
+
+impl ChannelStatus {
+    fn label(self) -> &'static str {
+        match self {
+            Self::Documented => "Documented",
+            Self::MissingPreDeadline => "Missing (pre-deadline 2026-09-11)",
+            Self::MissingPostDeadline => "Missing",
+        }
+    }
 }
 
 /// Aggregate violations by (severity, category, requirement) to reduce noise.
@@ -865,6 +951,7 @@ fn aggregate_violations(violations: &[crate::quality::Violation]) -> Vec<Aggrega
     groups
         .into_values()
         .map(|group| {
+            let standard_refs = format_standard_refs(&group[0].standard_refs);
             if group.len() == 1 {
                 AggregatedViolation {
                     severity: group[0].severity,
@@ -873,6 +960,7 @@ fn aggregate_violations(violations: &[crate::quality::Violation]) -> Vec<Aggrega
                     message: group[0].message.clone(),
                     remediation: group[0].remediation_guidance(),
                     count: 1,
+                    standard_refs,
                 }
             } else {
                 let elements: Vec<&str> =
@@ -900,6 +988,7 @@ fn aggregate_violations(violations: &[crate::quality::Violation]) -> Vec<Aggrega
                     message,
                     remediation: group[0].remediation_guidance(),
                     count: group.len(),
+                    standard_refs,
                 }
             }
         })
@@ -913,6 +1002,22 @@ struct AggregatedViolation<'a> {
     message: String,
     remediation: &'static str,
     count: usize,
+    /// Pre-rendered "Standard refs" cell — `<kind>:<id>` joined by `, `.
+    /// Empty when the violation has no derived refs.
+    standard_refs: String,
+}
+
+/// Render a `Vec<StandardRef>` as a compact, table-safe cell.
+fn format_standard_refs(refs: &[crate::quality::StandardRef]) -> String {
+    use std::fmt::Write;
+    let mut out = String::new();
+    for (i, r) in refs.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        let _ = write!(out, "{}: {}", r.standard.label(), r.id);
+    }
+    out
 }
 
 /// Write a markdown table of CRA compliance violations (aggregated)
@@ -923,11 +1028,11 @@ fn write_violation_table(
     let aggregated = aggregate_violations(violations);
     writeln!(
         md,
-        "| Severity | Category | Requirement | Message | Remediation |"
+        "| Severity | Category | Standard refs | Requirement | Message | Remediation |"
     )?;
     writeln!(
         md,
-        "|----------|----------|-------------|---------|-------------|"
+        "|----------|----------|---------------|-------------|---------|-------------|"
     )?;
     for v in &aggregated {
         let severity = match v.severity {
@@ -942,10 +1047,11 @@ fn write_violation_table(
         };
         writeln!(
             md,
-            "| {}{} | {} | {} | {} | {} |",
+            "| {}{} | {} | {} | {} | {} | {} |",
             severity,
             escape_markdown_table(&count_suffix),
             escape_markdown_table(v.category),
+            escape_markdown_table(&v.standard_refs),
             escape_markdown_table(v.requirement),
             escape_markdown_table(&v.message),
             escape_markdown_table(v.remediation),

--- a/src/reports/markdown.rs
+++ b/src/reports/markdown.rs
@@ -853,10 +853,7 @@ fn write_cra_compliance_view(md: &mut String, result: &ComplianceResult) -> std:
 /// Render a "Conformity assessment" subsection (CRA-P4.3) when a product
 /// class has been pinned. Surfaces the resolved Annex VIII route and a
 /// per-route evidence checklist.
-fn write_conformity_assessment_md(
-    md: &mut String,
-    result: &ComplianceResult,
-) -> std::fmt::Result {
+fn write_conformity_assessment_md(md: &mut String, result: &ComplianceResult) -> std::fmt::Result {
     let Some(summary) = result.conformity_summary.as_ref() else {
         return Ok(());
     };

--- a/src/reports/mod.rs
+++ b/src/reports/mod.rs
@@ -16,6 +16,7 @@
 //! be escaped before embedding in HTML or Markdown reports.
 
 pub mod analyst;
+pub mod csaf;
 mod csv;
 pub mod escape;
 mod html;
@@ -27,6 +28,7 @@ pub mod streaming;
 mod summary;
 mod types;
 
+pub use csaf::{CsafEmitOptions, emit_csaf};
 pub use csv::CsvReporter;
 pub use html::HtmlReporter;
 pub use json::JsonReporter;

--- a/src/reports/sarif.rs
+++ b/src/reports/sarif.rs
@@ -58,6 +58,7 @@ impl ReportGenerator for SarifReporter {
                             ),
                         },
                         locations: vec![],
+                        properties: None,
                     });
                 }
             }
@@ -74,6 +75,7 @@ impl ReportGenerator for SarifReporter {
                         ),
                     },
                     locations: vec![],
+                    properties: None,
                 });
             }
 
@@ -91,6 +93,7 @@ impl ReportGenerator for SarifReporter {
                             ),
                         },
                         locations: vec![],
+                        properties: None,
                     });
                 }
             }
@@ -122,6 +125,7 @@ impl ReportGenerator for SarifReporter {
                         ),
                     },
                     locations: vec![],
+                    properties: None,
                 });
             }
 
@@ -149,6 +153,7 @@ impl ReportGenerator for SarifReporter {
                             ),
                         },
                         locations: vec![],
+                        properties: None,
                     });
                 }
             }
@@ -168,6 +173,7 @@ impl ReportGenerator for SarifReporter {
                         ),
                     },
                     locations: vec![],
+                    properties: None,
                 });
             }
         }
@@ -193,6 +199,7 @@ impl ReportGenerator for SarifReporter {
                                 ),
                             },
                             locations: vec![],
+                            properties: None,
                         });
                     }
                     crate::model::EolStatus::ApproachingEol => {
@@ -212,6 +219,7 @@ impl ReportGenerator for SarifReporter {
                                 ),
                             },
                             locations: vec![],
+                            properties: None,
                         });
                     }
                     _ => {}
@@ -284,6 +292,7 @@ impl ReportGenerator for SarifReporter {
                     ),
                 },
                 locations: vec![],
+                properties: None,
             });
         }
 
@@ -507,8 +516,32 @@ fn violation_to_rule_id(requirement: &str) -> &'static str {
         return "SBOM-EO14028-GENERAL";
     }
 
+    // BSI TR-03183-2 rules (matched before generic CRA logic)
+    if req.contains("bsi tr-03183-2") || req.contains("tr-03183-2") {
+        if req.contains("§5.1") {
+            return "SBOM-BSI-TR-03183-2-5-1";
+        } else if req.contains("§5.2") {
+            return "SBOM-BSI-TR-03183-2-5-2";
+        } else if req.contains("§5.3") {
+            return "SBOM-BSI-TR-03183-2-5-3";
+        } else if req.contains("§5.4") {
+            return "SBOM-BSI-TR-03183-2-5-4";
+        } else if req.contains("§5.5") {
+            return "SBOM-BSI-TR-03183-2-5-5";
+        } else if req.contains("§6") {
+            return "SBOM-BSI-TR-03183-2-6";
+        }
+        return "SBOM-BSI-TR-03183-2-GENERAL";
+    }
+
+    // CRA prEN 40000-1-3 normative requirement IDs (most-specific first)
+    if req.contains("[pre-8-rq-02]") || req.contains("pre-8-rq-02") {
+        "SBOM-CRA-PRE-8-RQ-02"
+    } else if req.contains("[pre-7-rq-07-re]") || req.contains("pre-7-rq-07-re") {
+        "SBOM-CRA-PRE-7-RQ-07-RE"
+    }
     // CRA-specific rules (original logic)
-    if req.contains("art. 13(3)") || req.contains("art.13(3)") {
+    else if req.contains("art. 13(3)") || req.contains("art.13(3)") {
         "SBOM-CRA-ART-13-3"
     } else if req.contains("art. 13(4)") || req.contains("art.13(4)") {
         "SBOM-CRA-ART-13-4"
@@ -582,6 +615,16 @@ fn compliance_results_to_sarif(result: &ComplianceResult, label: Option<&str>) -
         .iter()
         .map(|v| {
             let element = v.element.as_deref().unwrap_or("unknown");
+            let standard_ids: Vec<String> = v
+                .standard_refs
+                .iter()
+                .map(|sr| format!("{}:{}", sarif_standard_label(sr.standard), sr.id))
+                .collect();
+            let properties = if standard_ids.is_empty() {
+                None
+            } else {
+                Some(SarifResultProperties { standard_ids })
+            };
             SarifResult {
                 rule_id: violation_to_rule_id(&v.requirement).to_string(),
                 level: violation_severity_to_level(v.severity),
@@ -596,9 +639,30 @@ fn compliance_results_to_sarif(result: &ComplianceResult, label: Option<&str>) -
                     ),
                 },
                 locations: vec![],
+                properties,
             }
         })
         .collect()
+}
+
+/// Compact, hyphen-safe label for a `StandardKind` used in SARIF
+/// `properties.standardIds` strings.
+fn sarif_standard_label(kind: crate::quality::StandardKind) -> &'static str {
+    use crate::quality::StandardKind;
+    match kind {
+        StandardKind::CraArticle => "CRA",
+        StandardKind::CraAnnex => "CRA-Annex",
+        StandardKind::Pren40000_1_3 => "prEN-40000-1-3",
+        StandardKind::BsiTr03183_2 => "BSI-TR-03183-2",
+        StandardKind::NistSsdf => "NIST-SSDF",
+        StandardKind::Eo14028 => "EO-14028",
+        StandardKind::FdaPremarket => "FDA",
+        StandardKind::NtiaMinimum => "NTIA",
+        StandardKind::Csaf2 => "CSAF",
+        StandardKind::Cnsa2 => "CNSA-2.0",
+        StandardKind::NistPqc => "NIST-PQC",
+        StandardKind::Other => "Other",
+    }
 }
 
 fn get_sarif_rules() -> Vec<SarifRule> {
@@ -1230,6 +1294,80 @@ fn get_sarif_compliance_rules() -> Vec<SarifRule> {
             },
             default_configuration: SarifConfiguration { level: SarifLevel::Warning },
         },
+        SarifRule {
+            id: "SBOM-CRA-PRE-8-RQ-02".to_string(),
+            name: "CraHardwareInventory".to_string(),
+            short_description: SarifMessage {
+                text: "CRA prEN 40000-1-3 [PRE-8-RQ-02]: Hardware components must be inventoried with producer, name, identifier, and firmware version"
+                    .to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Error },
+        },
+        SarifRule {
+            id: "SBOM-CRA-PRE-7-RQ-07-RE".to_string(),
+            name: "CraVendorHashCarryThrough".to_string(),
+            short_description: SarifMessage {
+                text: "CRA prEN 40000-1-3 [PRE-7-RQ-07-RE]: Upstream vendor-supplied component hashes must be carried through into the SBOM"
+                    .to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Warning },
+        },
+        SarifRule {
+            id: "SBOM-BSI-TR-03183-2-5-1".to_string(),
+            name: "BsiTr03183AuthorTool".to_string(),
+            short_description: SarifMessage {
+                text: "BSI TR-03183-2 §5.1: SBOM author/tool identification".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Error },
+        },
+        SarifRule {
+            id: "SBOM-BSI-TR-03183-2-5-2".to_string(),
+            name: "BsiTr03183Timestamp".to_string(),
+            short_description: SarifMessage {
+                text: "BSI TR-03183-2 §5.2: ISO-8601 timestamp".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Error },
+        },
+        SarifRule {
+            id: "SBOM-BSI-TR-03183-2-5-3".to_string(),
+            name: "BsiTr03183ComponentIdentifier".to_string(),
+            short_description: SarifMessage {
+                text: "BSI TR-03183-2 §5.3: Component name and unique identifier".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Error },
+        },
+        SarifRule {
+            id: "SBOM-BSI-TR-03183-2-5-4".to_string(),
+            name: "BsiTr03183ComponentHash".to_string(),
+            short_description: SarifMessage {
+                text: "BSI TR-03183-2 §5.4: Component cryptographic hash (SHA-256+)".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Error },
+        },
+        SarifRule {
+            id: "SBOM-BSI-TR-03183-2-5-5".to_string(),
+            name: "BsiTr03183Dependencies".to_string(),
+            short_description: SarifMessage {
+                text: "BSI TR-03183-2 §5.5: Dependency relationships".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Error },
+        },
+        SarifRule {
+            id: "SBOM-BSI-TR-03183-2-6".to_string(),
+            name: "BsiTr03183Recommended".to_string(),
+            short_description: SarifMessage {
+                text: "BSI TR-03183-2 §6: Recommended fields (license, supplier, lifecycle)".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Warning },
+        },
+        SarifRule {
+            id: "SBOM-BSI-TR-03183-2-GENERAL".to_string(),
+            name: "BsiTr03183General".to_string(),
+            short_description: SarifMessage {
+                text: "BSI TR-03183-2 general SBOM requirement".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Warning },
+        },
     ]
 }
 
@@ -1288,6 +1426,21 @@ struct SarifResult {
     level: SarifLevel,
     message: SarifMessage,
     locations: Vec<SarifLocation>,
+    /// Standard references (CRA Article, prEN 40000-1-3 ID, BSI section, …)
+    /// Surfaced in `properties.standardIds` so downstream GRC/CI tooling can
+    /// map a finding to the exact harmonised-standard clause.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    properties: Option<SarifResultProperties>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifResultProperties {
+    /// Standard reference IDs in the form `<standard>:<id>`
+    /// (e.g., `prEN-40000-1-3:PRE-7-RQ-07`, `CRA:Art. 13(4)`).
+    /// Plural to match SARIF `properties` extensibility convention.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    standard_ids: Vec<String>,
 }
 
 #[derive(Serialize)]

--- a/src/reports/sarif.rs
+++ b/src/reports/sarif.rs
@@ -248,7 +248,7 @@ impl ReportGenerator for SarifReporter {
                         name: "sbom-tools".to_string(),
                         version: env!("CARGO_PKG_VERSION").to_string(),
                         information_uri: "https://github.com/binarly-io/sbom-tools".to_string(),
-                        rules: get_sarif_rules(),
+                        rules: SarifRuleWithUri::wrap_all(get_sarif_rules()),
                     },
                 },
                 results,
@@ -312,7 +312,7 @@ impl ReportGenerator for SarifReporter {
                         name: "sbom-tools".to_string(),
                         version: env!("CARGO_PKG_VERSION").to_string(),
                         information_uri: "https://github.com/binarly-io/sbom-tools".to_string(),
-                        rules: get_sarif_view_rules(),
+                        rules: SarifRuleWithUri::wrap_all(get_sarif_view_rules()),
                     },
                 },
                 results,
@@ -329,7 +329,7 @@ impl ReportGenerator for SarifReporter {
 }
 
 pub fn generate_compliance_sarif(result: &ComplianceResult) -> Result<String, ReportError> {
-    let rules = get_sarif_rules_for_standard(result.level);
+    let rules = SarifRuleWithUri::wrap_all(get_sarif_rules_for_standard(result.level));
     let sarif = SarifReport {
         schema: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json".to_string(),
         version: "2.1.0".to_string(),
@@ -372,7 +372,7 @@ pub fn generate_multi_compliance_sarif(
                     name: "sbom-tools".to_string(),
                     version: env!("CARGO_PKG_VERSION").to_string(),
                     information_uri: "https://github.com/binarly-io/sbom-tools".to_string(),
-                    rules: all_rules,
+                    rules: SarifRuleWithUri::wrap_all(all_rules),
                 },
             },
             results: all_results,
@@ -620,10 +620,18 @@ fn compliance_results_to_sarif(result: &ComplianceResult, label: Option<&str>) -
                 .iter()
                 .map(|sr| format!("{}:{}", sarif_standard_label(sr.standard), sr.id))
                 .collect();
-            let properties = if standard_ids.is_empty() {
+            let standard_help_uris: Vec<String> = v
+                .standard_refs
+                .iter()
+                .filter_map(|sr| sr.help_uri.clone())
+                .collect();
+            let properties = if standard_ids.is_empty() && standard_help_uris.is_empty() {
                 None
             } else {
-                Some(SarifResultProperties { standard_ids })
+                Some(SarifResultProperties {
+                    standard_ids,
+                    standard_help_uris,
+                })
             };
             SarifResult {
                 rule_id: violation_to_rule_id(&v.requirement).to_string(),
@@ -643,6 +651,39 @@ fn compliance_results_to_sarif(result: &ComplianceResult, label: Option<&str>) -
             }
         })
         .collect()
+}
+
+/// Canonical URL for a SARIF rule, derived from its ID prefix. Returns
+/// `None` for rule families that do not map to a single regulation /
+/// specification (e.g., `SBOM-TOOLS-*` change-tracking rules).
+fn rule_help_uri(rule_id: &str) -> Option<&'static str> {
+    if rule_id.starts_with("SBOM-CRA-") {
+        Some("https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng")
+    } else if rule_id.starts_with("SBOM-BSI-") {
+        Some(
+            "https://www.bsi.bund.de/EN/Themen/Unternehmen-und-Organisationen/Standards-und-Zertifizierung/Technische-Richtlinien/TR-nach-Thema-sortiert/tr03183/TR-03183_node.html",
+        )
+    } else if rule_id.starts_with("SBOM-NIST-SSDF-") || rule_id.starts_with("SBOM-SSDF-") {
+        Some("https://doi.org/10.6028/NIST.SP.800-218")
+    } else if rule_id.starts_with("SBOM-EO14028-") || rule_id.starts_with("SBOM-EO-14028-") {
+        Some("https://www.federalregister.gov/d/2021-10460")
+    } else if rule_id.starts_with("SBOM-FDA-") {
+        Some(
+            "https://www.fda.gov/regulatory-information/search-fda-guidance-documents/cybersecurity-medical-devices-quality-system-considerations-and-content-premarket-submissions",
+        )
+    } else if rule_id.starts_with("SBOM-NTIA-") {
+        Some("https://www.ntia.doc.gov/files/ntia/publications/sbom_minimum_elements_report.pdf")
+    } else if rule_id.starts_with("SBOM-PQC-") || rule_id.starts_with("SBOM-NIST-PQC-") {
+        Some("https://csrc.nist.gov/projects/post-quantum-cryptography")
+    } else if rule_id.starts_with("SBOM-CNSA-") {
+        Some(
+            "https://media.defense.gov/2022/Sep/07/2003071834/-1/-1/0/CSA_CNSA_2.0_ALGORITHMS_.PDF",
+        )
+    } else if rule_id.starts_with("SBOM-CSAF-") {
+        Some("https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html")
+    } else {
+        None
+    }
 }
 
 /// Compact, hyphen-safe label for a `StandardKind` used in SARIF
@@ -1401,7 +1442,7 @@ struct SarifDriver {
     name: String,
     version: String,
     information_uri: String,
-    rules: Vec<SarifRule>,
+    rules: Vec<SarifRuleWithUri>,
 }
 
 #[derive(Serialize)]
@@ -1411,6 +1452,30 @@ struct SarifRule {
     name: String,
     short_description: SarifMessage,
     default_configuration: SarifConfiguration,
+}
+
+/// SarifRule plus a derived `helpUri` (CRA-P5.1). Wraps the existing rule
+/// definitions at serialization time so we don't need to thread the URL
+/// through every call site that constructs a `SarifRule`. Computed via
+/// `rule_help_uri()` based on the rule-ID prefix.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifRuleWithUri {
+    #[serde(flatten)]
+    inner: SarifRule,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    help_uri: Option<&'static str>,
+}
+
+impl SarifRuleWithUri {
+    fn wrap(inner: SarifRule) -> Self {
+        let help_uri = rule_help_uri(&inner.id);
+        Self { inner, help_uri }
+    }
+
+    fn wrap_all(rules: Vec<SarifRule>) -> Vec<Self> {
+        rules.into_iter().map(Self::wrap).collect()
+    }
 }
 
 #[derive(Serialize)]
@@ -1441,6 +1506,11 @@ struct SarifResultProperties {
     /// Plural to match SARIF `properties` extensibility convention.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     standard_ids: Vec<String>,
+    /// Canonical URLs for each standard the violation references — lifted
+    /// from `StandardRef::help_uri`. Order parallels `standard_ids`. Empty
+    /// when none of the references have a canonical home.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    standard_help_uris: Vec<String>,
 }
 
 #[derive(Serialize)]

--- a/src/tui/app_states/compliance.rs
+++ b/src/tui/app_states/compliance.rs
@@ -21,6 +21,8 @@ pub enum PolicyPreset {
     Cnsa2,
     /// NIST PQC Readiness — IR 8547 + FIPS 203/204/205
     NistPqc,
+    /// BSI TR-03183-2 — German national CRA-aligned SBOM guideline
+    BsiTr03183_2,
 }
 
 impl PolicyPreset {
@@ -35,7 +37,8 @@ impl PolicyPreset {
             Self::NistSsdf => Self::Eo14028,
             Self::Eo14028 => Self::Cnsa2,
             Self::Cnsa2 => Self::NistPqc,
-            Self::NistPqc => Self::Enterprise,
+            Self::NistPqc => Self::BsiTr03183_2,
+            Self::BsiTr03183_2 => Self::Enterprise,
         }
     }
 
@@ -51,6 +54,7 @@ impl PolicyPreset {
             Self::Eo14028 => "EO 14028",
             Self::Cnsa2 => "CNSA 2.0",
             Self::NistPqc => "NIST PQC",
+            Self::BsiTr03183_2 => "BSI TR-03183-2",
         }
     }
 
@@ -65,6 +69,7 @@ impl PolicyPreset {
                 | Self::Eo14028
                 | Self::Cnsa2
                 | Self::NistPqc
+                | Self::BsiTr03183_2
         )
     }
 
@@ -78,6 +83,7 @@ impl PolicyPreset {
             Self::Eo14028 => Some(crate::quality::ComplianceLevel::Eo14028),
             Self::Cnsa2 => Some(crate::quality::ComplianceLevel::Cnsa2),
             Self::NistPqc => Some(crate::quality::ComplianceLevel::NistPqc),
+            Self::BsiTr03183_2 => Some(crate::quality::ComplianceLevel::BsiTr03183_2),
             _ => None,
         }
     }

--- a/src/tui/app_states/compliance.rs
+++ b/src/tui/app_states/compliance.rs
@@ -23,6 +23,10 @@ pub enum PolicyPreset {
     NistPqc,
     /// BSI TR-03183-2 — German national CRA-aligned SBOM guideline
     BsiTr03183_2,
+    /// CRA Article 24 — Open-source software steward (lighter manufacturer profile)
+    CraOssSteward,
+    /// EUCC Substantial — Reg. (EU) 2024/482 reference profile (Annex IV)
+    EuccSubstantial,
 }
 
 impl PolicyPreset {
@@ -38,7 +42,9 @@ impl PolicyPreset {
             Self::Eo14028 => Self::Cnsa2,
             Self::Cnsa2 => Self::NistPqc,
             Self::NistPqc => Self::BsiTr03183_2,
-            Self::BsiTr03183_2 => Self::Enterprise,
+            Self::BsiTr03183_2 => Self::CraOssSteward,
+            Self::CraOssSteward => Self::EuccSubstantial,
+            Self::EuccSubstantial => Self::Enterprise,
         }
     }
 
@@ -55,6 +61,8 @@ impl PolicyPreset {
             Self::Cnsa2 => "CNSA 2.0",
             Self::NistPqc => "NIST PQC",
             Self::BsiTr03183_2 => "BSI TR-03183-2",
+            Self::CraOssSteward => "CRA OSS Steward",
+            Self::EuccSubstantial => "EUCC",
         }
     }
 
@@ -70,6 +78,8 @@ impl PolicyPreset {
                 | Self::Cnsa2
                 | Self::NistPqc
                 | Self::BsiTr03183_2
+                | Self::CraOssSteward
+                | Self::EuccSubstantial
         )
     }
 
@@ -84,6 +94,8 @@ impl PolicyPreset {
             Self::Cnsa2 => Some(crate::quality::ComplianceLevel::Cnsa2),
             Self::NistPqc => Some(crate::quality::ComplianceLevel::NistPqc),
             Self::BsiTr03183_2 => Some(crate::quality::ComplianceLevel::BsiTr03183_2),
+            Self::CraOssSteward => Some(crate::quality::ComplianceLevel::CraOssSteward),
+            Self::EuccSubstantial => Some(crate::quality::ComplianceLevel::EuccSubstantial),
             _ => None,
         }
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -19,6 +19,7 @@ mod app_impl_items;
 mod app_impl_nav;
 mod app_impl_search;
 mod app_states;
+pub use app_states::PolicyPreset;
 pub(crate) mod clipboard;
 pub(crate) mod constants;
 mod events;

--- a/src/tui/shared/quality.rs
+++ b/src/tui/shared/quality.rs
@@ -30,6 +30,7 @@ pub const fn get_profile_weights(
         ScoringProfile::Security => (0.12, 0.18, 0.05, 0.20, 0.10, 0.15, 0.10, 0.10),
         ScoringProfile::LicenseCompliance => (0.15, 0.12, 0.35, 0.05, 0.10, 0.05, 0.10, 0.08),
         ScoringProfile::Cra => (0.12, 0.18, 0.08, 0.15, 0.12, 0.12, 0.15, 0.08),
+        ScoringProfile::BsiTr03183_2 => (0.10, 0.22, 0.08, 0.10, 0.12, 0.18, 0.12, 0.08),
         ScoringProfile::Comprehensive => (0.15, 0.13, 0.13, 0.10, 0.12, 0.12, 0.13, 0.12),
         ScoringProfile::Cbom => (0.15, 0.15, 0.22, 0.10, 0.13, 0.15, 0.08, 0.02),
     }

--- a/src/tui/view/app.rs
+++ b/src/tui/view/app.rs
@@ -131,6 +131,12 @@ pub struct ViewApp {
 
     /// Optional export filename template (from `--export-template` CLI arg).
     pub(crate) export_template: Option<String>,
+
+    /// Optional CRA sidecar metadata. When set, `compute_compliance_results`
+    /// passes it to `ComplianceChecker::with_sidecar()` so OSS-Steward,
+    /// EUCC, Article 14, and product-class checks render correctly in
+    /// the TUI compliance tab.
+    pub(crate) cra_sidecar: Option<crate::model::CraSidecarMetadata>,
 }
 
 impl ViewApp {
@@ -217,6 +223,7 @@ impl ViewApp {
             algorithm_sort_by: AlgorithmSortBy::default(),
             bookmarked: HashSet::new(),
             export_template: None,
+            cra_sidecar: None,
         };
 
         // Pre-compute vuln cache at startup to avoid freeze on first tab visit
@@ -226,10 +233,23 @@ impl ViewApp {
         app
     }
 
+    /// Set the CRA sidecar metadata on this `ViewApp`. Stored so the
+    /// compliance tab can render OSS-Steward / EUCC / Article 14 /
+    /// product-class checks against the same sidecar the CLI uses.
+    pub fn with_cra_sidecar(mut self, sidecar: crate::model::CraSidecarMetadata) -> Self {
+        // Invalidate cached results so the sidecar takes effect on next render.
+        self.compliance_results = None;
+        self.cra_sidecar = Some(sidecar);
+        self
+    }
+
     /// Lazily compute compliance results for all standards when first needed.
     pub fn ensure_compliance_results(&mut self) {
         if self.compliance_results.is_none() {
-            self.compliance_results = Some(compute_compliance_results(&self.sbom));
+            self.compliance_results = Some(compute_compliance_results(
+                &self.sbom,
+                self.cra_sidecar.as_ref(),
+            ));
         }
     }
 

--- a/src/tui/view/views/compliance.rs
+++ b/src/tui/view/views/compliance.rs
@@ -1209,11 +1209,17 @@ impl StandardComplianceState {
 
 /// Compute compliance results for all standards
 #[must_use]
-pub fn compute_compliance_results(sbom: &crate::model::NormalizedSbom) -> Vec<ComplianceResult> {
+pub fn compute_compliance_results(
+    sbom: &crate::model::NormalizedSbom,
+    sidecar: Option<&crate::model::CraSidecarMetadata>,
+) -> Vec<ComplianceResult> {
     ComplianceLevel::all()
         .iter()
         .map(|level| {
-            let checker = ComplianceChecker::new(*level);
+            let mut checker = ComplianceChecker::new(*level);
+            if let Some(sc) = sidecar {
+                checker = checker.with_sidecar(sc.clone());
+            }
             checker.check(sbom)
         })
         .collect()

--- a/src/tui/view/views/compliance.rs
+++ b/src/tui/view/views/compliance.rs
@@ -338,17 +338,10 @@ fn render_category_breakdown(frame: &mut Frame, area: Rect, result: &ComplianceR
 
     // Conformity-assessment route (CRA-P4.3): only when product class pinned.
     if let Some(summary) = result.conformity_summary.as_ref() {
-        let satisfied = summary
-            .evidence
-            .iter()
-            .filter(|e| e.satisfied)
-            .count();
+        let satisfied = summary.evidence.iter().filter(|e| e.satisfied).count();
         let total = summary.evidence.len();
         lines.push(Line::from(vec![
-            Span::styled(
-                "  Annex VIII: ",
-                Style::default().fg(scheme.muted),
-            ),
+            Span::styled("  Annex VIII: ", Style::default().fg(scheme.muted)),
             Span::styled(
                 summary.route.label(),
                 Style::default().fg(scheme.text).bold(),

--- a/src/tui/view/views/compliance.rs
+++ b/src/tui/view/views/compliance.rs
@@ -336,6 +336,38 @@ fn render_category_breakdown(frame: &mut Frame, area: Rect, result: &ComplianceR
         Style::default().fg(status_color).bold(),
     )])];
 
+    // Conformity-assessment route (CRA-P4.3): only when product class pinned.
+    if let Some(summary) = result.conformity_summary.as_ref() {
+        let satisfied = summary
+            .evidence
+            .iter()
+            .filter(|e| e.satisfied)
+            .count();
+        let total = summary.evidence.len();
+        lines.push(Line::from(vec![
+            Span::styled(
+                "  Annex VIII: ",
+                Style::default().fg(scheme.muted),
+            ),
+            Span::styled(
+                summary.route.label(),
+                Style::default().fg(scheme.text).bold(),
+            ),
+            Span::styled(
+                format!("  ({})", summary.product_class.label()),
+                Style::default().fg(scheme.muted),
+            ),
+            Span::styled(
+                format!("  {satisfied}/{total} evidence"),
+                Style::default().fg(if satisfied == total {
+                    scheme.success
+                } else {
+                    scheme.warning
+                }),
+            ),
+        ]));
+    }
+
     // Show up to 4 categories with proportional bars
     let bar_max = (h_chunks[0].width as usize).saturating_sub(30).clamp(8, 40);
     for (cat, errors, warnings, infos) in sorted_cats.iter().take(4) {

--- a/tests/cra_adjacent_regulation_tests.rs
+++ b/tests/cra_adjacent_regulation_tests.rs
@@ -1,0 +1,150 @@
+//! Integration tests for CRA-P4.4 Adjacent regulation surfacing.
+//!
+//! Asserts that the cra-docs technical-documentation.md template surfaces
+//! NIS2 / GDPR / AI Act / RED guidance only when the corresponding
+//! sidecar flag is set, and that none of the sections fire when the
+//! sidecar omits all five flags.
+
+use sbom_tools::cli::run_cra_docs;
+use sbom_tools::model::CraSidecarMetadata;
+use std::fs;
+use tempfile::tempdir;
+
+const MINIMAL_CDX: &str = r#"{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "metadata": {"component": {"type": "application", "name": "app", "version": "1.0.0"}},
+    "components": []
+}"#;
+
+fn write_temp(dir: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
+    let p = dir.join(name);
+    fs::write(&p, body).unwrap();
+    p
+}
+
+fn run_with_sidecar(sidecar: CraSidecarMetadata) -> String {
+    let dir = tempdir().unwrap();
+    let sbom = write_temp(dir.path(), "app.cdx.json", MINIMAL_CDX);
+    let sidecar_path = dir.path().join("app.cra.json");
+    fs::write(&sidecar_path, serde_json::to_string(&sidecar).unwrap()).unwrap();
+    let out = dir.path().join("dossier");
+    run_cra_docs(sbom, out.clone(), Some(sidecar_path), None).expect("cra-docs runs");
+    fs::read_to_string(out.join("technical-documentation.md")).unwrap()
+}
+
+#[test]
+fn empty_sidecar_omits_adjacent_regulation_section() {
+    let tech = run_with_sidecar(CraSidecarMetadata::default());
+    assert!(
+        !tech.contains("Adjacent regulation"),
+        "Adjacent regulation must NOT render when no flags set"
+    );
+}
+
+#[test]
+fn nis2_essential_entity_renders_art_23_guidance() {
+    let tech = run_with_sidecar(CraSidecarMetadata {
+        is_nis2_essential_entity: true,
+        ..Default::default()
+    });
+    assert!(tech.contains("Adjacent regulation"));
+    assert!(tech.contains("NIS2"));
+    assert!(tech.contains("essential entity"));
+    assert!(tech.contains("Art. 23"));
+}
+
+#[test]
+fn nis2_important_entity_renders_distinct_label() {
+    let tech = run_with_sidecar(CraSidecarMetadata {
+        is_nis2_important_entity: true,
+        ..Default::default()
+    });
+    assert!(tech.contains("important entity"));
+    assert!(tech.contains("Annex II"));
+}
+
+#[test]
+fn personal_data_renders_gdpr_art_32_guidance() {
+    let tech = run_with_sidecar(CraSidecarMetadata {
+        processes_personal_data: true,
+        ..Default::default()
+    });
+    assert!(tech.contains("GDPR"));
+    assert!(tech.contains("Art. 32"));
+    assert!(tech.contains("DPIA") || tech.contains("Art. 35"));
+}
+
+#[test]
+fn high_risk_ai_renders_ai_act_guidance() {
+    let tech = run_with_sidecar(CraSidecarMetadata {
+        is_high_risk_ai: true,
+        ..Default::default()
+    });
+    assert!(tech.contains("AI Act"));
+    assert!(tech.contains("high-risk"));
+    assert!(tech.contains("Art. 72") || tech.contains("Art. 73"));
+}
+
+#[test]
+fn red_repealed_until_renders_red_guidance() {
+    let until = chrono::DateTime::parse_from_rfc3339("2025-08-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    let tech = run_with_sidecar(CraSidecarMetadata {
+        red_repealed_until: Some(until),
+        ..Default::default()
+    });
+    assert!(tech.contains("Radio Equipment Directive"));
+    assert!(tech.contains("2014/53/EU"));
+    assert!(tech.contains("2025-08-01"));
+}
+
+#[test]
+fn all_flags_set_renders_all_four_sections() {
+    let until = chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+        .unwrap()
+        .with_timezone(&chrono::Utc);
+    let tech = run_with_sidecar(CraSidecarMetadata {
+        is_nis2_essential_entity: true,
+        processes_personal_data: true,
+        is_high_risk_ai: true,
+        red_repealed_until: Some(until),
+        ..Default::default()
+    });
+    assert!(tech.contains("NIS2"));
+    assert!(tech.contains("GDPR"));
+    assert!(tech.contains("AI Act"));
+    assert!(tech.contains("Radio Equipment Directive"));
+}
+
+#[test]
+fn sidecar_flag_serde_roundtrip() {
+    let original = CraSidecarMetadata {
+        is_nis2_essential_entity: true,
+        is_nis2_important_entity: false,
+        processes_personal_data: true,
+        is_high_risk_ai: true,
+        red_repealed_until: Some(
+            chrono::DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        ),
+        ..Default::default()
+    };
+    let json = serde_json::to_string(&original).unwrap();
+    let parsed: CraSidecarMetadata = serde_json::from_str(&json).unwrap();
+    assert!(parsed.is_nis2_essential_entity);
+    assert!(!parsed.is_nis2_important_entity);
+    assert!(parsed.processes_personal_data);
+    assert!(parsed.is_high_risk_ai);
+    assert!(parsed.red_repealed_until.is_some());
+
+    // Default values should not serialize (skip_serializing_if).
+    let default_json = serde_json::to_string(&CraSidecarMetadata::default()).unwrap();
+    assert!(!default_json.contains("is_nis2_essential_entity"));
+    assert!(!default_json.contains("is_nis2_important_entity"));
+    assert!(!default_json.contains("processes_personal_data"));
+    assert!(!default_json.contains("is_high_risk_ai"));
+    assert!(!default_json.contains("red_repealed_until"));
+}

--- a/tests/cra_conformity_summary_tests.rs
+++ b/tests/cra_conformity_summary_tests.rs
@@ -1,0 +1,172 @@
+//! Integration tests for CRA-P4.3 ConformityAssessmentSummary surface.
+//!
+//! Asserts that:
+//! - `ComplianceResult::conformity_summary` is populated only when a CRA
+//!   product class is pinned.
+//! - The evidence checklist matches the expected per-route shape.
+//! - Markdown / HTML report rendering surfaces the summary.
+
+use sbom_tools::model::{
+    Component, ConformityRoute, CraProductClass, CraSidecarMetadata, ExternalRefType,
+    ExternalReference, NormalizedSbom,
+};
+use sbom_tools::quality::{ComplianceChecker, ComplianceLevel};
+
+#[test]
+fn no_summary_when_class_not_pinned() {
+    let sbom = NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+    assert!(
+        result.conformity_summary.is_none(),
+        "no summary when no product class pinned"
+    );
+}
+
+#[test]
+fn summary_present_at_default_class_lists_doc_and_module_a() {
+    let sbom = NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Default)
+        .check(&sbom);
+    let summary = result
+        .conformity_summary
+        .as_ref()
+        .expect("summary present at Default");
+    assert_eq!(summary.product_class, CraProductClass::Default);
+    assert_eq!(summary.route, ConformityRoute::ModuleA);
+    let labels: Vec<&str> = summary.evidence.iter().map(|e| e.label.as_str()).collect();
+    assert!(labels.contains(&"EU Declaration of Conformity"));
+    assert!(labels.contains(&"Internal-control technical file"));
+    assert!(labels.contains(&"PSIRT contact (Art. 14)"));
+}
+
+#[test]
+fn summary_module_bc_includes_eu_type_examination() {
+    let sidecar = CraSidecarMetadata {
+        product_class: Some(CraProductClass::ImportantClass2),
+        conformity_assessment_route: Some(ConformityRoute::ModuleBC),
+        ..Default::default()
+    };
+    let sbom = NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_sidecar(sidecar)
+        .check(&sbom);
+    let summary = result.conformity_summary.expect("summary");
+    assert_eq!(summary.route, ConformityRoute::ModuleBC);
+    let labels: Vec<&str> = summary.evidence.iter().map(|e| e.label.as_str()).collect();
+    assert!(labels.iter().any(|l| l.contains("EU-type examination")));
+    assert!(labels.iter().any(|l| l.contains("Production conformity")));
+}
+
+#[test]
+fn summary_module_h_includes_qms_certification() {
+    let sidecar = CraSidecarMetadata {
+        product_class: Some(CraProductClass::ImportantClass2),
+        conformity_assessment_route: Some(ConformityRoute::ModuleH),
+        ..Default::default()
+    };
+    let sbom = NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_sidecar(sidecar)
+        .check(&sbom);
+    let summary = result.conformity_summary.expect("summary");
+    assert_eq!(summary.route, ConformityRoute::ModuleH);
+    let labels: Vec<&str> = summary.evidence.iter().map(|e| e.label.as_str()).collect();
+    assert!(
+        labels
+            .iter()
+            .any(|l| l.contains("Quality-management-system"))
+    );
+    assert!(labels.iter().any(|l| l.contains("surveillance")));
+}
+
+#[test]
+fn summary_eucc_includes_target_of_evaluation() {
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Critical)
+        .check(&NormalizedSbom::default());
+    let summary = result.conformity_summary.expect("summary");
+    assert_eq!(summary.route, ConformityRoute::Eucc);
+    let labels: Vec<&str> = summary.evidence.iter().map(|e| e.label.as_str()).collect();
+    assert!(labels.iter().any(|l| l.contains("EUCC")));
+    assert!(labels.iter().any(|l| l.contains("Target of Evaluation")));
+}
+
+#[test]
+fn doc_evidence_satisfied_by_attestation_external_ref() {
+    let mut sbom = NormalizedSbom::default();
+    let mut c = Component::new("app".to_string(), "app".to_string());
+    c.external_refs.push(ExternalReference {
+        ref_type: ExternalRefType::Attestation,
+        url: "https://example.com/doc".to_string(),
+        comment: None,
+        hashes: Vec::new(),
+    });
+    sbom.add_component(c);
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Default)
+        .check(&sbom);
+    let summary = result.conformity_summary.expect("summary");
+    let doc_row = summary
+        .evidence
+        .iter()
+        .find(|e| e.label == "EU Declaration of Conformity")
+        .unwrap();
+    assert!(
+        doc_row.satisfied,
+        "Attestation external ref should satisfy DoC evidence"
+    );
+}
+
+#[test]
+fn psirt_evidence_satisfied_by_sidecar() {
+    let sidecar = CraSidecarMetadata {
+        product_class: Some(CraProductClass::ImportantClass1),
+        psirt_url: Some("https://example.com/psirt".to_string()),
+        ..Default::default()
+    };
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_sidecar(sidecar)
+        .check(&NormalizedSbom::default());
+    let summary = result.conformity_summary.expect("summary");
+    let psirt = summary
+        .evidence
+        .iter()
+        .find(|e| e.label.contains("PSIRT"))
+        .unwrap();
+    assert!(psirt.satisfied);
+}
+
+#[test]
+fn eucc_evidence_satisfied_by_certification_with_eucc_url() {
+    let mut sbom = NormalizedSbom::default();
+    let mut c = Component::new("app".to_string(), "app".to_string());
+    c.external_refs.push(ExternalReference {
+        ref_type: ExternalRefType::Certification,
+        url: "https://eucc.eu/cert/abc".to_string(),
+        comment: None,
+        hashes: Vec::new(),
+    });
+    sbom.add_component(c);
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Critical)
+        .check(&sbom);
+    let summary = result.conformity_summary.expect("summary");
+    let eucc = summary
+        .evidence
+        .iter()
+        .find(|e| e.label.contains("EUCC"))
+        .unwrap();
+    assert!(eucc.satisfied, "EUCC URL must satisfy EUCC evidence row");
+}
+
+#[test]
+fn json_serialization_roundtrips_conformity_summary() {
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Critical)
+        .check(&NormalizedSbom::default());
+    let json = serde_json::to_string(&result).unwrap();
+    assert!(json.contains("conformity_summary"));
+    assert!(json.contains("Critical"));
+    assert!(json.contains("Eucc") || json.contains("EUCC"));
+}

--- a/tests/cra_docs_tests.rs
+++ b/tests/cra_docs_tests.rs
@@ -1,0 +1,178 @@
+//! Integration tests for the `cra-docs` CLI subcommand (CRA-P4.1).
+//!
+//! Exercises the dossier generator end-to-end: parses an SBOM, optionally
+//! a sidecar, and asserts that the three CRA-P4.1 dossier files are
+//! emitted with the expected sections and that sidecar fields propagate
+//! into each template.
+
+use sbom_tools::cli::run_cra_docs;
+use std::fs;
+use tempfile::tempdir;
+
+const MINIMAL_CDX: &str = r#"{
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.5",
+    "serialNumber": "urn:uuid:11111111-1111-1111-1111-111111111111",
+    "metadata": {
+        "component": {
+            "type": "application",
+            "name": "example-app",
+            "version": "1.0.0"
+        }
+    },
+    "components": [
+        {"type": "library", "name": "lib-a", "version": "1.2.3", "purl": "pkg:cargo/lib-a@1.2.3"},
+        {"type": "library", "name": "lib-b", "version": "0.9.0", "purl": "pkg:cargo/lib-b@0.9.0"}
+    ]
+}"#;
+
+const SIDECAR_JSON: &str = r#"{
+    "manufacturerName": "Example Corp",
+    "manufacturerEmail": "legal@example.com",
+    "productName": "Example App",
+    "productVersion": "1.0.0",
+    "ceMarkingReference": "EU-DoC-2026-001",
+    "psirtUrl": "https://example.com/psirt",
+    "securityContact": "security@example.com",
+    "coordinatedDisclosurePolicyUrl": "https://example.com/security/cvd",
+    "earlyWarningContact": "ew@example.com",
+    "incidentReportContact": "incidents@example.com",
+    "enisaReportingPlatformId": "EU-MFR-1",
+    "riskAssessmentUrl": "https://example.com/risk-assessment.pdf",
+    "riskAssessmentMethodology": "ISO/IEC 27005:2022",
+    "supportEndDate": "2030-12-31T00:00:00Z",
+    "productClass": "important-class-1"
+}"#;
+
+fn write_temp(dir: &std::path::Path, name: &str, body: &str) -> std::path::PathBuf {
+    let p = dir.join(name);
+    fs::write(&p, body).unwrap();
+    p
+}
+
+#[test]
+fn cra_docs_creates_all_three_dossier_files() {
+    let dir = tempdir().unwrap();
+    let sbom = write_temp(dir.path(), "app.cdx.json", MINIMAL_CDX);
+    let out = dir.path().join("dossier");
+
+    run_cra_docs(sbom, out.clone(), None, None).expect("cra-docs runs");
+
+    assert!(out.join("eu-declaration-of-conformity.md").exists());
+    assert!(out.join("technical-documentation.md").exists());
+    assert!(out.join("vulnerability-handling-policy.md").exists());
+}
+
+#[test]
+fn cra_docs_propagates_sidecar_into_doc_template() {
+    let dir = tempdir().unwrap();
+    let sbom = write_temp(dir.path(), "app.cdx.json", MINIMAL_CDX);
+    let sidecar = write_temp(dir.path(), "app.cra.json", SIDECAR_JSON);
+    let out = dir.path().join("dossier");
+
+    run_cra_docs(sbom, out.clone(), Some(sidecar), None).expect("cra-docs runs");
+
+    let doc = fs::read_to_string(out.join("eu-declaration-of-conformity.md")).unwrap();
+    assert!(doc.contains("Example Corp"), "manufacturer name in DoC");
+    assert!(doc.contains("legal@example.com"));
+    assert!(doc.contains("EU-DoC-2026-001"));
+    assert!(doc.contains("Example App"));
+    assert!(
+        doc.contains("Important Class I"),
+        "sidecar productClass surfaces in DoC class"
+    );
+}
+
+#[test]
+fn cra_docs_propagates_sidecar_into_vuln_policy() {
+    let dir = tempdir().unwrap();
+    let sbom = write_temp(dir.path(), "app.cdx.json", MINIMAL_CDX);
+    let sidecar = write_temp(dir.path(), "app.cra.json", SIDECAR_JSON);
+    let out = dir.path().join("dossier");
+
+    run_cra_docs(sbom, out.clone(), Some(sidecar), None).expect("cra-docs runs");
+
+    let policy = fs::read_to_string(out.join("vulnerability-handling-policy.md")).unwrap();
+    assert!(policy.contains("https://example.com/psirt"));
+    assert!(policy.contains("security@example.com"));
+    assert!(policy.contains("https://example.com/security/cvd"));
+    assert!(policy.contains("ew@example.com"));
+    assert!(policy.contains("incidents@example.com"));
+    assert!(policy.contains("EU-MFR-1"));
+}
+
+#[test]
+fn cra_docs_tech_doc_summarises_components_and_compliance() {
+    let dir = tempdir().unwrap();
+    let sbom = write_temp(dir.path(), "app.cdx.json", MINIMAL_CDX);
+    let sidecar = write_temp(dir.path(), "app.cra.json", SIDECAR_JSON);
+    let out = dir.path().join("dossier");
+
+    run_cra_docs(sbom, out.clone(), Some(sidecar), None).expect("cra-docs runs");
+
+    let tech = fs::read_to_string(out.join("technical-documentation.md")).unwrap();
+    // Components in scope reflects the SBOM (1 primary + 2 libs = 3 in CycloneDX
+    // but our SBOM model may handle this differently; assert the structural
+    // header at minimum).
+    assert!(tech.contains("Components in scope:"));
+    assert!(tech.contains("Compliance check summary"));
+    assert!(tech.contains("https://example.com/risk-assessment.pdf"));
+    assert!(tech.contains("ISO/IEC 27005:2022"));
+}
+
+#[test]
+fn cra_docs_auto_discovers_adjacent_sidecar() {
+    let dir = tempdir().unwrap();
+    let sbom = write_temp(dir.path(), "app.cdx.json", MINIMAL_CDX);
+    // sidecar named `<sbom-stem>.cra.json` is auto-discovered
+    let _ = write_temp(dir.path(), "app.cra.json", SIDECAR_JSON);
+    let out = dir.path().join("dossier");
+
+    run_cra_docs(sbom, out.clone(), None, None).expect("cra-docs runs");
+
+    let doc = fs::read_to_string(out.join("eu-declaration-of-conformity.md")).unwrap();
+    assert!(
+        doc.contains("Example Corp"),
+        "auto-discovered sidecar must populate manufacturer"
+    );
+}
+
+#[test]
+fn cra_docs_cli_product_class_overrides_default_when_no_sidecar() {
+    let dir = tempdir().unwrap();
+    let sbom = write_temp(dir.path(), "app.cdx.json", MINIMAL_CDX);
+    let out = dir.path().join("dossier");
+
+    run_cra_docs(
+        sbom,
+        out.clone(),
+        None,
+        Some("critical".to_string()),
+    )
+    .expect("cra-docs runs");
+
+    let doc = fs::read_to_string(out.join("eu-declaration-of-conformity.md")).unwrap();
+    assert!(
+        doc.contains("Critical (Annex IV)"),
+        "CLI --cra-product-class=critical must surface in DoC"
+    );
+    assert!(
+        doc.contains("EUCC"),
+        "Critical class default route is EUCC"
+    );
+}
+
+#[test]
+fn cra_docs_unfilled_fields_show_tbd_placeholders() {
+    let dir = tempdir().unwrap();
+    let sbom = write_temp(dir.path(), "app.cdx.json", MINIMAL_CDX);
+    let out = dir.path().join("dossier");
+
+    run_cra_docs(sbom, out.clone(), None, None).expect("cra-docs runs");
+
+    let doc = fs::read_to_string(out.join("eu-declaration-of-conformity.md")).unwrap();
+    assert!(
+        doc.contains("_TBD"),
+        "DoC without sidecar must contain _TBD_ placeholders for unfilled fields"
+    );
+}

--- a/tests/cra_docs_tests.rs
+++ b/tests/cra_docs_tests.rs
@@ -143,23 +143,14 @@ fn cra_docs_cli_product_class_overrides_default_when_no_sidecar() {
     let sbom = write_temp(dir.path(), "app.cdx.json", MINIMAL_CDX);
     let out = dir.path().join("dossier");
 
-    run_cra_docs(
-        sbom,
-        out.clone(),
-        None,
-        Some("critical".to_string()),
-    )
-    .expect("cra-docs runs");
+    run_cra_docs(sbom, out.clone(), None, Some("critical".to_string())).expect("cra-docs runs");
 
     let doc = fs::read_to_string(out.join("eu-declaration-of-conformity.md")).unwrap();
     assert!(
         doc.contains("Critical (Annex IV)"),
         "CLI --cra-product-class=critical must surface in DoC"
     );
-    assert!(
-        doc.contains("EUCC"),
-        "Critical class default route is EUCC"
-    );
+    assert!(doc.contains("EUCC"), "Critical class default route is EUCC");
 }
 
 #[test]

--- a/tests/cra_golden_fixtures_tests.rs
+++ b/tests/cra_golden_fixtures_tests.rs
@@ -20,8 +20,16 @@ fn fixtures_dir() -> PathBuf {
 fn cra_compliant_cdx_with_sidecar_has_no_errors_at_phase2() {
     let sbom_path = fixtures_dir().join("cra-compliant.cdx.json");
     let sidecar_path = fixtures_dir().join("cra-compliant.cra.json");
-    assert!(sbom_path.exists(), "fixture missing: {}", sbom_path.display());
-    assert!(sidecar_path.exists(), "sidecar missing: {}", sidecar_path.display());
+    assert!(
+        sbom_path.exists(),
+        "fixture missing: {}",
+        sbom_path.display()
+    );
+    assert!(
+        sidecar_path.exists(),
+        "sidecar missing: {}",
+        sidecar_path.display()
+    );
 
     let parsed = parse_sbom(&sbom_path).expect("parse compliant fixture");
     let sidecar = CraSidecarMetadata::from_file(&sidecar_path).expect("load sidecar");
@@ -112,7 +120,10 @@ fn noncompliant_weak_hashes_fires_at_bsi_or_phase2() {
         bsi_hash_finding,
         "weak-hashes fixture must fire a BSI TR-03183-2 hash-related violation; \
          got requirements: {:?}",
-        bsi.violations.iter().map(|v| &v.requirement).collect::<Vec<_>>()
+        bsi.violations
+            .iter()
+            .map(|v| &v.requirement)
+            .collect::<Vec<_>>()
     );
 }
 

--- a/tests/cra_golden_fixtures_tests.rs
+++ b/tests/cra_golden_fixtures_tests.rs
@@ -1,0 +1,159 @@
+//! Golden-fixture regression tests (CRA-P5.2).
+//!
+//! Each fixture pins an expected violation profile against
+//! `ComplianceChecker` so future changes that flip a check into / out of
+//! the active set fail loudly. The expectations are deliberately broad
+//! (presence/absence of a CRA Article, severity classes) rather than
+//! exact violation count, so that adding more fine-grained checks does
+//! not require updating every fixture in lockstep.
+
+use sbom_tools::model::CraSidecarMetadata;
+use sbom_tools::parsers::parse_sbom;
+use sbom_tools::quality::{ComplianceChecker, ComplianceLevel, ViolationSeverity};
+use std::path::PathBuf;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cra")
+}
+
+#[test]
+fn cra_compliant_cdx_with_sidecar_has_no_errors_at_phase2() {
+    let sbom_path = fixtures_dir().join("cra-compliant.cdx.json");
+    let sidecar_path = fixtures_dir().join("cra-compliant.cra.json");
+    assert!(sbom_path.exists(), "fixture missing: {}", sbom_path.display());
+    assert!(sidecar_path.exists(), "sidecar missing: {}", sidecar_path.display());
+
+    let parsed = parse_sbom(&sbom_path).expect("parse compliant fixture");
+    let sidecar = CraSidecarMetadata::from_file(&sidecar_path).expect("load sidecar");
+
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_sidecar(sidecar)
+        .check(&parsed);
+
+    let errors: Vec<_> = result
+        .violations
+        .iter()
+        .filter(|v| v.severity == ViolationSeverity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "Compliant fixture should produce no Errors at CraPhase2; got: {errors:?}"
+    );
+}
+
+#[test]
+fn cra_compliant_cdx_passes_bsi_with_no_errors() {
+    let sbom_path = fixtures_dir().join("cra-compliant.cdx.json");
+    let parsed = parse_sbom(&sbom_path).expect("parse compliant fixture");
+    let result = ComplianceChecker::new(ComplianceLevel::BsiTr03183_2).check(&parsed);
+    let errors: Vec<_> = result
+        .violations
+        .iter()
+        .filter(|v| v.severity == ViolationSeverity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "Compliant fixture should pass BSI TR-03183-2 §5 with no Errors; got: {errors:?}"
+    );
+}
+
+#[test]
+fn cra_compliant_passes_oss_steward_floor() {
+    let sbom_path = fixtures_dir().join("cra-compliant.cdx.json");
+    let sidecar_path = fixtures_dir().join("cra-compliant.cra.json");
+    let parsed = parse_sbom(&sbom_path).unwrap();
+    let sidecar = CraSidecarMetadata::from_file(&sidecar_path).unwrap();
+    let result = ComplianceChecker::new(ComplianceLevel::CraOssSteward)
+        .with_sidecar(sidecar)
+        .check(&parsed);
+    let errors: Vec<_> = result
+        .violations
+        .iter()
+        .filter(|v| v.severity == ViolationSeverity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "Compliant fixture should pass OSS-steward floor with no Errors; got: {errors:?}"
+    );
+}
+
+#[test]
+fn noncompliant_no_manufacturer_fires_art_13_15_or_supplier_check() {
+    let sbom_path = fixtures_dir().join("cra-noncompliant-no-manufacturer.cdx.json");
+    assert!(sbom_path.exists());
+    let parsed = parse_sbom(&sbom_path).expect("parse fixture");
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&parsed);
+
+    let manufacturer_finding = result.violations.iter().any(|v| {
+        v.requirement.contains("Art. 13(15)")
+            || v.requirement.contains("Manufacturer")
+            || v.requirement.contains("manufacturer")
+            || v.requirement.contains("Supplier")
+            || v.requirement.contains("supplier")
+    });
+    assert!(
+        manufacturer_finding,
+        "no-manufacturer fixture should fire either Art. 13(15) or supplier-tracking violation"
+    );
+}
+
+#[test]
+fn noncompliant_weak_hashes_fires_at_bsi_or_phase2() {
+    // BSI TR-03183-2 §5.4 requires SHA-256+ on every component.
+    let sbom_path = fixtures_dir().join("cra-noncompliant-weak-hashes.cdx.json");
+    let parsed = parse_sbom(&sbom_path).expect("parse fixture");
+
+    let bsi = ComplianceChecker::new(ComplianceLevel::BsiTr03183_2).check(&parsed);
+    let bsi_hash_finding = bsi
+        .violations
+        .iter()
+        .any(|v| v.requirement.contains("BSI TR-03183-2") || v.requirement.contains("hash"));
+    assert!(
+        bsi_hash_finding,
+        "weak-hashes fixture must fire a BSI TR-03183-2 hash-related violation; \
+         got requirements: {:?}",
+        bsi.violations.iter().map(|v| &v.requirement).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn vendor_hash_carry_through_satisfied_by_compliant_fixture() {
+    // The compliant fixture has SHA-256 on every vendor component. Under
+    // CraPhase2 + ImportantClass2 (80% threshold, Error), no vendor-hash
+    // violation should fire.
+    let sbom_path = fixtures_dir().join("cra-compliant.cdx.json");
+    let sidecar_path = fixtures_dir().join("cra-compliant.cra.json");
+    let parsed = parse_sbom(&sbom_path).unwrap();
+    let mut sc = CraSidecarMetadata::from_file(&sidecar_path).unwrap();
+    sc.product_class = Some(sbom_tools::model::CraProductClass::ImportantClass2);
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_sidecar(sc)
+        .check(&parsed);
+    assert!(
+        !result
+            .violations
+            .iter()
+            .any(|v| v.requirement.contains("PRE-7-RQ-07-RE")),
+        "Compliant fixture must clear vendor-hash carry-through at Important-2"
+    );
+}
+
+#[test]
+fn conformity_summary_present_when_class_pinned_via_sidecar() {
+    let sbom_path = fixtures_dir().join("cra-compliant.cdx.json");
+    let sidecar_path = fixtures_dir().join("cra-compliant.cra.json");
+    let parsed = parse_sbom(&sbom_path).unwrap();
+    let sc = CraSidecarMetadata::from_file(&sidecar_path).unwrap();
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_sidecar(sc)
+        .check(&parsed);
+    assert!(
+        result.conformity_summary.is_some(),
+        "Sidecar pins productClass=important-class-1 → summary expected"
+    );
+    let summary = result.conformity_summary.unwrap();
+    assert_eq!(
+        summary.product_class,
+        sbom_tools::model::CraProductClass::ImportantClass1
+    );
+}

--- a/tests/cra_oss_steward_tests.rs
+++ b/tests/cra_oss_steward_tests.rs
@@ -1,0 +1,251 @@
+//! Integration tests for CRA-P3.3 Article 24 open-source steward profile.
+//!
+//! Article 24 stewards (Eclipse Foundation, Apache, Linux Foundation, etc.)
+//! supply software under the CRA but with reduced obligations: SBOM,
+//! vulnerability handling process, and CVD policy are still required;
+//! manufacturer email, EU DoC, conformity-assessment module, and Article 14
+//! reporting channels are NOT enforced.
+
+use sbom_tools::model::{
+    Component, CraSidecarMetadata, ExternalRefType, ExternalReference, NormalizedSbom,
+};
+use sbom_tools::quality::{ComplianceChecker, ComplianceLevel, ViolationSeverity};
+
+fn empty_sbom() -> NormalizedSbom {
+    NormalizedSbom::default()
+}
+
+fn sbom_with_security_contact() -> NormalizedSbom {
+    let mut sbom = NormalizedSbom::default();
+    let mut c = Component::new("foo".to_string(), "foo".to_string())
+        .with_purl("pkg:cargo/foo@1.0".to_string());
+    c.external_refs.push(ExternalReference {
+        ref_type: ExternalRefType::SecurityContact,
+        url: "https://example.org/security".to_string(),
+        comment: None,
+        hashes: Vec::new(),
+    });
+    sbom.add_component(c);
+    sbom
+}
+
+fn sbom_with_advisories() -> NormalizedSbom {
+    let mut sbom = NormalizedSbom::default();
+    let mut c = Component::new("foo".to_string(), "foo".to_string())
+        .with_purl("pkg:cargo/foo@1.0".to_string());
+    c.external_refs.push(ExternalReference {
+        ref_type: ExternalRefType::Advisories,
+        url: "https://example.org/advisories".to_string(),
+        comment: None,
+        hashes: Vec::new(),
+    });
+    sbom.add_component(c);
+    sbom
+}
+
+#[test]
+fn oss_steward_is_cra_aligned() {
+    assert!(ComplianceLevel::CraOssSteward.is_cra());
+    assert_eq!(ComplianceLevel::CraOssSteward.cra_phase(), None);
+}
+
+#[test]
+fn oss_steward_listed_in_all() {
+    assert!(ComplianceLevel::all().contains(&ComplianceLevel::CraOssSteward));
+}
+
+#[test]
+fn oss_steward_short_name_fits_compact_label() {
+    assert!(ComplianceLevel::CraOssSteward.short_name().len() <= 8);
+}
+
+#[test]
+fn oss_steward_does_not_require_manufacturer_email() {
+    // Eclipse-Foundation-style SBOM: no manufacturer email, no DoC reference,
+    // no Article 14 channels — but DOES have a SecurityContact for the
+    // vulnerability-handling process.
+    let sbom = sbom_with_security_contact();
+
+    let res_steward =
+        ComplianceChecker::new(ComplianceLevel::CraOssSteward).check(&sbom);
+    let res_phase2 = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+
+    // Steward profile: should not fire manufacturer-email Art. 13(15)
+    assert!(
+        !res_steward
+            .violations
+            .iter()
+            .any(|v| v.requirement.contains("Art. 13(15)")
+                || v.requirement.contains("Manufacturer")),
+        "OSS steward must not fire manufacturer-email checks"
+    );
+
+    // Steward profile: should not fire Article 14 reporting checks
+    assert!(
+        !res_steward
+            .violations
+            .iter()
+            .any(|v| v.requirement.contains("Art. 14")),
+        "OSS steward must not fire Article 14 reporting checks"
+    );
+
+    // Steward profile: should not fire EU DoC (Annex VII) check
+    assert!(
+        !res_steward
+            .violations
+            .iter()
+            .any(|v| v.requirement.contains("Annex VII")
+                || v.requirement.contains("Declaration of Conformity")),
+        "OSS steward must not fire EU DoC checks"
+    );
+
+    // Steward profile: should not fire vendor-hash carry-through ([PRE-7-RQ-07-RE])
+    assert!(
+        !res_steward
+            .violations
+            .iter()
+            .any(|v| v.requirement.contains("PRE-7-RQ-07-RE")),
+        "OSS steward must not fire vendor-hash carry-through"
+    );
+
+    // Same SBOM under CraPhase2: SHOULD fire at least one of the
+    // manufacturer-only checks the steward profile relaxes.
+    let phase2_has_manufacturer_only = res_phase2.violations.iter().any(|v| {
+        v.requirement.contains("Art. 14")
+            || v.requirement.contains("Annex VII")
+            || v.requirement.contains("PRE-7-RQ-07-RE")
+    });
+    assert!(
+        phase2_has_manufacturer_only,
+        "Sanity: same SBOM under CraPhase2 should still surface manufacturer-only checks"
+    );
+}
+
+#[test]
+fn oss_steward_requires_vulnerability_handling_process() {
+    // Bare SBOM with no SecurityContact / Advisories / sidecar PSIRT URL:
+    // steward floor must fire an Error.
+    let sbom = empty_sbom();
+    let res = ComplianceChecker::new(ComplianceLevel::CraOssSteward).check(&sbom);
+    let v = res
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("Vulnerability-handling process"))
+        .expect("Steward must require vuln-handling process");
+    assert_eq!(v.severity, ViolationSeverity::Error);
+}
+
+#[test]
+fn oss_steward_vuln_handling_satisfied_by_security_contact() {
+    let sbom = sbom_with_security_contact();
+    let res = ComplianceChecker::new(ComplianceLevel::CraOssSteward).check(&sbom);
+    assert!(
+        !res.violations
+            .iter()
+            .any(|v| v.requirement.contains("Vulnerability-handling process")),
+        "SecurityContact external ref satisfies steward vuln-handling requirement"
+    );
+}
+
+#[test]
+fn oss_steward_vuln_handling_satisfied_by_sidecar_psirt() {
+    let sbom = empty_sbom();
+    let sidecar = CraSidecarMetadata {
+        psirt_url: Some("https://example.org/psirt".to_string()),
+        ..Default::default()
+    };
+    let res = ComplianceChecker::new(ComplianceLevel::CraOssSteward)
+        .with_sidecar(sidecar)
+        .check(&sbom);
+    assert!(
+        !res.violations
+            .iter()
+            .any(|v| v.requirement.contains("Vulnerability-handling process")),
+        "Sidecar psirt_url satisfies steward vuln-handling requirement"
+    );
+}
+
+#[test]
+fn oss_steward_recommends_cvd_policy_as_warning() {
+    // No Advisories ref, no sidecar coordinated_disclosure_policy_url
+    let sbom = sbom_with_security_contact();
+    let res = ComplianceChecker::new(ComplianceLevel::CraOssSteward).check(&sbom);
+    let v = res
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("Art. 13(7)"))
+        .expect("Steward should warn on missing CVD policy");
+    assert_eq!(v.severity, ViolationSeverity::Warning);
+}
+
+#[test]
+fn oss_steward_cvd_satisfied_by_advisories_ref() {
+    let sbom = sbom_with_advisories();
+    let res = ComplianceChecker::new(ComplianceLevel::CraOssSteward).check(&sbom);
+    assert!(
+        !res.violations
+            .iter()
+            .any(|v| v.requirement.contains("Art. 13(7)")),
+        "Advisories external ref satisfies CVD policy requirement"
+    );
+}
+
+#[test]
+fn oss_steward_cvd_satisfied_by_sidecar_policy_url() {
+    let sbom = sbom_with_security_contact();
+    let sidecar = CraSidecarMetadata {
+        coordinated_disclosure_policy_url: Some(
+            "https://example.org/security/cvd-policy".to_string(),
+        ),
+        ..Default::default()
+    };
+    let res = ComplianceChecker::new(ComplianceLevel::CraOssSteward)
+        .with_sidecar(sidecar)
+        .check(&sbom);
+    assert!(
+        !res.violations
+            .iter()
+            .any(|v| v.requirement.contains("Art. 13(7)")),
+        "Sidecar coordinated_disclosure_policy_url satisfies CVD requirement"
+    );
+}
+
+#[test]
+fn oss_steward_does_not_run_hardware_check() {
+    // A "device" component with no producer/version: under CraPhase2 this
+    // would fire the [PRE-8-RQ-02] hardware check. Under steward, it's
+    // skipped entirely.
+    let mut sbom = sbom_with_security_contact();
+    let mut device = Component::new("hw".to_string(), "router-mcu".to_string());
+    device.component_type = sbom_tools::model::ComponentType::Device;
+    sbom.add_component(device);
+
+    let res = ComplianceChecker::new(ComplianceLevel::CraOssSteward).check(&sbom);
+    assert!(
+        !res.violations
+            .iter()
+            .any(|v| v.requirement.contains("PRE-8-RQ-02")),
+        "OSS steward must not run hardware [PRE-8-RQ-02] checks"
+    );
+}
+
+#[test]
+fn sidecar_is_oss_steward_field_roundtrips() {
+    let original = CraSidecarMetadata {
+        is_oss_steward: true,
+        ..Default::default()
+    };
+    let json = serde_json::to_string(&original).unwrap();
+    assert!(json.contains("is_oss_steward") || json.contains("isOssSteward"));
+    let parsed: CraSidecarMetadata = serde_json::from_str(&json).unwrap();
+    assert!(parsed.is_oss_steward);
+
+    // Default value (false) must NOT serialize (skip_serializing_if)
+    let default_sidecar = CraSidecarMetadata::default();
+    let default_json = serde_json::to_string(&default_sidecar).unwrap();
+    assert!(
+        !default_json.contains("is_oss_steward")
+            && !default_json.contains("isOssSteward"),
+        "is_oss_steward=false should be skipped during serialization"
+    );
+}

--- a/tests/cra_oss_steward_tests.rs
+++ b/tests/cra_oss_steward_tests.rs
@@ -66,17 +66,14 @@ fn oss_steward_does_not_require_manufacturer_email() {
     // vulnerability-handling process.
     let sbom = sbom_with_security_contact();
 
-    let res_steward =
-        ComplianceChecker::new(ComplianceLevel::CraOssSteward).check(&sbom);
+    let res_steward = ComplianceChecker::new(ComplianceLevel::CraOssSteward).check(&sbom);
     let res_phase2 = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
 
     // Steward profile: should not fire manufacturer-email Art. 13(15)
     assert!(
-        !res_steward
-            .violations
-            .iter()
-            .any(|v| v.requirement.contains("Art. 13(15)")
-                || v.requirement.contains("Manufacturer")),
+        !res_steward.violations.iter().any(
+            |v| v.requirement.contains("Art. 13(15)") || v.requirement.contains("Manufacturer")
+        ),
         "OSS steward must not fire manufacturer-email checks"
     );
 
@@ -244,8 +241,7 @@ fn sidecar_is_oss_steward_field_roundtrips() {
     let default_sidecar = CraSidecarMetadata::default();
     let default_json = serde_json::to_string(&default_sidecar).unwrap();
     assert!(
-        !default_json.contains("is_oss_steward")
-            && !default_json.contains("isOssSteward"),
+        !default_json.contains("is_oss_steward") && !default_json.contains("isOssSteward"),
         "is_oss_steward=false should be skipped during serialization"
     );
 }

--- a/tests/cra_p1_p2_gaps_tests.rs
+++ b/tests/cra_p1_p2_gaps_tests.rs
@@ -1,0 +1,342 @@
+//! Integration tests for CRA P1/P2 gap-fill features.
+//!
+//! Covers cases listed in `memory/cra-improvement-plan.md` that were not
+//! exercised by the unit tests landed in P1/P2:
+//! - sidecar auto-discovery preference vs. explicit flag
+//! - invalid sidecar YAML must not panic
+//! - Annex I Part III transitive=Warning under CraPhase1
+//! - SBOM-side ExternalRefType::RiskAssessment satisfies Art. 13(2)
+//! - multi-standard `--standard bsi,cra,ntia` produces independent results
+
+use sbom_tools::model::{
+    Component, CraSidecarMetadata, DependencyEdge, DependencyType, ExternalRefType,
+    ExternalReference, NormalizedSbom, Organization, SwhidKind,
+};
+use sbom_tools::quality::{ComplianceChecker, ComplianceLevel, ViolationSeverity};
+use std::path::PathBuf;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/cra")
+}
+
+#[test]
+fn invalid_sidecar_yaml_does_not_panic_returns_error() {
+    let path = fixtures_dir().join("invalid.cra.yaml");
+    assert!(path.exists(), "fixture missing: {}", path.display());
+    let result = CraSidecarMetadata::from_file(&path);
+    assert!(
+        result.is_err(),
+        "Invalid YAML should return an error, not panic"
+    );
+}
+
+#[test]
+fn sidecar_auto_discovery_prefers_explicit_flag() {
+    let dir = tempfile::tempdir().unwrap();
+    let sbom_path = dir.path().join("sbom.json");
+    std::fs::write(
+        &sbom_path,
+        r#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[]}"#,
+    )
+    .unwrap();
+
+    // Auto-discoverable sidecar adjacent to the SBOM.
+    let auto = CraSidecarMetadata {
+        manufacturer_name: Some("AutoDiscoveredCorp".to_string()),
+        ..Default::default()
+    };
+    std::fs::write(
+        dir.path().join("sbom.cra.json"),
+        serde_json::to_string(&auto).unwrap(),
+    )
+    .unwrap();
+
+    // Sanity: auto-discovery would pick up "AutoDiscoveredCorp"
+    let discovered = CraSidecarMetadata::find_for_sbom(&sbom_path).unwrap();
+    assert_eq!(
+        discovered.manufacturer_name.as_deref(),
+        Some("AutoDiscoveredCorp")
+    );
+
+    // An explicit path should override auto-discovery semantics — we model
+    // that by simulating the precedence the CLI implements: when explicit
+    // path is provided, callers use it directly and never invoke find_for_sbom.
+    let explicit_path = dir.path().join("explicit.cra.json");
+    let explicit = CraSidecarMetadata {
+        manufacturer_name: Some("ExplicitCorp".to_string()),
+        ..Default::default()
+    };
+    std::fs::write(&explicit_path, serde_json::to_string(&explicit).unwrap()).unwrap();
+
+    let loaded = CraSidecarMetadata::from_file(&explicit_path).unwrap();
+    assert_eq!(
+        loaded.manufacturer_name.as_deref(),
+        Some("ExplicitCorp"),
+        "Explicit path should load the explicit file, not the auto-discovered one"
+    );
+}
+
+#[test]
+fn cra_phase1_transitive_supplier_is_warning_or_softer() {
+    let mut sbom = NormalizedSbom::default();
+    let mut app = Component::new("app".to_string(), "app".to_string())
+        .with_purl("pkg:cargo/app@1.0".to_string());
+    app.supplier = Some(Organization::new("AppCorp".to_string()));
+    let mut lib = Component::new("lib".to_string(), "lib".to_string())
+        .with_purl("pkg:cargo/lib@1.0".to_string());
+    lib.supplier = Some(Organization::new("LibCorp".to_string()));
+    let deep = Component::new("deep".to_string(), "deep".to_string())
+        .with_purl("pkg:cargo/deep@1.0".to_string());
+
+    let app_id = app.canonical_id.clone();
+    let lib_id = lib.canonical_id.clone();
+    let deep_id = deep.canonical_id.clone();
+    sbom.primary_component_id = Some(app_id.clone());
+    sbom.components.insert(app_id.clone(), app);
+    sbom.components.insert(lib_id.clone(), lib);
+    sbom.components.insert(deep_id.clone(), deep);
+    sbom.edges.push(DependencyEdge::new(
+        app_id,
+        lib_id.clone(),
+        DependencyType::DependsOn,
+    ));
+    sbom.edges.push(DependencyEdge::new(
+        lib_id,
+        deep_id,
+        DependencyType::DependsOn,
+    ));
+
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase1).check(&sbom);
+    let direct_err = result.violations.iter().any(|v| {
+        v.requirement.contains("Direct dependency supplier")
+            && v.severity == ViolationSeverity::Error
+    });
+    assert!(
+        !direct_err,
+        "Under CraPhase1, direct dependency missing supplier is at most a Warning, not Error"
+    );
+    let transitive_severity = result
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("Transitive dependency supplier"))
+        .map(|v| v.severity);
+    assert!(
+        matches!(
+            transitive_severity,
+            Some(ViolationSeverity::Warning) | Some(ViolationSeverity::Info)
+        ),
+        "Under CraPhase1, transitive supplier missing should be Warning or Info; got {transitive_severity:?}"
+    );
+}
+
+#[test]
+fn art_13_2_external_reference_satisfies_check() {
+    let mut sbom = NormalizedSbom::default();
+    let mut comp = Component::new("app".to_string(), "app".to_string())
+        .with_purl("pkg:cargo/app@1.0".to_string());
+    comp.external_refs.push(ExternalReference {
+        ref_type: ExternalRefType::RiskAssessment,
+        url: "https://example.com/risk-assessment.pdf".to_string(),
+        comment: None,
+        hashes: Vec::new(),
+    });
+    sbom.add_component(comp);
+
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+    assert!(
+        !result
+            .violations
+            .iter()
+            .any(|v| v.requirement.contains("Art. 13(2)")),
+        "SBOM-side risk-assessment ExternalReference should satisfy Art. 13(2)"
+    );
+}
+
+#[test]
+fn multi_standard_bsi_cra_ntia_produces_independent_results() {
+    // Empty SBOM exercises all three checks producing distinct violation sets.
+    let sbom = NormalizedSbom::default();
+    let bsi = ComplianceChecker::new(ComplianceLevel::BsiTr03183_2).check(&sbom);
+    let cra = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+    let ntia = ComplianceChecker::new(ComplianceLevel::NtiaMinimum).check(&sbom);
+
+    // Each level produces violations
+    assert!(!bsi.violations.is_empty());
+    assert!(!cra.violations.is_empty());
+    assert!(!ntia.violations.is_empty());
+
+    // Levels are reported correctly
+    assert_eq!(bsi.level, ComplianceLevel::BsiTr03183_2);
+    assert_eq!(cra.level, ComplianceLevel::CraPhase2);
+    assert_eq!(ntia.level, ComplianceLevel::NtiaMinimum);
+
+    // BSI-only requirement IDs only appear in the BSI result
+    let bsi_specific = bsi
+        .violations
+        .iter()
+        .any(|v| v.requirement.contains("BSI TR-03183-2"));
+    let cra_has_bsi = cra
+        .violations
+        .iter()
+        .any(|v| v.requirement.contains("BSI TR-03183-2"));
+    let ntia_has_bsi = ntia
+        .violations
+        .iter()
+        .any(|v| v.requirement.contains("BSI TR-03183-2"));
+    assert!(
+        bsi_specific,
+        "BSI level must produce BSI-specific violations"
+    );
+    assert!(
+        !cra_has_bsi,
+        "CRA level must not surface BSI-specific violations"
+    );
+    assert!(
+        !ntia_has_bsi,
+        "NTIA level must not surface BSI-specific violations"
+    );
+
+    // CRA-only Art. 14 readiness only appears in the CRA result
+    let cra_has_art_14 = cra
+        .violations
+        .iter()
+        .any(|v| v.requirement.contains("Art. 14"));
+    let bsi_has_art_14 = bsi
+        .violations
+        .iter()
+        .any(|v| v.requirement.contains("Art. 14"));
+    assert!(cra_has_art_14, "CRA level must produce Art. 14 violations");
+    assert!(
+        !bsi_has_art_14,
+        "BSI level must not surface Art. 14 violations"
+    );
+}
+
+#[test]
+fn hardware_fixture_passes_pre_8_rq_02() {
+    let path = fixtures_dir().join("router-hardware.cdx.json");
+    assert!(path.exists(), "fixture missing: {}", path.display());
+    let parsed = sbom_tools::parsers::parse_sbom(&path).expect("parse hardware fixture");
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&parsed);
+
+    // The fixture is intentionally well-formed for hardware: every device/
+    // firmware component has producer + identifier + version (firmware).
+    let pre_8 = result
+        .violations
+        .iter()
+        .filter(|v| v.requirement.contains("PRE-8-RQ-02"))
+        .filter(|v| v.severity == ViolationSeverity::Error)
+        .count();
+    assert_eq!(
+        pre_8, 0,
+        "Hardware fixture should produce no [PRE-8-RQ-02] errors; got {pre_8}"
+    );
+}
+
+#[test]
+fn swhid_roundtrip_fixture_parses_all_kinds() {
+    let path = fixtures_dir().join("swhid-roundtrip.cdx.json");
+    assert!(path.exists(), "fixture missing: {}", path.display());
+    let parsed = sbom_tools::parsers::parse_sbom(&path).expect("parse SWHID fixture");
+
+    let by_name = |name: &str| -> &sbom_tools::model::Component {
+        parsed
+            .components
+            .values()
+            .find(|c| c.name == name)
+            .unwrap_or_else(|| panic!("missing component {name}"))
+    };
+
+    // 1. cnt SWHID
+    let cnt = by_name("lib-content");
+    assert_eq!(cnt.identifiers.swhid.len(), 1);
+    assert_eq!(cnt.identifiers.swhid[0].kind, SwhidKind::Cnt);
+    assert_eq!(
+        cnt.identifiers.swhid[0].hash_hex(),
+        "94a9ed024d3859793618152ea559a168bbcbb5e2"
+    );
+    assert!(cnt.identifiers.swhid[0].qualifiers.is_empty());
+    assert_eq!(
+        cnt.identifiers.swhid[0].to_string(),
+        "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2",
+        "cnt SWHID must round-trip exactly"
+    );
+
+    // 2. dir SWHID
+    let dir = by_name("lib-tree");
+    assert_eq!(dir.identifiers.swhid[0].kind, SwhidKind::Dir);
+
+    // 3. rev SWHID with origin qualifier
+    let rev = by_name("lib-revision");
+    assert_eq!(rev.identifiers.swhid[0].kind, SwhidKind::Rev);
+    assert_eq!(rev.identifiers.swhid[0].qualifiers.len(), 1);
+    assert_eq!(
+        rev.identifiers.swhid[0].qualifiers[0],
+        (
+            "origin".to_string(),
+            "https://github.com/example/lib-revision".to_string()
+        )
+    );
+    // Round-trip preserves the qualifier
+    assert_eq!(
+        rev.identifiers.swhid[0].to_string(),
+        "swh:1:rev:deadbeefdeadbeefdeadbeefdeadbeefdeadbeef;origin=https://github.com/example/lib-revision"
+    );
+
+    // 4. Multiple SWHIDs on a single component
+    let multi = by_name("lib-multi-swhid");
+    assert_eq!(multi.identifiers.swhid.len(), 2);
+    assert_eq!(multi.identifiers.swhid[0].kind, SwhidKind::Cnt);
+    assert_eq!(multi.identifiers.swhid[1].kind, SwhidKind::Dir);
+
+    // CRA Annex I [PRE-7-RQ-07] check: components with only SWHID still
+    // satisfy the identifier requirement (proven by no Annex I violation
+    // for these names — they all also have PURLs, but the BSI/CRA checks
+    // accept SWHID alone, exercised by other unit tests).
+    assert!(cnt.identifiers.has_cra_identifier());
+    assert!(dir.identifiers.has_cra_identifier());
+    assert!(rev.identifiers.has_cra_identifier());
+    assert!(multi.identifiers.has_cra_identifier());
+}
+
+#[test]
+fn bsi_fixture_with_sidecar_passes() {
+    let sbom_path = fixtures_dir().join("bsi-compliant.cdx.json");
+    let sidecar_path = fixtures_dir().join("bsi-compliant.cra.json");
+    assert!(sbom_path.exists());
+    assert!(sidecar_path.exists());
+
+    let parsed = sbom_tools::parsers::parse_sbom(&sbom_path).expect("parse BSI fixture");
+    let sidecar = CraSidecarMetadata::from_file(&sidecar_path).expect("load BSI fixture sidecar");
+
+    // BSI level: the fixture itself satisfies all §5 mandatory rules
+    let bsi = ComplianceChecker::new(ComplianceLevel::BsiTr03183_2).check(&parsed);
+    let errors: Vec<_> = bsi
+        .violations
+        .iter()
+        .filter(|v| v.severity == ViolationSeverity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "BSI-compliant fixture should produce no Errors at BsiTr03183_2 level; got {errors:?}"
+    );
+
+    // CRA level + sidecar: should not produce Warning-level Art. 13(15)/13(12)/13(7) findings
+    let cra_with_sc = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_sidecar(sidecar)
+        .check(&parsed);
+    let warnings_for: Vec<_> = cra_with_sc
+        .violations
+        .iter()
+        .filter(|v| v.severity == ViolationSeverity::Warning)
+        .filter(|v| {
+            v.requirement.contains("Art. 13(15)")
+                || v.requirement.contains("Art. 13(12)")
+                || v.requirement.contains("Art. 13(7)")
+        })
+        .collect();
+    assert!(
+        warnings_for.is_empty(),
+        "CRA + sidecar should suppress Art. 13(15)/13(12)/13(7) Warnings; got {warnings_for:?}"
+    );
+}

--- a/tests/cra_p5_tests.rs
+++ b/tests/cra_p5_tests.rs
@@ -1,0 +1,274 @@
+//! Combined integration tests for CRA-P5.4 (EuccSubstantial),
+//! P5.5 (controls-assertion sidecar block), and P5.7 (TUI presets).
+
+use sbom_tools::model::{ControlAssertion, CraSidecarMetadata};
+use sbom_tools::quality::{ComplianceChecker, ComplianceLevel, ViolationSeverity};
+use std::collections::BTreeMap;
+
+// ============================================================================
+// P5.4 — EuccSubstantial
+// ============================================================================
+
+#[test]
+fn eucc_substantial_in_compliance_level_all() {
+    assert!(ComplianceLevel::all().contains(&ComplianceLevel::EuccSubstantial));
+}
+
+#[test]
+fn eucc_substantial_short_name_fits_compact_label() {
+    assert!(ComplianceLevel::EuccSubstantial.short_name().len() <= 8);
+}
+
+#[test]
+fn eucc_substantial_without_sidecar_fires_all_four_must_haves() {
+    let sbom = sbom_tools::model::NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::EuccSubstantial).check(&sbom);
+    let requirements: Vec<&String> = result.violations.iter().map(|v| &v.requirement).collect();
+    assert!(
+        requirements
+            .iter()
+            .any(|r| r.contains("Protection Profile reference"))
+    );
+    assert!(
+        requirements
+            .iter()
+            .any(|r| r.contains("Target of Evaluation reference"))
+    );
+    assert!(requirements.iter().any(|r| r.contains("ITSEF")));
+    assert!(
+        requirements
+            .iter()
+            .any(|r| r.contains("valid-until date"))
+    );
+}
+
+#[test]
+fn eucc_substantial_with_complete_sidecar_only_warns() {
+    let sidecar = CraSidecarMetadata {
+        eucc_protection_profile_id: Some("PP-CC-MFR-2024-01".to_string()),
+        eucc_target_of_evaluation: Some("https://example.com/toe".to_string()),
+        eucc_itsef_identifier: Some("ITSEF-DE-001".to_string()),
+        eucc_valid_until: Some(
+            chrono::DateTime::parse_from_rfc3339("2030-12-31T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        ),
+        ..Default::default()
+    };
+    let sbom = sbom_tools::model::NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::EuccSubstantial)
+        .with_sidecar(sidecar)
+        .check(&sbom);
+    let errors: Vec<_> = result
+        .violations
+        .iter()
+        .filter(|v| v.severity == ViolationSeverity::Error)
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "Complete EUCC sidecar should produce no Errors; got {errors:?}"
+    );
+}
+
+#[test]
+fn eucc_substantial_expired_certificate_is_error() {
+    let sidecar = CraSidecarMetadata {
+        eucc_protection_profile_id: Some("PP".to_string()),
+        eucc_target_of_evaluation: Some("toe".to_string()),
+        eucc_itsef_identifier: Some("itsef".to_string()),
+        eucc_valid_until: Some(
+            chrono::DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&chrono::Utc),
+        ),
+        ..Default::default()
+    };
+    let sbom = sbom_tools::model::NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::EuccSubstantial)
+        .with_sidecar(sidecar)
+        .check(&sbom);
+    assert!(
+        result.violations.iter().any(|v| v.severity == ViolationSeverity::Error
+            && v.message.contains("expired"))
+    );
+}
+
+#[test]
+fn eucc_substantial_near_expiry_is_warning() {
+    let near = chrono::Utc::now() + chrono::Duration::days(60);
+    let sidecar = CraSidecarMetadata {
+        eucc_protection_profile_id: Some("PP".to_string()),
+        eucc_target_of_evaluation: Some("toe".to_string()),
+        eucc_itsef_identifier: Some("itsef".to_string()),
+        eucc_valid_until: Some(near),
+        ..Default::default()
+    };
+    let sbom = sbom_tools::model::NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::EuccSubstantial)
+        .with_sidecar(sidecar)
+        .check(&sbom);
+    assert!(
+        result.violations.iter().any(|v| v.severity == ViolationSeverity::Warning
+            && v.message.contains("expires within"))
+    );
+}
+
+// ============================================================================
+// P5.5 — controls-assertion sidecar block
+// ============================================================================
+
+#[test]
+fn controls_assertion_satisfied_with_evidence_clears_check() {
+    let mut controls: BTreeMap<String, ControlAssertion> = BTreeMap::new();
+    controls.insert(
+        "1.a".to_string(),
+        ControlAssertion {
+            satisfied: true,
+            evidence_url: Some("https://example.com/evidence/1.a.pdf".to_string()),
+            methodology: Some("prEN 40000-1-2 §5.3".to_string()),
+            note: None,
+        },
+    );
+    let sidecar = CraSidecarMetadata {
+        annex_i_part_i_controls: controls,
+        ..Default::default()
+    };
+    let sbom = sbom_tools::model::NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_sidecar(sidecar)
+        .check(&sbom);
+    assert!(
+        !result
+            .violations
+            .iter()
+            .any(|v| v.requirement.contains("Annex I Part I 1.a")),
+        "satisfied + evidence_url present must not fire"
+    );
+}
+
+#[test]
+fn controls_assertion_satisfied_without_evidence_fires_warning() {
+    let mut controls: BTreeMap<String, ControlAssertion> = BTreeMap::new();
+    controls.insert(
+        "1.a".to_string(),
+        ControlAssertion {
+            satisfied: true,
+            evidence_url: None,
+            methodology: Some("informal".to_string()),
+            note: None,
+        },
+    );
+    let sidecar = CraSidecarMetadata {
+        annex_i_part_i_controls: controls,
+        ..Default::default()
+    };
+    let sbom = sbom_tools::model::NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_sidecar(sidecar)
+        .check(&sbom);
+    let v = result
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("Annex I Part I 1.a"))
+        .expect("warning expected");
+    assert_eq!(v.severity, ViolationSeverity::Warning);
+}
+
+#[test]
+fn controls_assertion_unsatisfied_does_not_fire() {
+    let mut controls: BTreeMap<String, ControlAssertion> = BTreeMap::new();
+    controls.insert(
+        "1.b".to_string(),
+        ControlAssertion {
+            satisfied: false,
+            evidence_url: None,
+            methodology: None,
+            note: Some("Not yet implemented".to_string()),
+        },
+    );
+    let sidecar = CraSidecarMetadata {
+        annex_i_part_i_controls: controls,
+        ..Default::default()
+    };
+    let sbom = sbom_tools::model::NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_sidecar(sidecar)
+        .check(&sbom);
+    assert!(
+        !result
+            .violations
+            .iter()
+            .any(|v| v.requirement.contains("Annex I Part I 1.b"))
+    );
+}
+
+#[test]
+fn controls_assertion_serde_roundtrip_preserves_btreemap() {
+    let mut controls: BTreeMap<String, ControlAssertion> = BTreeMap::new();
+    controls.insert(
+        "1.a".to_string(),
+        ControlAssertion {
+            satisfied: true,
+            evidence_url: Some("u".to_string()),
+            methodology: Some("m".to_string()),
+            note: None,
+        },
+    );
+    controls.insert(
+        "2.m".to_string(),
+        ControlAssertion {
+            satisfied: false,
+            ..Default::default()
+        },
+    );
+    let original = CraSidecarMetadata {
+        annex_i_part_i_controls: controls,
+        ..Default::default()
+    };
+    let json = serde_json::to_string(&original).unwrap();
+    assert!(json.contains("annex_i_part_i_controls") || json.contains("annexIPartIControls"));
+    let parsed: CraSidecarMetadata = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed.annex_i_part_i_controls.len(), 2);
+    assert!(parsed.annex_i_part_i_controls["1.a"].satisfied);
+    assert!(!parsed.annex_i_part_i_controls["2.m"].satisfied);
+
+    // Default (empty) must skip serialization.
+    let default_json = serde_json::to_string(&CraSidecarMetadata::default()).unwrap();
+    assert!(!default_json.contains("annex_i_part_i_controls"));
+    assert!(!default_json.contains("annexIPartIControls"));
+}
+
+// ============================================================================
+// P5.7 — TUI presets
+// ============================================================================
+
+#[test]
+fn tui_policy_preset_includes_eucc_and_oss_steward() {
+    use sbom_tools::tui::PolicyPreset;
+    let p = PolicyPreset::EuccSubstantial;
+    assert_eq!(
+        p.compliance_level(),
+        Some(ComplianceLevel::EuccSubstantial)
+    );
+    assert!(p.is_standards_based());
+
+    let oss = PolicyPreset::CraOssSteward;
+    assert_eq!(
+        oss.compliance_level(),
+        Some(ComplianceLevel::CraOssSteward)
+    );
+    assert!(oss.is_standards_based());
+}
+
+#[test]
+fn tui_policy_preset_cycle_visits_eucc_and_oss_steward() {
+    use sbom_tools::tui::PolicyPreset;
+    let mut seen = Vec::new();
+    let mut p = PolicyPreset::Enterprise;
+    for _ in 0..14 {
+        seen.push(p);
+        p = p.next();
+    }
+    assert!(seen.contains(&PolicyPreset::EuccSubstantial));
+    assert!(seen.contains(&PolicyPreset::CraOssSteward));
+}

--- a/tests/cra_p5_tests.rs
+++ b/tests/cra_p5_tests.rs
@@ -35,11 +35,7 @@ fn eucc_substantial_without_sidecar_fires_all_four_must_haves() {
             .any(|r| r.contains("Target of Evaluation reference"))
     );
     assert!(requirements.iter().any(|r| r.contains("ITSEF")));
-    assert!(
-        requirements
-            .iter()
-            .any(|r| r.contains("valid-until date"))
-    );
+    assert!(requirements.iter().any(|r| r.contains("valid-until date")));
 }
 
 #[test]
@@ -88,8 +84,10 @@ fn eucc_substantial_expired_certificate_is_error() {
         .with_sidecar(sidecar)
         .check(&sbom);
     assert!(
-        result.violations.iter().any(|v| v.severity == ViolationSeverity::Error
-            && v.message.contains("expired"))
+        result
+            .violations
+            .iter()
+            .any(|v| v.severity == ViolationSeverity::Error && v.message.contains("expired"))
     );
 }
 
@@ -108,8 +106,11 @@ fn eucc_substantial_near_expiry_is_warning() {
         .with_sidecar(sidecar)
         .check(&sbom);
     assert!(
-        result.violations.iter().any(|v| v.severity == ViolationSeverity::Warning
-            && v.message.contains("expires within"))
+        result
+            .violations
+            .iter()
+            .any(|v| v.severity == ViolationSeverity::Warning
+                && v.message.contains("expires within"))
     );
 }
 
@@ -246,17 +247,11 @@ fn controls_assertion_serde_roundtrip_preserves_btreemap() {
 fn tui_policy_preset_includes_eucc_and_oss_steward() {
     use sbom_tools::tui::PolicyPreset;
     let p = PolicyPreset::EuccSubstantial;
-    assert_eq!(
-        p.compliance_level(),
-        Some(ComplianceLevel::EuccSubstantial)
-    );
+    assert_eq!(p.compliance_level(), Some(ComplianceLevel::EuccSubstantial));
     assert!(p.is_standards_based());
 
     let oss = PolicyPreset::CraOssSteward;
-    assert_eq!(
-        oss.compliance_level(),
-        Some(ComplianceLevel::CraOssSteward)
-    );
+    assert_eq!(oss.compliance_level(), Some(ComplianceLevel::CraOssSteward));
     assert!(oss.is_standards_based());
 }
 

--- a/tests/cra_product_class_tests.rs
+++ b/tests/cra_product_class_tests.rs
@@ -1,0 +1,449 @@
+//! Integration tests for CRA-P3.2 product-class severity calibration.
+//!
+//! Covers:
+//! - Vendor-hash threshold scaling (Default 50%, Important-1/2 80%, Critical 100%)
+//! - Vendor-hash severity scaling (Default/Important-1 Warning, Important-2/Critical Error)
+//! - EOL severity escalation (Warning → Error at Important-2/Critical)
+//! - Article 14 PSIRT severity escalation (Warning → Error at Important-2/Critical)
+//! - Annex VII Declaration-of-Conformity severity scaling (Info → Warning → Error)
+//! - EUCC reference check fires only at ImportantClass2/Critical
+//! - Module-attestation check fires only on B+C / H / EUCC routes
+//! - Sidecar productClass overrides explicit `with_product_class`
+//! - CLI parse_cli aliases
+
+use sbom_tools::model::{
+    Component, ConformityRoute, CraProductClass, CraSidecarMetadata, EolInfo, EolStatus,
+    ExternalRefType, ExternalReference, Hash, HashAlgorithm, NormalizedSbom, Organization,
+};
+use sbom_tools::quality::{
+    ClassCheck, ComplianceChecker, ComplianceLevel, ViolationSeverity,
+};
+
+// --- helpers -----------------------------------------------------------------
+
+/// Build an SBOM with `vendor_total` vendor-supplied components, of which
+/// `with_hash` carry a SHA-256 hash. Vendor = supplier set + PURL identifier.
+fn vendor_sbom(vendor_total: usize, with_hash: usize) -> NormalizedSbom {
+    let mut sbom = NormalizedSbom::default();
+    for i in 0..vendor_total {
+        let mut c = Component::new(format!("c{i}"), format!("c{i}"))
+            .with_purl(format!("pkg:cargo/c{i}@1.0"));
+        c.supplier = Some(Organization::new(format!("Vendor{i}")));
+        if i < with_hash {
+            c.hashes.push(Hash {
+                algorithm: HashAlgorithm::Sha256,
+                value: format!("{:064x}", i + 1),
+            });
+        }
+        sbom.add_component(c);
+    }
+    sbom
+}
+
+fn vendor_hash_violation(result: &sbom_tools::quality::ComplianceResult) -> Option<ViolationSeverity> {
+    result
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("PRE-7-RQ-07-RE"))
+        .map(|v| v.severity)
+}
+
+// --- vendor-hash threshold + severity ---------------------------------------
+
+#[test]
+fn vendor_hash_default_class_warns_below_50pct() {
+    // 4/10 = 40% coverage → below 50% threshold
+    let sbom = vendor_sbom(10, 4);
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Default)
+        .check(&sbom);
+    assert_eq!(vendor_hash_violation(&res), Some(ViolationSeverity::Warning));
+}
+
+#[test]
+fn vendor_hash_default_class_clean_above_50pct() {
+    // 6/10 = 60% — clears Default's 50% bar
+    let sbom = vendor_sbom(10, 6);
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Default)
+        .check(&sbom);
+    assert_eq!(vendor_hash_violation(&res), None);
+}
+
+#[test]
+fn vendor_hash_important_class_1_warns_below_80pct() {
+    // 6/10 = 60% — fails Important-1's 80% bar; severity is Warning
+    let sbom = vendor_sbom(10, 6);
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::ImportantClass1)
+        .check(&sbom);
+    assert_eq!(vendor_hash_violation(&res), Some(ViolationSeverity::Warning));
+}
+
+#[test]
+fn vendor_hash_important_class_2_errors_below_80pct() {
+    // 6/10 = 60% — fails Important-2's 80% bar; severity is Error
+    let sbom = vendor_sbom(10, 6);
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::ImportantClass2)
+        .check(&sbom);
+    assert_eq!(vendor_hash_violation(&res), Some(ViolationSeverity::Error));
+}
+
+#[test]
+fn vendor_hash_critical_demands_100pct() {
+    // 9/10 = 90% — fails Critical's 100% bar; severity is Error
+    let sbom = vendor_sbom(10, 9);
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Critical)
+        .check(&sbom);
+    assert_eq!(vendor_hash_violation(&res), Some(ViolationSeverity::Error));
+
+    // 10/10 = 100% — clears
+    let sbom2 = vendor_sbom(10, 10);
+    let res2 = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Critical)
+        .check(&sbom2);
+    assert_eq!(vendor_hash_violation(&res2), None);
+}
+
+#[test]
+fn vendor_hash_no_class_preserves_phase2_two_stage() {
+    // No product class set: existing CraPhase2 logic — warn at <80%, error at <50%
+    let sbom_warn = vendor_sbom(10, 6); // 60%
+    let res_warn = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom_warn);
+    assert_eq!(
+        vendor_hash_violation(&res_warn),
+        Some(ViolationSeverity::Warning)
+    );
+
+    let sbom_err = vendor_sbom(10, 4); // 40%
+    let res_err = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom_err);
+    assert_eq!(vendor_hash_violation(&res_err), Some(ViolationSeverity::Error));
+}
+
+// --- EOL severity escalation -------------------------------------------------
+
+fn sbom_with_eol_component() -> NormalizedSbom {
+    let mut sbom = NormalizedSbom::default();
+    let mut c = Component::new("eol".to_string(), "eol-lib".to_string())
+        .with_purl("pkg:cargo/eol-lib@1.0".to_string());
+    c.supplier = Some(Organization::new("EolCorp".to_string()));
+    c.eol = Some(EolInfo {
+        status: EolStatus::EndOfLife,
+        product: "eol-lib".to_string(),
+        cycle: "1".to_string(),
+        eol_date: None,
+        support_end_date: None,
+        is_lts: false,
+        latest_in_cycle: None,
+        latest_release_date: None,
+        days_until_eol: None,
+    });
+    sbom.add_component(c);
+    sbom
+}
+
+#[test]
+fn eol_severity_escalates_to_error_at_important_class_2() {
+    let sbom = sbom_with_eol_component();
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::ImportantClass2)
+        .check(&sbom);
+    let v = res
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("lifecycle management"))
+        .expect("EOL component violation expected");
+    assert_eq!(v.severity, ViolationSeverity::Error);
+}
+
+#[test]
+fn eol_severity_remains_warning_at_default_class() {
+    let sbom = sbom_with_eol_component();
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Default)
+        .check(&sbom);
+    let v = res
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("lifecycle management"))
+        .expect("EOL component violation expected");
+    assert_eq!(v.severity, ViolationSeverity::Warning);
+}
+
+// --- Annex VII DoC severity scaling -----------------------------------------
+
+#[test]
+fn doc_reference_severity_scales_with_class() {
+    let sbom = NormalizedSbom::default();
+
+    let res_default = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Default)
+        .check(&sbom);
+    let v = res_default
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("Annex VII"))
+        .expect("Annex VII DoC violation expected");
+    assert_eq!(v.severity, ViolationSeverity::Info);
+
+    let res_imp1 = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::ImportantClass1)
+        .check(&sbom);
+    let v = res_imp1
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("Annex VII"))
+        .expect("Annex VII DoC violation expected");
+    assert_eq!(v.severity, ViolationSeverity::Warning);
+
+    let res_critical = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Critical)
+        .check(&sbom);
+    let v = res_critical
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("Annex VII"))
+        .expect("Annex VII DoC violation expected");
+    assert_eq!(v.severity, ViolationSeverity::Error);
+}
+
+// --- EUCC reference check ----------------------------------------------------
+
+#[test]
+fn eucc_reference_check_skipped_at_default_and_important_1() {
+    let sbom = NormalizedSbom::default();
+    for class in [CraProductClass::Default, CraProductClass::ImportantClass1] {
+        let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+            .with_product_class(class)
+            .check(&sbom);
+        assert!(
+            !res.violations.iter().any(|v| v.requirement.contains("EUCC")),
+            "EUCC check should be skipped at {class:?}"
+        );
+    }
+}
+
+#[test]
+fn eucc_reference_check_fires_info_at_important_class_2() {
+    let sbom = NormalizedSbom::default();
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::ImportantClass2)
+        .check(&sbom);
+    let v = res
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("EUCC"))
+        .expect("EUCC violation expected at Important-2");
+    assert_eq!(v.severity, ViolationSeverity::Info);
+}
+
+#[test]
+fn eucc_reference_check_fires_error_at_critical() {
+    let sbom = NormalizedSbom::default();
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Critical)
+        .check(&sbom);
+    let v = res
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("EUCC"))
+        .expect("EUCC violation expected at Critical");
+    assert_eq!(v.severity, ViolationSeverity::Error);
+}
+
+#[test]
+fn eucc_reference_satisfied_by_certification_with_eucc_url() {
+    let mut sbom = NormalizedSbom::default();
+    let mut c = Component::new("app".to_string(), "app".to_string())
+        .with_purl("pkg:cargo/app@1.0".to_string());
+    c.external_refs.push(ExternalReference {
+        ref_type: ExternalRefType::Certification,
+        url: "https://eucc.example.eu/cert/123".to_string(),
+        comment: None,
+        hashes: Vec::new(),
+    });
+    sbom.add_component(c);
+
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Critical)
+        .check(&sbom);
+    assert!(
+        !res.violations.iter().any(|v| v.requirement.contains("EUCC")),
+        "EUCC reference satisfied by EUCC certification URL"
+    );
+}
+
+// --- Module attestation check ------------------------------------------------
+
+#[test]
+fn module_attestation_skipped_at_default_class() {
+    let sbom = NormalizedSbom::default();
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Default)
+        .check(&sbom);
+    assert!(
+        !res.violations
+            .iter()
+            .any(|v| v.requirement.contains("attestation reference")),
+        "Module attestation check should be skipped at Default"
+    );
+}
+
+#[test]
+fn module_attestation_skipped_for_module_a_route() {
+    // Important-1 with explicit Module A → skip
+    let sidecar = CraSidecarMetadata {
+        product_class: Some(CraProductClass::ImportantClass1),
+        conformity_assessment_route: Some(ConformityRoute::ModuleA),
+        ..Default::default()
+    };
+    let sbom = NormalizedSbom::default();
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_sidecar(sidecar)
+        .check(&sbom);
+    assert!(
+        !res.violations
+            .iter()
+            .any(|v| v.requirement.contains("attestation reference")),
+        "Module attestation check should be skipped on Module A route"
+    );
+}
+
+#[test]
+fn module_attestation_fires_warning_at_important_1_module_bc() {
+    let sidecar = CraSidecarMetadata {
+        product_class: Some(CraProductClass::ImportantClass1),
+        conformity_assessment_route: Some(ConformityRoute::ModuleBC),
+        ..Default::default()
+    };
+    let sbom = NormalizedSbom::default();
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_sidecar(sidecar)
+        .check(&sbom);
+    let v = res
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("attestation reference"))
+        .expect("Module attestation violation expected");
+    assert_eq!(v.severity, ViolationSeverity::Warning);
+}
+
+#[test]
+fn module_attestation_fires_error_at_critical_with_default_route() {
+    // Critical implies EUCC by default — non-Module-A → check fires
+    let sbom = NormalizedSbom::default();
+    let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Critical)
+        .check(&sbom);
+    let v = res
+        .violations
+        .iter()
+        .find(|v| v.requirement.contains("attestation reference"))
+        .expect("Module attestation violation expected");
+    assert_eq!(v.severity, ViolationSeverity::Error);
+}
+
+// --- sidecar-vs-explicit precedence -----------------------------------------
+
+#[test]
+fn sidecar_product_class_overrides_explicit_with_product_class() {
+    let sidecar = CraSidecarMetadata {
+        product_class: Some(CraProductClass::Critical),
+        ..Default::default()
+    };
+    let checker = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::Default)
+        .with_sidecar(sidecar);
+    assert_eq!(checker.effective_product_class(), CraProductClass::Critical);
+}
+
+#[test]
+fn explicit_with_product_class_used_when_sidecar_lacks_class() {
+    let sidecar = CraSidecarMetadata {
+        manufacturer_name: Some("Mfr".to_string()),
+        ..Default::default()
+    };
+    let checker = ComplianceChecker::new(ComplianceLevel::CraPhase2)
+        .with_product_class(CraProductClass::ImportantClass1)
+        .with_sidecar(sidecar);
+    assert_eq!(
+        checker.effective_product_class(),
+        CraProductClass::ImportantClass1
+    );
+}
+
+#[test]
+fn no_class_falls_back_to_default_class() {
+    let checker = ComplianceChecker::new(ComplianceLevel::CraPhase2);
+    assert_eq!(checker.effective_product_class(), CraProductClass::Default);
+    assert!(!checker.has_explicit_product_class());
+}
+
+#[test]
+fn class_severity_table_matches_plan() {
+    let mk = |c| ComplianceChecker::new(ComplianceLevel::CraPhase2).with_product_class(c);
+    use ClassCheck as K;
+    use CraProductClass as C;
+    use ViolationSeverity as S;
+
+    // Vendor hash
+    assert_eq!(mk(C::Default).class_severity(K::VendorHashCoverage), Some(S::Warning));
+    assert_eq!(mk(C::ImportantClass1).class_severity(K::VendorHashCoverage), Some(S::Warning));
+    assert_eq!(mk(C::ImportantClass2).class_severity(K::VendorHashCoverage), Some(S::Error));
+    assert_eq!(mk(C::Critical).class_severity(K::VendorHashCoverage), Some(S::Error));
+    // EOL
+    assert_eq!(mk(C::Default).class_severity(K::EolComponents), Some(S::Warning));
+    assert_eq!(mk(C::Critical).class_severity(K::EolComponents), Some(S::Error));
+    // DoC
+    assert_eq!(mk(C::Default).class_severity(K::DocReference), Some(S::Info));
+    assert_eq!(mk(C::ImportantClass1).class_severity(K::DocReference), Some(S::Warning));
+    assert_eq!(mk(C::Critical).class_severity(K::DocReference), Some(S::Error));
+    // EUCC
+    assert_eq!(mk(C::Default).class_severity(K::EuccReference), None);
+    assert_eq!(mk(C::ImportantClass1).class_severity(K::EuccReference), None);
+    assert_eq!(mk(C::ImportantClass2).class_severity(K::EuccReference), Some(S::Info));
+    assert_eq!(mk(C::Critical).class_severity(K::EuccReference), Some(S::Error));
+    // Module attestation
+    assert_eq!(mk(C::Default).class_severity(K::ModuleAttestation), None);
+    assert_eq!(mk(C::ImportantClass1).class_severity(K::ModuleAttestation), Some(S::Warning));
+    assert_eq!(mk(C::Critical).class_severity(K::ModuleAttestation), Some(S::Error));
+    // PSIRT
+    assert_eq!(mk(C::ImportantClass2).class_severity(K::Psirt), Some(S::Error));
+}
+
+#[test]
+fn vendor_hash_threshold_table_matches_plan() {
+    let mk = |c| ComplianceChecker::new(ComplianceLevel::CraPhase2).with_product_class(c);
+    assert!((mk(CraProductClass::Default).vendor_hash_threshold() - 0.50).abs() < 1e-9);
+    assert!((mk(CraProductClass::ImportantClass1).vendor_hash_threshold() - 0.80).abs() < 1e-9);
+    assert!((mk(CraProductClass::ImportantClass2).vendor_hash_threshold() - 0.80).abs() < 1e-9);
+    assert!((mk(CraProductClass::Critical).vendor_hash_threshold() - 1.00).abs() < 1e-9);
+}
+
+#[test]
+fn effective_route_falls_back_to_class_default() {
+    let mk = |c| ComplianceChecker::new(ComplianceLevel::CraPhase2).with_product_class(c);
+    assert_eq!(mk(CraProductClass::Default).effective_route(), ConformityRoute::ModuleA);
+    assert_eq!(
+        mk(CraProductClass::ImportantClass1).effective_route(),
+        ConformityRoute::ModuleA
+    );
+    assert_eq!(
+        mk(CraProductClass::ImportantClass2).effective_route(),
+        ConformityRoute::ModuleBC
+    );
+    assert_eq!(mk(CraProductClass::Critical).effective_route(), ConformityRoute::Eucc);
+}
+
+#[test]
+fn effective_route_sidecar_wins() {
+    let sidecar = CraSidecarMetadata {
+        product_class: Some(CraProductClass::Critical),
+        conformity_assessment_route: Some(ConformityRoute::ModuleH),
+        ..Default::default()
+    };
+    let checker = ComplianceChecker::new(ComplianceLevel::CraPhase2).with_sidecar(sidecar);
+    assert_eq!(checker.effective_route(), ConformityRoute::ModuleH);
+}

--- a/tests/cra_product_class_tests.rs
+++ b/tests/cra_product_class_tests.rs
@@ -15,9 +15,7 @@ use sbom_tools::model::{
     Component, ConformityRoute, CraProductClass, CraSidecarMetadata, EolInfo, EolStatus,
     ExternalRefType, ExternalReference, Hash, HashAlgorithm, NormalizedSbom, Organization,
 };
-use sbom_tools::quality::{
-    ClassCheck, ComplianceChecker, ComplianceLevel, ViolationSeverity,
-};
+use sbom_tools::quality::{ClassCheck, ComplianceChecker, ComplianceLevel, ViolationSeverity};
 
 // --- helpers -----------------------------------------------------------------
 
@@ -40,7 +38,9 @@ fn vendor_sbom(vendor_total: usize, with_hash: usize) -> NormalizedSbom {
     sbom
 }
 
-fn vendor_hash_violation(result: &sbom_tools::quality::ComplianceResult) -> Option<ViolationSeverity> {
+fn vendor_hash_violation(
+    result: &sbom_tools::quality::ComplianceResult,
+) -> Option<ViolationSeverity> {
     result
         .violations
         .iter()
@@ -57,7 +57,10 @@ fn vendor_hash_default_class_warns_below_50pct() {
     let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
         .with_product_class(CraProductClass::Default)
         .check(&sbom);
-    assert_eq!(vendor_hash_violation(&res), Some(ViolationSeverity::Warning));
+    assert_eq!(
+        vendor_hash_violation(&res),
+        Some(ViolationSeverity::Warning)
+    );
 }
 
 #[test]
@@ -77,7 +80,10 @@ fn vendor_hash_important_class_1_warns_below_80pct() {
     let res = ComplianceChecker::new(ComplianceLevel::CraPhase2)
         .with_product_class(CraProductClass::ImportantClass1)
         .check(&sbom);
-    assert_eq!(vendor_hash_violation(&res), Some(ViolationSeverity::Warning));
+    assert_eq!(
+        vendor_hash_violation(&res),
+        Some(ViolationSeverity::Warning)
+    );
 }
 
 #[test]
@@ -119,7 +125,10 @@ fn vendor_hash_no_class_preserves_phase2_two_stage() {
 
     let sbom_err = vendor_sbom(10, 4); // 40%
     let res_err = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom_err);
-    assert_eq!(vendor_hash_violation(&res_err), Some(ViolationSeverity::Error));
+    assert_eq!(
+        vendor_hash_violation(&res_err),
+        Some(ViolationSeverity::Error)
+    );
 }
 
 // --- EOL severity escalation -------------------------------------------------
@@ -219,7 +228,9 @@ fn eucc_reference_check_skipped_at_default_and_important_1() {
             .with_product_class(class)
             .check(&sbom);
         assert!(
-            !res.violations.iter().any(|v| v.requirement.contains("EUCC")),
+            !res.violations
+                .iter()
+                .any(|v| v.requirement.contains("EUCC")),
             "EUCC check should be skipped at {class:?}"
         );
     }
@@ -270,7 +281,9 @@ fn eucc_reference_satisfied_by_certification_with_eucc_url() {
         .with_product_class(CraProductClass::Critical)
         .check(&sbom);
     assert!(
-        !res.violations.iter().any(|v| v.requirement.contains("EUCC")),
+        !res.violations
+            .iter()
+            .any(|v| v.requirement.contains("EUCC")),
         "EUCC reference satisfied by EUCC certification URL"
     );
 }
@@ -389,28 +402,73 @@ fn class_severity_table_matches_plan() {
     use ViolationSeverity as S;
 
     // Vendor hash
-    assert_eq!(mk(C::Default).class_severity(K::VendorHashCoverage), Some(S::Warning));
-    assert_eq!(mk(C::ImportantClass1).class_severity(K::VendorHashCoverage), Some(S::Warning));
-    assert_eq!(mk(C::ImportantClass2).class_severity(K::VendorHashCoverage), Some(S::Error));
-    assert_eq!(mk(C::Critical).class_severity(K::VendorHashCoverage), Some(S::Error));
+    assert_eq!(
+        mk(C::Default).class_severity(K::VendorHashCoverage),
+        Some(S::Warning)
+    );
+    assert_eq!(
+        mk(C::ImportantClass1).class_severity(K::VendorHashCoverage),
+        Some(S::Warning)
+    );
+    assert_eq!(
+        mk(C::ImportantClass2).class_severity(K::VendorHashCoverage),
+        Some(S::Error)
+    );
+    assert_eq!(
+        mk(C::Critical).class_severity(K::VendorHashCoverage),
+        Some(S::Error)
+    );
     // EOL
-    assert_eq!(mk(C::Default).class_severity(K::EolComponents), Some(S::Warning));
-    assert_eq!(mk(C::Critical).class_severity(K::EolComponents), Some(S::Error));
+    assert_eq!(
+        mk(C::Default).class_severity(K::EolComponents),
+        Some(S::Warning)
+    );
+    assert_eq!(
+        mk(C::Critical).class_severity(K::EolComponents),
+        Some(S::Error)
+    );
     // DoC
-    assert_eq!(mk(C::Default).class_severity(K::DocReference), Some(S::Info));
-    assert_eq!(mk(C::ImportantClass1).class_severity(K::DocReference), Some(S::Warning));
-    assert_eq!(mk(C::Critical).class_severity(K::DocReference), Some(S::Error));
+    assert_eq!(
+        mk(C::Default).class_severity(K::DocReference),
+        Some(S::Info)
+    );
+    assert_eq!(
+        mk(C::ImportantClass1).class_severity(K::DocReference),
+        Some(S::Warning)
+    );
+    assert_eq!(
+        mk(C::Critical).class_severity(K::DocReference),
+        Some(S::Error)
+    );
     // EUCC
     assert_eq!(mk(C::Default).class_severity(K::EuccReference), None);
-    assert_eq!(mk(C::ImportantClass1).class_severity(K::EuccReference), None);
-    assert_eq!(mk(C::ImportantClass2).class_severity(K::EuccReference), Some(S::Info));
-    assert_eq!(mk(C::Critical).class_severity(K::EuccReference), Some(S::Error));
+    assert_eq!(
+        mk(C::ImportantClass1).class_severity(K::EuccReference),
+        None
+    );
+    assert_eq!(
+        mk(C::ImportantClass2).class_severity(K::EuccReference),
+        Some(S::Info)
+    );
+    assert_eq!(
+        mk(C::Critical).class_severity(K::EuccReference),
+        Some(S::Error)
+    );
     // Module attestation
     assert_eq!(mk(C::Default).class_severity(K::ModuleAttestation), None);
-    assert_eq!(mk(C::ImportantClass1).class_severity(K::ModuleAttestation), Some(S::Warning));
-    assert_eq!(mk(C::Critical).class_severity(K::ModuleAttestation), Some(S::Error));
+    assert_eq!(
+        mk(C::ImportantClass1).class_severity(K::ModuleAttestation),
+        Some(S::Warning)
+    );
+    assert_eq!(
+        mk(C::Critical).class_severity(K::ModuleAttestation),
+        Some(S::Error)
+    );
     // PSIRT
-    assert_eq!(mk(C::ImportantClass2).class_severity(K::Psirt), Some(S::Error));
+    assert_eq!(
+        mk(C::ImportantClass2).class_severity(K::Psirt),
+        Some(S::Error)
+    );
 }
 
 #[test]
@@ -425,7 +483,10 @@ fn vendor_hash_threshold_table_matches_plan() {
 #[test]
 fn effective_route_falls_back_to_class_default() {
     let mk = |c| ComplianceChecker::new(ComplianceLevel::CraPhase2).with_product_class(c);
-    assert_eq!(mk(CraProductClass::Default).effective_route(), ConformityRoute::ModuleA);
+    assert_eq!(
+        mk(CraProductClass::Default).effective_route(),
+        ConformityRoute::ModuleA
+    );
     assert_eq!(
         mk(CraProductClass::ImportantClass1).effective_route(),
         ConformityRoute::ModuleA
@@ -434,7 +495,10 @@ fn effective_route_falls_back_to_class_default() {
         mk(CraProductClass::ImportantClass2).effective_route(),
         ConformityRoute::ModuleBC
     );
-    assert_eq!(mk(CraProductClass::Critical).effective_route(), ConformityRoute::Eucc);
+    assert_eq!(
+        mk(CraProductClass::Critical).effective_route(),
+        ConformityRoute::Eucc
+    );
 }
 
 #[test]

--- a/tests/cra_readiness_tests.rs
+++ b/tests/cra_readiness_tests.rs
@@ -62,10 +62,13 @@ fn cra_missing_identifier_and_version_are_errors() {
             && v.requirement == "CRA Art. 13(12): Component version"
     }));
 
+    // Updated requirement string to reflect prEN 40000-1-3 [PRE-7-RQ-07] mapping
+    // and SWHID acceptance (CRA P1.2/P1.3).
     assert!(result.violations.iter().any(|v| {
         v.severity == ViolationSeverity::Error
             && v.category == ViolationCategory::ComponentIdentification
-            && v.requirement == "CRA Annex I: Unique component identifier (PURL/CPE/SWID)"
+            && v.requirement.contains("Annex I")
+            && v.requirement.contains("PRE-7-RQ-07")
     }));
 }
 

--- a/tests/csaf_emit_tests.rs
+++ b/tests/csaf_emit_tests.rs
@@ -1,0 +1,218 @@
+//! Integration tests for CRA-P4.2 CSAF v2.0 emitter.
+//!
+//! Covers:
+//! - Schema-level structural assertions on emitted CSAF documents.
+//! - Round-trip: ingest a CSAF advisory → enrich an SBOM → emit CSAF →
+//!   re-ingest the emitted document → identical VEX states are produced.
+//! - Sidecar/options propagation (publisher, title, document ID).
+
+use sbom_tools::enrichment::vex::VexEnricher;
+use sbom_tools::model::{
+    Component, NormalizedSbom, VexState, VexStatus, VulnerabilityRef, VulnerabilitySource,
+};
+use sbom_tools::reports::{CsafEmitOptions, emit_csaf};
+use std::path::PathBuf;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/csaf")
+}
+
+fn sbom_with_vex_states(entries: &[(&str, &str, &str, VexState)]) -> NormalizedSbom {
+    let mut sbom = NormalizedSbom::default();
+    for (name, version, vuln, state) in entries {
+        let mut c =
+            Component::new((*name).to_string(), format!("{name}@{version}"));
+        c.version = Some((*version).to_string());
+        c.identifiers.purl =
+            Some(format!("pkg:cargo/{name}@{version}"));
+        let mut v =
+            VulnerabilityRef::new((*vuln).to_string(), VulnerabilitySource::Cve);
+        v.vex_status = Some(VexStatus::new(state.clone()));
+        c.vulnerabilities.push(v);
+        sbom.add_component(c);
+    }
+    sbom
+}
+
+#[test]
+fn emit_produces_valid_csaf_v2_0_document_skeleton() {
+    let sbom = sbom_with_vex_states(&[
+        ("foo", "1.0.0", "CVE-2024-12345", VexState::Affected),
+        ("bar", "2.0.0", "CVE-2024-12345", VexState::Fixed),
+    ]);
+    let csaf = emit_csaf(&sbom, &CsafEmitOptions::default()).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&csaf).unwrap();
+    assert_eq!(json["document"]["csaf_version"], "2.0");
+    assert!(json["document"]["title"].as_str().unwrap().contains("VEX"));
+    assert!(
+        json["document"]["tracking"]["id"]
+            .as_str()
+            .is_some_and(|s| s.starts_with("sbom-tools-vex-"))
+    );
+    assert_eq!(json["document"]["tracking"]["version"], "1");
+    assert_eq!(json["document"]["tracking"]["status"], "final");
+
+    // Generator metadata identifies sbom-tools as the engine.
+    let engine = &json["document"]["tracking"]["generator"]["engine"];
+    assert_eq!(engine["name"], "sbom-tools");
+    assert!(engine["version"].is_string());
+}
+
+#[test]
+fn emit_options_override_defaults() {
+    let sbom = sbom_with_vex_states(&[("foo", "1.0", "CVE-2024-1", VexState::Affected)]);
+    let opts = CsafEmitOptions {
+        document_id: Some("EX-2026-001".to_string()),
+        publisher_name: Some("Example Corp".to_string()),
+        publisher_namespace: Some("https://example.com".to_string()),
+        publisher_category: Some("vendor".to_string()),
+        title: Some("Test Advisory".to_string()),
+        category: Some("csaf_security_advisory".to_string()),
+    };
+    let csaf = emit_csaf(&sbom, &opts).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&csaf).unwrap();
+    assert_eq!(json["document"]["category"], "csaf_security_advisory");
+    assert_eq!(json["document"]["title"], "Test Advisory");
+    assert_eq!(json["document"]["tracking"]["id"], "EX-2026-001");
+    assert_eq!(json["document"]["publisher"]["name"], "Example Corp");
+    assert_eq!(json["document"]["publisher"]["namespace"], "https://example.com");
+}
+
+#[test]
+fn emitted_csaf_passes_internal_format_detector() {
+    // The emitter output should re-parse via the same VexEnricher path
+    // that ingests CSAF advisories — the auto-detector must classify it
+    // as CSAF (not as OpenVEX or CycloneDX VEX).
+    let sbom = sbom_with_vex_states(&[("foo", "1.0", "CVE-2024-1", VexState::Affected)]);
+    let csaf = emit_csaf(&sbom, &CsafEmitOptions::default()).unwrap();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("emitted.csaf.json");
+    std::fs::write(&path, &csaf).unwrap();
+
+    let enricher = VexEnricher::from_files(&[path]).expect("re-ingest");
+    assert_eq!(enricher.stats().documents_loaded, 1);
+    assert!(enricher.stats().statements_parsed >= 1);
+}
+
+#[test]
+fn round_trip_preserves_vex_states_across_ingest_emit_ingest() {
+    // 1. Ingest the canonical CSAF fixture and apply it to a matching SBOM.
+    let csaf_in = fixtures_dir().join("example-advisory.csaf.json");
+    let mut enricher_in = VexEnricher::from_files(&[csaf_in]).unwrap();
+
+    let mut sbom = NormalizedSbom::default();
+    for (name, version, purl) in [
+        ("example-app-1.0", "1.0.0", "pkg:cargo/example-app@1.0.0"),
+        ("example-app-1.1", "1.1.0", "pkg:cargo/example-app@1.1.0"),
+        ("example-app-2.0", "2.0.0", "pkg:cargo/example-app@2.0.0"),
+    ] {
+        let mut c = Component::new(name.to_string(), format!("{name}@{version}"));
+        c.version = Some(version.to_string());
+        c.identifiers.purl = Some(purl.to_string());
+        for vuln in ["CVE-2024-99001", "CVE-2024-99002"] {
+            c.vulnerabilities.push(VulnerabilityRef::new(
+                vuln.to_string(),
+                VulnerabilitySource::Cve,
+            ));
+        }
+        sbom.add_component(c);
+    }
+    enricher_in.enrich_sbom(&mut sbom);
+
+    // Snapshot the VEX states after the first ingest.
+    let mut before: Vec<(String, String, String)> = Vec::new();
+    for c in sbom.components.values() {
+        let purl = c.identifiers.purl.clone().unwrap();
+        for v in &c.vulnerabilities {
+            if let Some(state) = v.vex_status.as_ref().map(|s| s.status.clone()) {
+                before.push((purl.clone(), v.id.clone(), format!("{state:?}")));
+            }
+        }
+    }
+    before.sort();
+    assert!(
+        !before.is_empty(),
+        "first ingest should have applied at least one VEX status"
+    );
+
+    // 2. Emit the SBOM's VEX state as a new CSAF advisory.
+    let csaf_out = emit_csaf(&sbom, &CsafEmitOptions::default()).unwrap();
+
+    // 3. Re-ingest the emitted CSAF into a fresh SBOM with identical
+    //    components and check the same VEX states are reapplied.
+    let dir = tempfile::tempdir().unwrap();
+    let csaf_path = dir.path().join("round-trip.csaf.json");
+    std::fs::write(&csaf_path, &csaf_out).unwrap();
+
+    let mut enricher_out = VexEnricher::from_files(&[csaf_path]).unwrap();
+    let mut sbom2 = NormalizedSbom::default();
+    for c in sbom.components.values() {
+        let mut nc = Component::new(c.name.clone(), c.name.clone());
+        nc.version = c.version.clone();
+        nc.identifiers.purl = c.identifiers.purl.clone();
+        for v in &c.vulnerabilities {
+            nc.vulnerabilities.push(VulnerabilityRef::new(
+                v.id.clone(),
+                VulnerabilitySource::Cve,
+            ));
+        }
+        sbom2.add_component(nc);
+    }
+    enricher_out.enrich_sbom(&mut sbom2);
+
+    let mut after: Vec<(String, String, String)> = Vec::new();
+    for c in sbom2.components.values() {
+        let purl = c.identifiers.purl.clone().unwrap();
+        for v in &c.vulnerabilities {
+            if let Some(state) = v.vex_status.as_ref().map(|s| s.status.clone()) {
+                after.push((purl.clone(), v.id.clone(), format!("{state:?}")));
+            }
+        }
+    }
+    after.sort();
+
+    assert_eq!(
+        before, after,
+        "Round-trip CSAF emit→ingest must preserve every VEX state"
+    );
+}
+
+#[test]
+fn emit_skips_components_without_purl_or_vex_status() {
+    let mut sbom = NormalizedSbom::default();
+    // No PURL: should be skipped
+    let mut c1 = Component::new("nopurl".to_string(), "nopurl".to_string());
+    let mut v1 = VulnerabilityRef::new(
+        "CVE-2024-1".to_string(),
+        VulnerabilitySource::Cve,
+    );
+    v1.vex_status = Some(VexStatus::new(VexState::Affected));
+    c1.vulnerabilities.push(v1);
+    sbom.add_component(c1);
+
+    // PURL but no vex_status on its vuln: product surfaces, no status entry
+    let mut c2 = Component::new("withpurl".to_string(), "withpurl".to_string());
+    c2.identifiers.purl = Some("pkg:cargo/withpurl@1".to_string());
+    c2.vulnerabilities.push(VulnerabilityRef::new(
+        "CVE-2024-2".to_string(),
+        VulnerabilitySource::Cve,
+    ));
+    sbom.add_component(c2);
+
+    let csaf = emit_csaf(&sbom, &CsafEmitOptions::default()).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&csaf).unwrap();
+
+    let products = json["product_tree"]["full_product_names"]
+        .as_array()
+        .unwrap();
+    assert_eq!(products.len(), 1);
+    assert_eq!(products[0]["name"], "withpurl");
+
+    // No vex_status anywhere → no vulnerabilities[]
+    assert!(
+        json["vulnerabilities"]
+            .as_array()
+            .map_or(true, std::vec::Vec::is_empty)
+    );
+}

--- a/tests/csaf_emit_tests.rs
+++ b/tests/csaf_emit_tests.rs
@@ -20,13 +20,10 @@ fn fixtures_dir() -> PathBuf {
 fn sbom_with_vex_states(entries: &[(&str, &str, &str, VexState)]) -> NormalizedSbom {
     let mut sbom = NormalizedSbom::default();
     for (name, version, vuln, state) in entries {
-        let mut c =
-            Component::new((*name).to_string(), format!("{name}@{version}"));
+        let mut c = Component::new((*name).to_string(), format!("{name}@{version}"));
         c.version = Some((*version).to_string());
-        c.identifiers.purl =
-            Some(format!("pkg:cargo/{name}@{version}"));
-        let mut v =
-            VulnerabilityRef::new((*vuln).to_string(), VulnerabilitySource::Cve);
+        c.identifiers.purl = Some(format!("pkg:cargo/{name}@{version}"));
+        let mut v = VulnerabilityRef::new((*vuln).to_string(), VulnerabilitySource::Cve);
         v.vex_status = Some(VexStatus::new(state.clone()));
         c.vulnerabilities.push(v);
         sbom.add_component(c);
@@ -75,7 +72,10 @@ fn emit_options_override_defaults() {
     assert_eq!(json["document"]["title"], "Test Advisory");
     assert_eq!(json["document"]["tracking"]["id"], "EX-2026-001");
     assert_eq!(json["document"]["publisher"]["name"], "Example Corp");
-    assert_eq!(json["document"]["publisher"]["namespace"], "https://example.com");
+    assert_eq!(
+        json["document"]["publisher"]["namespace"],
+        "https://example.com"
+    );
 }
 
 #[test]
@@ -183,10 +183,7 @@ fn emit_skips_components_without_purl_or_vex_status() {
     let mut sbom = NormalizedSbom::default();
     // No PURL: should be skipped
     let mut c1 = Component::new("nopurl".to_string(), "nopurl".to_string());
-    let mut v1 = VulnerabilityRef::new(
-        "CVE-2024-1".to_string(),
-        VulnerabilitySource::Cve,
-    );
+    let mut v1 = VulnerabilityRef::new("CVE-2024-1".to_string(), VulnerabilitySource::Cve);
     v1.vex_status = Some(VexStatus::new(VexState::Affected));
     c1.vulnerabilities.push(v1);
     sbom.add_component(c1);

--- a/tests/csaf_tests.rs
+++ b/tests/csaf_tests.rs
@@ -1,0 +1,173 @@
+//! Integration tests for CSAF v2.0 (ISO/IEC 20153:2025) ingest.
+//!
+//! Covers:
+//! - Auto-detection of CSAF v2.0 documents (vs OpenVEX / CycloneDX VEX)
+//! - End-to-end VEX enrichment pipeline applying CSAF status
+//! - product_status mapping (known_affected/known_not_affected/fixed/etc.)
+//! - Recursive `branches[]` flattening in product_tree
+//! - Round-trip with the existing VexEnricher dispatcher
+
+use sbom_tools::enrichment::vex::VexEnricher;
+use sbom_tools::model::{
+    Component, NormalizedSbom, VexState, VulnerabilityRef, VulnerabilitySource,
+};
+use std::path::PathBuf;
+
+fn fixtures_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/csaf")
+}
+
+fn build_sbom_with_vuln(name: &str, purl: &str, version: &str, vuln: &str) -> NormalizedSbom {
+    let mut sbom = NormalizedSbom::default();
+    let mut comp = Component::new(name.to_string(), format!("{name}@{version}"));
+    comp.version = Some(version.to_string());
+    comp.identifiers.purl = Some(purl.to_string());
+    comp.vulnerabilities.push(VulnerabilityRef::new(
+        vuln.to_string(),
+        VulnerabilitySource::Cve,
+    ));
+    sbom.add_component(comp);
+    sbom
+}
+
+#[test]
+fn vex_enricher_auto_detects_csaf_fixture() {
+    let path = fixtures_dir().join("example-advisory.csaf.json");
+    assert!(path.exists(), "fixture missing: {}", path.display());
+
+    let enricher = VexEnricher::from_files(&[path]).expect("CSAF parse should succeed");
+    let stats = enricher.stats();
+    assert_eq!(stats.documents_loaded, 1);
+    // 4 status entries: 1 known_affected + 2 fixed (CVE-99001) + 1 known_not_affected + 1 under_investigation (CVE-99002) = 5
+    assert!(stats.statements_parsed >= 4);
+}
+
+#[test]
+fn csaf_known_affected_marks_component_affected() {
+    let path = fixtures_dir().join("example-advisory.csaf.json");
+    let mut enricher = VexEnricher::from_files(&[path]).expect("CSAF parse should succeed");
+
+    let mut sbom = build_sbom_with_vuln(
+        "example-app",
+        "pkg:cargo/example-app@1.0.0",
+        "1.0.0",
+        "CVE-2024-99001",
+    );
+    enricher.enrich_sbom(&mut sbom);
+
+    let comp = sbom.components.values().next().expect("component");
+    let vuln = &comp.vulnerabilities[0];
+    let vex = vuln.vex_status.as_ref().expect("VEX applied");
+    assert_eq!(vex.status, VexState::Affected);
+}
+
+#[test]
+fn csaf_fixed_marks_component_fixed() {
+    let path = fixtures_dir().join("example-advisory.csaf.json");
+    let mut enricher = VexEnricher::from_files(&[path]).expect("CSAF parse should succeed");
+
+    let mut sbom = build_sbom_with_vuln(
+        "example-app",
+        "pkg:cargo/example-app@1.1.0",
+        "1.1.0",
+        "CVE-2024-99001",
+    );
+    enricher.enrich_sbom(&mut sbom);
+
+    let comp = sbom.components.values().next().expect("component");
+    let vuln = &comp.vulnerabilities[0];
+    let vex = vuln.vex_status.as_ref().expect("VEX applied");
+    assert_eq!(vex.status, VexState::Fixed);
+}
+
+#[test]
+fn csaf_known_not_affected_maps_correctly() {
+    let path = fixtures_dir().join("example-advisory.csaf.json");
+    let mut enricher = VexEnricher::from_files(&[path]).expect("CSAF parse should succeed");
+
+    let mut sbom = build_sbom_with_vuln(
+        "example-app",
+        "pkg:cargo/example-app@2.0.0",
+        "2.0.0",
+        "CVE-2024-99002",
+    );
+    enricher.enrich_sbom(&mut sbom);
+
+    let comp = sbom.components.values().next().expect("component");
+    let vuln = &comp.vulnerabilities[0];
+    let vex = vuln.vex_status.as_ref().expect("VEX applied");
+    assert_eq!(vex.status, VexState::NotAffected);
+}
+
+#[test]
+fn csaf_under_investigation_maps_correctly() {
+    let path = fixtures_dir().join("example-advisory.csaf.json");
+    let mut enricher = VexEnricher::from_files(&[path]).expect("CSAF parse should succeed");
+
+    let mut sbom = build_sbom_with_vuln(
+        "example-app",
+        "pkg:cargo/example-app@1.1.0",
+        "1.1.0",
+        "CVE-2024-99002",
+    );
+    enricher.enrich_sbom(&mut sbom);
+
+    let comp = sbom.components.values().next().expect("component");
+    let vuln = &comp.vulnerabilities[0];
+    let vex = vuln.vex_status.as_ref().expect("VEX applied");
+    assert_eq!(vex.status, VexState::UnderInvestigation);
+}
+
+#[test]
+fn csaf_branched_product_tree_flattens_for_lookup() {
+    let path = fixtures_dir().join("branched-tree.csaf.json");
+    let mut enricher = VexEnricher::from_files(&[path]).expect("CSAF parse should succeed");
+
+    let mut sbom = build_sbom_with_vuln(
+        "branchy",
+        "pkg:cargo/branchy@1.0.0",
+        "1.0.0",
+        "CVE-2024-88001",
+    );
+    enricher.enrich_sbom(&mut sbom);
+
+    let comp = sbom.components.values().next().expect("component");
+    let vuln = &comp.vulnerabilities[0];
+    let vex = vuln
+        .vex_status
+        .as_ref()
+        .expect("VEX applied via flattened branches");
+    assert_eq!(vex.status, VexState::Affected);
+}
+
+#[test]
+fn csaf_does_not_apply_to_unrelated_purl() {
+    // Same CVE, different PURL → should not match (CSAF entry is product-scoped)
+    let path = fixtures_dir().join("example-advisory.csaf.json");
+    let mut enricher = VexEnricher::from_files(&[path]).expect("CSAF parse should succeed");
+
+    let mut sbom = build_sbom_with_vuln(
+        "different-app",
+        "pkg:cargo/different-app@1.0.0",
+        "1.0.0",
+        "CVE-2024-99001",
+    );
+    enricher.enrich_sbom(&mut sbom);
+
+    let comp = sbom.components.values().next().expect("component");
+    let vuln = &comp.vulnerabilities[0];
+    assert!(
+        vuln.vex_status.is_none(),
+        "CSAF entry must not match unrelated PURL"
+    );
+}
+
+#[test]
+fn csaf_format_priority_over_cyclonedx_or_openvex() {
+    // The CSAF fixture is detected as CSAF first, not as CycloneDX VEX or
+    // OpenVEX. Sanity check by loading and confirming a CSAF-specific
+    // status (known_not_affected from CVE-2024-99002).
+    let path = fixtures_dir().join("example-advisory.csaf.json");
+    let enricher = VexEnricher::from_files(&[path]).expect("must parse as CSAF");
+    assert!(enricher.stats().statements_parsed > 0);
+}

--- a/tests/fixtures/cra/bsi-compliant.cdx.json
+++ b/tests/fixtures/cra/bsi-compliant.cdx.json
@@ -1,0 +1,65 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:1d2c3b4a-5e6f-7a8b-9c0d-1e2f3a4b5c6d",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-04-26T08:30:00Z",
+    "tools": [
+      {
+        "vendor": "Acme",
+        "name": "sbom-tools",
+        "version": "0.1.19"
+      }
+    ],
+    "component": {
+      "type": "application",
+      "bom-ref": "demo-app",
+      "name": "demo-app",
+      "version": "1.0.0",
+      "purl": "pkg:cargo/demo-app@1.0.0",
+      "supplier": { "name": "Demo Corp" },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0000000000000000000000000000000000000000000000000000000000000fff"
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "serde",
+      "name": "serde",
+      "version": "1.0.197",
+      "purl": "pkg:cargo/serde@1.0.197",
+      "supplier": { "name": "serde-rs maintainers" },
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0000000000000000000000000000000000000000000000000000000000000001"
+        }
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "tokio",
+      "name": "tokio",
+      "version": "1.40.0",
+      "purl": "pkg:cargo/tokio@1.40.0",
+      "supplier": { "name": "Tokio Contributors" },
+      "licenses": [{ "license": { "id": "MIT" } }],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "0000000000000000000000000000000000000000000000000000000000000002"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    { "ref": "demo-app", "dependsOn": ["serde", "tokio"] }
+  ]
+}

--- a/tests/fixtures/cra/bsi-compliant.cra.json
+++ b/tests/fixtures/cra/bsi-compliant.cra.json
@@ -1,0 +1,15 @@
+{
+  "securityContact": "security@example.com",
+  "vulnerabilityDisclosureUrl": "https://example.com/security",
+  "manufacturerName": "Demo Corp",
+  "manufacturerEmail": "contact@example.com",
+  "productName": "Demo App",
+  "productVersion": "1.0.0",
+  "psirtUrl": "https://example.com/psirt",
+  "earlyWarningContact": "psirt@example.com",
+  "incidentReportContact": "incidents@example.com",
+  "enisaReportingPlatformId": "EU-MFR-DEMO",
+  "coordinatedDisclosurePolicyUrl": "https://example.com/security/cvd-policy",
+  "riskAssessmentUrl": "https://example.com/docs/risk-assessment-2026.pdf",
+  "riskAssessmentMethodology": "ISO/IEC 27005:2022"
+}

--- a/tests/fixtures/cra/cra-compliant.cdx.json
+++ b/tests/fixtures/cra/cra-compliant.cdx.json
@@ -1,0 +1,57 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:fc1234ab-cdef-4567-89ab-cdef01234567",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-01-15T09:00:00Z",
+    "tools": {
+      "components": [
+        {"type": "application", "name": "sbom-tools", "version": "0.1.20"}
+      ]
+    },
+    "supplier": {"name": "ExampleCorp", "url": ["https://example.com"], "contact": [{"name": "Security", "email": "security@example.com"}]},
+    "manufacturer": {"name": "ExampleCorp", "contact": [{"email": "legal@example.com"}]},
+    "component": {
+      "type": "application",
+      "bom-ref": "primary",
+      "name": "example-app",
+      "version": "1.0.0",
+      "purl": "pkg:cargo/example-app@1.0.0",
+      "supplier": {"name": "ExampleCorp"},
+      "hashes": [{"alg": "SHA-256", "content": "1111111111111111111111111111111111111111111111111111111111111111"}],
+      "externalReferences": [
+        {"type": "vcs", "url": "https://github.com/example/example-app"},
+        {"type": "issue-tracker", "url": "https://github.com/example/example-app/issues"},
+        {"type": "advisories", "url": "https://example.com/security/advisories"},
+        {"type": "security-contact", "url": "mailto:security@example.com"},
+        {"type": "attestation", "url": "https://example.com/doc.pdf"}
+      ]
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "lib-a",
+      "name": "lib-a",
+      "version": "2.3.4",
+      "purl": "pkg:cargo/lib-a@2.3.4",
+      "supplier": {"name": "LibAVendor"},
+      "hashes": [{"alg": "SHA-256", "content": "2222222222222222222222222222222222222222222222222222222222222222"}],
+      "licenses": [{"license": {"id": "Apache-2.0"}}]
+    },
+    {
+      "type": "library",
+      "bom-ref": "lib-b",
+      "name": "lib-b",
+      "version": "0.9.1",
+      "purl": "pkg:cargo/lib-b@0.9.1",
+      "supplier": {"name": "LibBVendor"},
+      "hashes": [{"alg": "SHA-256", "content": "3333333333333333333333333333333333333333333333333333333333333333"}],
+      "licenses": [{"license": {"id": "MIT"}}]
+    }
+  ],
+  "dependencies": [
+    {"ref": "primary", "dependsOn": ["lib-a", "lib-b"]}
+  ]
+}

--- a/tests/fixtures/cra/cra-compliant.cra.json
+++ b/tests/fixtures/cra/cra-compliant.cra.json
@@ -1,0 +1,20 @@
+{
+  "securityContact": "security@example.com",
+  "vulnerabilityDisclosureUrl": "https://example.com/security",
+  "supportEndDate": "2031-01-15T00:00:00Z",
+  "manufacturerName": "ExampleCorp",
+  "manufacturerEmail": "legal@example.com",
+  "productName": "example-app",
+  "productVersion": "1.0.0",
+  "ceMarkingReference": "EU-DoC-2026-001",
+  "updateMechanism": "Signed OTA via secure channel",
+  "psirtUrl": "https://example.com/psirt",
+  "earlyWarningContact": "psirt@example.com",
+  "incidentReportContact": "incidents@example.com",
+  "enisaReportingPlatformId": "EU-MFR-12345",
+  "coordinatedDisclosurePolicyUrl": "https://example.com/security/cvd-policy",
+  "riskAssessmentUrl": "https://example.com/docs/risk-assessment-2026.pdf",
+  "riskAssessmentMethodology": "ISO/IEC 27005:2022",
+  "productClass": "important-class-1",
+  "conformityAssessmentRoute": "module-a"
+}

--- a/tests/fixtures/cra/cra-noncompliant-no-manufacturer.cdx.json
+++ b/tests/fixtures/cra/cra-noncompliant-no-manufacturer.cdx.json
@@ -1,0 +1,25 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:bb1234ab-cdef-4567-89ab-cdef01234567",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-01-15T09:00:00Z",
+    "component": {
+      "type": "application",
+      "name": "anon-app",
+      "version": "1.0.0",
+      "purl": "pkg:cargo/anon-app@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "1111111111111111111111111111111111111111111111111111111111111111"}]
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "lib-a",
+      "version": "1.0.0",
+      "purl": "pkg:cargo/lib-a@1.0.0",
+      "hashes": [{"alg": "SHA-256", "content": "2222222222222222222222222222222222222222222222222222222222222222"}]
+    }
+  ]
+}

--- a/tests/fixtures/cra/cra-noncompliant-weak-hashes.cdx.json
+++ b/tests/fixtures/cra/cra-noncompliant-weak-hashes.cdx.json
@@ -1,0 +1,37 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:cc1234ab-cdef-4567-89ab-cdef01234567",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-01-15T09:00:00Z",
+    "supplier": {"name": "ExampleCorp", "contact": [{"email": "legal@example.com"}]},
+    "manufacturer": {"name": "ExampleCorp", "contact": [{"email": "legal@example.com"}]},
+    "component": {
+      "type": "application",
+      "name": "weakhash-app",
+      "version": "1.0.0",
+      "purl": "pkg:cargo/weakhash-app@1.0.0",
+      "supplier": {"name": "ExampleCorp"},
+      "hashes": [{"alg": "MD5", "content": "5d41402abc4b2a76b9719d911017c592"}]
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "name": "lib-md5",
+      "version": "1.0",
+      "purl": "pkg:cargo/lib-md5@1.0",
+      "supplier": {"name": "LibVendor"},
+      "hashes": [{"alg": "MD5", "content": "5d41402abc4b2a76b9719d911017c592"}]
+    },
+    {
+      "type": "library",
+      "name": "lib-sha1",
+      "version": "1.0",
+      "purl": "pkg:cargo/lib-sha1@1.0",
+      "supplier": {"name": "LibVendor"},
+      "hashes": [{"alg": "SHA-1", "content": "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"}]
+    }
+  ]
+}

--- a/tests/fixtures/cra/invalid.cra.yaml
+++ b/tests/fixtures/cra/invalid.cra.yaml
@@ -1,0 +1,5 @@
+: this is not valid yaml because the key is empty
+- and: this
+  is: also
+    invalid
+indentation: ":

--- a/tests/fixtures/cra/router-hardware.cdx.json
+++ b/tests/fixtures/cra/router-hardware.cdx.json
@@ -1,0 +1,68 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:5d3f1d62-5a4f-4b0a-9d5d-f0d85c9c1a01",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-04-26T12:00:00Z",
+    "tools": [
+      {
+        "vendor": "Acme",
+        "name": "sbom-tools",
+        "version": "0.1.19"
+      }
+    ],
+    "manufacturer": {
+      "name": "Acme Network Hardware GmbH",
+      "contact": [
+        { "email": "security@acme.example" }
+      ]
+    },
+    "component": {
+      "type": "device",
+      "bom-ref": "router-1",
+      "name": "Acme Edge Router",
+      "version": "2.4.0",
+      "purl": "pkg:generic/acme/edge-router@2.4.0",
+      "supplier": { "name": "Acme Network Hardware GmbH" }
+    }
+  },
+  "components": [
+    {
+      "type": "firmware",
+      "bom-ref": "router-1-fw",
+      "name": "Edge Router Firmware",
+      "version": "2.4.0-build312",
+      "purl": "pkg:generic/acme/edge-router-firmware@2.4.0-build312",
+      "supplier": { "name": "Acme Network Hardware GmbH" },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "abc123def4567890abc123def4567890abc123def4567890abc123def4567890"
+        }
+      ]
+    },
+    {
+      "type": "device",
+      "bom-ref": "wifi-radio",
+      "name": "Wi-Fi Radio Module",
+      "version": "rev-3",
+      "purl": "pkg:generic/acme/wifi-radio@rev-3",
+      "supplier": { "name": "Acme Radio Subsidiary" }
+    },
+    {
+      "type": "device-driver",
+      "bom-ref": "wifi-driver",
+      "name": "Wi-Fi Driver",
+      "version": "1.2.0",
+      "purl": "pkg:generic/acme/wifi-driver@1.2.0",
+      "supplier": { "name": "Acme Network Hardware GmbH" }
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "router-1",
+      "dependsOn": ["router-1-fw", "wifi-radio", "wifi-driver"]
+    }
+  ]
+}

--- a/tests/fixtures/cra/swhid-roundtrip.cdx.json
+++ b/tests/fixtures/cra/swhid-roundtrip.cdx.json
@@ -1,0 +1,62 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "serialNumber": "urn:uuid:7c8d9e0a-1b2c-3d4e-5f6a-7b8c9d0e1f2a",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-04-26T10:00:00Z",
+    "tools": [
+      { "vendor": "Acme", "name": "sbom-tools", "version": "0.1.19" }
+    ],
+    "component": {
+      "type": "application",
+      "bom-ref": "swhid-app",
+      "name": "swhid-demo",
+      "version": "1.0.0",
+      "purl": "pkg:cargo/swhid-demo@1.0.0"
+    }
+  },
+  "components": [
+    {
+      "type": "library",
+      "bom-ref": "lib-content",
+      "name": "lib-content",
+      "version": "0.1.0",
+      "purl": "pkg:generic/lib-content@0.1.0",
+      "swhid": [
+        "swh:1:cnt:94a9ed024d3859793618152ea559a168bbcbb5e2"
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "lib-tree",
+      "name": "lib-tree",
+      "version": "2.0.0",
+      "purl": "pkg:generic/lib-tree@2.0.0",
+      "swhid": [
+        "swh:1:dir:309cf2674ee7a0749978cf8265ab91a60aea0f7d"
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "lib-revision-with-origin",
+      "name": "lib-revision",
+      "version": "git-pinned",
+      "purl": "pkg:github/example/lib-revision@deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+      "swhid": [
+        "swh:1:rev:deadbeefdeadbeefdeadbeefdeadbeefdeadbeef;origin=https://github.com/example/lib-revision"
+      ]
+    },
+    {
+      "type": "library",
+      "bom-ref": "lib-multi-swhid",
+      "name": "lib-multi-swhid",
+      "version": "3.1.4",
+      "purl": "pkg:generic/lib-multi-swhid@3.1.4",
+      "swhid": [
+        "swh:1:cnt:1234567890abcdef1234567890abcdef12345678",
+        "swh:1:dir:abcdef1234567890abcdef1234567890abcdef12"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/csaf/branched-tree.csaf.json
+++ b/tests/fixtures/csaf/branched-tree.csaf.json
@@ -1,0 +1,44 @@
+{
+  "document": {
+    "category": "csaf_security_advisory",
+    "csaf_version": "2.0",
+    "publisher": {"category": "vendor", "name": "Branchy"},
+    "title": "Branched product tree fixture",
+    "tracking": {"id": "BR-2024-0001"}
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "BranchyCorp",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "Branchy",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "1.0",
+                "product": {
+                  "product_id": "BRANCHY-1.0",
+                  "name": "Branchy 1.0",
+                  "product_identification_helper": {
+                    "purl": "pkg:cargo/branchy@1.0.0"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-88001",
+      "product_status": {
+        "known_affected": ["BRANCHY-1.0"]
+      }
+    }
+  ]
+}

--- a/tests/fixtures/csaf/example-advisory.csaf.json
+++ b/tests/fixtures/csaf/example-advisory.csaf.json
@@ -1,0 +1,87 @@
+{
+  "document": {
+    "category": "csaf_security_advisory",
+    "csaf_version": "2.0",
+    "publisher": {
+      "category": "vendor",
+      "name": "Example Corp",
+      "namespace": "https://example.com"
+    },
+    "title": "Example security advisory for example-app",
+    "tracking": {
+      "id": "EX-2024-0001",
+      "initial_release_date": "2024-06-01T00:00:00Z",
+      "current_release_date": "2024-06-15T00:00:00Z",
+      "version": "1",
+      "status": "final",
+      "revision_history": [
+        {
+          "date": "2024-06-01T00:00:00Z",
+          "number": "1",
+          "summary": "Initial publication"
+        }
+      ],
+      "generator": {
+        "engine": {
+          "name": "csaf-test-fixture",
+          "version": "0.1"
+        }
+      }
+    }
+  },
+  "product_tree": {
+    "full_product_names": [
+      {
+        "product_id": "EXAMPLE-APP-1.0",
+        "name": "example-app 1.0",
+        "product_identification_helper": {
+          "purl": "pkg:cargo/example-app@1.0.0",
+          "cpe": "cpe:2.3:a:example:example-app:1.0.0:*:*:*:*:*:*:*"
+        }
+      },
+      {
+        "product_id": "EXAMPLE-APP-1.1",
+        "name": "example-app 1.1",
+        "product_identification_helper": {
+          "purl": "pkg:cargo/example-app@1.1.0"
+        }
+      },
+      {
+        "product_id": "EXAMPLE-APP-2.0",
+        "name": "example-app 2.0",
+        "product_identification_helper": {
+          "purl": "pkg:cargo/example-app@2.0.0"
+        }
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2024-99001",
+      "title": "Buffer overflow in example-app < 1.1",
+      "scores": [
+        {
+          "cvss_v3": {
+            "version": "3.1",
+            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "baseScore": 9.8,
+            "baseSeverity": "CRITICAL"
+          },
+          "products": ["EXAMPLE-APP-1.0"]
+        }
+      ],
+      "product_status": {
+        "known_affected": ["EXAMPLE-APP-1.0"],
+        "fixed": ["EXAMPLE-APP-1.1", "EXAMPLE-APP-2.0"]
+      }
+    },
+    {
+      "cve": "CVE-2024-99002",
+      "title": "Missing input validation",
+      "product_status": {
+        "known_not_affected": ["EXAMPLE-APP-2.0"],
+        "under_investigation": ["EXAMPLE-APP-1.1"]
+      }
+    }
+  ]
+}

--- a/tests/sarif_help_uri_tests.rs
+++ b/tests/sarif_help_uri_tests.rs
@@ -9,9 +9,7 @@
 //!   when violations carry `StandardRef::help_uri`.
 
 use sbom_tools::model::{Component, NormalizedSbom};
-use sbom_tools::quality::{
-    ComplianceChecker, ComplianceLevel, StandardKind, StandardRef,
-};
+use sbom_tools::quality::{ComplianceChecker, ComplianceLevel, StandardKind, StandardRef};
 use sbom_tools::reports::generate_compliance_sarif;
 
 #[test]
@@ -27,7 +25,9 @@ fn standard_ref_new_auto_populates_help_uri_for_cra() {
 fn standard_ref_new_auto_populates_help_uri_for_bsi() {
     let r = StandardRef::new(StandardKind::BsiTr03183_2, "TR-03183-2 §5.4");
     assert!(
-        r.help_uri.as_deref().is_some_and(|u| u.contains("bsi.bund.de")),
+        r.help_uri
+            .as_deref()
+            .is_some_and(|u| u.contains("bsi.bund.de")),
         "BSI helpUri should point at bsi.bund.de, got: {:?}",
         r.help_uri
     );
@@ -36,10 +36,7 @@ fn standard_ref_new_auto_populates_help_uri_for_bsi() {
 #[test]
 fn standard_ref_new_pren_remains_none_until_published() {
     let r = StandardRef::new(StandardKind::Pren40000_1_3, "PRE-7-RQ-07");
-    assert!(
-        r.help_uri.is_none(),
-        "prEN 40000-1-3 has no public URL yet"
-    );
+    assert!(r.help_uri.is_none(), "prEN 40000-1-3 has no public URL yet");
 }
 
 #[test]
@@ -89,7 +86,9 @@ fn sarif_output_includes_help_uri_for_cra_rules() {
         .as_array()
         .expect("rules array");
     let cra_rule_with_uri = rules.iter().any(|r| {
-        r["id"].as_str().is_some_and(|id| id.starts_with("SBOM-CRA-"))
+        r["id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("SBOM-CRA-"))
             && r["helpUri"]
                 .as_str()
                 .is_some_and(|u| u.contains("eur-lex.europa.eu"))

--- a/tests/sarif_help_uri_tests.rs
+++ b/tests/sarif_help_uri_tests.rs
@@ -1,0 +1,146 @@
+//! Integration tests for CRA-P5.1 SARIF helpUri linking.
+//!
+//! Asserts that:
+//! - `StandardRef::new` auto-populates `help_uri` from `StandardKind`
+//!   (canonical EUR-Lex / BSI / NIST / OASIS URLs).
+//! - SARIF rule definitions include `helpUri` for CRA-, BSI-, NTIA-,
+//!   SSDF-, EO-, FDA-, PQC-, CSAF-, CNSA-prefixed rules.
+//! - SARIF result `properties.standardHelpUris` parallels `standardIds`
+//!   when violations carry `StandardRef::help_uri`.
+
+use sbom_tools::model::{Component, NormalizedSbom};
+use sbom_tools::quality::{
+    ComplianceChecker, ComplianceLevel, StandardKind, StandardRef,
+};
+use sbom_tools::reports::generate_compliance_sarif;
+
+#[test]
+fn standard_ref_new_auto_populates_help_uri_for_cra() {
+    let r = StandardRef::new(StandardKind::CraArticle, "Art. 13(4)");
+    assert_eq!(
+        r.help_uri.as_deref(),
+        Some("https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng")
+    );
+}
+
+#[test]
+fn standard_ref_new_auto_populates_help_uri_for_bsi() {
+    let r = StandardRef::new(StandardKind::BsiTr03183_2, "TR-03183-2 §5.4");
+    assert!(
+        r.help_uri.as_deref().is_some_and(|u| u.contains("bsi.bund.de")),
+        "BSI helpUri should point at bsi.bund.de, got: {:?}",
+        r.help_uri
+    );
+}
+
+#[test]
+fn standard_ref_new_pren_remains_none_until_published() {
+    let r = StandardRef::new(StandardKind::Pren40000_1_3, "PRE-7-RQ-07");
+    assert!(
+        r.help_uri.is_none(),
+        "prEN 40000-1-3 has no public URL yet"
+    );
+}
+
+#[test]
+fn standard_ref_new_other_remains_none() {
+    let r = StandardRef::new(StandardKind::Other, "ad-hoc");
+    assert!(r.help_uri.is_none());
+}
+
+#[test]
+fn standard_kinds_have_canonical_help_uri() {
+    let kinds_with_uri = [
+        StandardKind::CraArticle,
+        StandardKind::CraAnnex,
+        StandardKind::BsiTr03183_2,
+        StandardKind::NistSsdf,
+        StandardKind::Eo14028,
+        StandardKind::FdaPremarket,
+        StandardKind::NtiaMinimum,
+        StandardKind::Csaf2,
+        StandardKind::Cnsa2,
+        StandardKind::NistPqc,
+    ];
+    for kind in kinds_with_uri {
+        let uri = kind.canonical_help_uri("any-id");
+        assert!(
+            uri.is_some(),
+            "{kind:?} should expose a canonical helpUri for CRA-P5.1"
+        );
+        let uri = uri.unwrap();
+        assert!(
+            uri.starts_with("https://"),
+            "{kind:?} helpUri must be HTTPS, got {uri}"
+        );
+    }
+}
+
+#[test]
+fn sarif_output_includes_help_uri_for_cra_rules() {
+    // Empty SBOM under CraPhase2 generates many violations and exercises
+    // the entire SARIF rule table.
+    let sbom = NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+    let sarif = generate_compliance_sarif(&result).expect("SARIF generation");
+    let json: serde_json::Value = serde_json::from_str(&sarif).expect("valid JSON");
+
+    let rules = json["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .expect("rules array");
+    let cra_rule_with_uri = rules.iter().any(|r| {
+        r["id"].as_str().is_some_and(|id| id.starts_with("SBOM-CRA-"))
+            && r["helpUri"]
+                .as_str()
+                .is_some_and(|u| u.contains("eur-lex.europa.eu"))
+    });
+    assert!(
+        cra_rule_with_uri,
+        "At least one CRA rule must carry a EUR-Lex helpUri"
+    );
+}
+
+#[test]
+fn sarif_output_results_include_standard_help_uris() {
+    let mut sbom = NormalizedSbom::default();
+    let c = Component::new("foo".to_string(), "foo".to_string());
+    sbom.add_component(c);
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&sbom);
+    let sarif = generate_compliance_sarif(&result).expect("SARIF generation");
+    let json: serde_json::Value = serde_json::from_str(&sarif).expect("valid JSON");
+
+    let results = json["runs"][0]["results"].as_array().expect("results");
+    let with_uri = results.iter().any(|r| {
+        r["properties"]["standardHelpUris"]
+            .as_array()
+            .is_some_and(|a| !a.is_empty())
+    });
+    assert!(
+        with_uri,
+        "At least one result should expose properties.standardHelpUris"
+    );
+}
+
+#[test]
+fn sarif_output_includes_help_uri_for_bsi_rules() {
+    let sbom = NormalizedSbom::default();
+    let result = ComplianceChecker::new(ComplianceLevel::BsiTr03183_2).check(&sbom);
+    let sarif = generate_compliance_sarif(&result).expect("SARIF generation");
+    let json: serde_json::Value = serde_json::from_str(&sarif).expect("valid JSON");
+
+    let rules = json["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .expect("rules array");
+    let bsi_rule_with_uri = rules.iter().any(|r| {
+        r["id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("SBOM-BSI-"))
+            && r["helpUri"]
+                .as_str()
+                .is_some_and(|u| u.contains("bsi.bund.de"))
+    });
+    assert!(
+        bsi_rule_with_uri,
+        "BSI rules must carry a bsi.bund.de helpUri"
+    );
+}


### PR DESCRIPTION
## Summary

Comprehensive [Cyber Resilience Act](https://eur-lex.europa.eu/eli/reg/2024/2847/oj/eng) compliance overhaul aligning sbom-tools with the CRA, prEN 40000-1-3 horizontal standard, BSI TR-03183-2, CSAF v2.0, CRA Annex III/IV product-class taxonomy, Article 24 OSS steward profile, EUCC Substantial reference profile, and adjacent EU regulation (NIS2 / GDPR / AI Act / RED). **Closes the entire `memory/cra-improvement-plan.md` (P1 through P5).**

11 commits, ~9,800 LOC across 50+ files. Tests: **802 → 1,170 passing** (+368 new tests, 0 regressions).

## Commits in this PR

| Phase  | Commit    | Adds |
|--------|-----------|------|
| **P1+P2** | `3791ef2` | sidecar wiring, prEN 40000-1-3 IDs (`StandardKind` / `StandardRef`), SWHID identifier (`CanonicalId::Swhid`), vendor-hash carry-through, hardware [PRE-8-RQ-02], BSI TR-03183-2, Article 14 readiness, Article 13(2) risk-assessment, direct/transitive supplier split |
| **P3.2** | `e197ea7` | `CraProductClass` + `ConformityRoute`, `--cra-product-class` flag, `ClassCheck` calibration table, vendor-hash threshold ramp 50/80/80/100, EOL/DoC/Art.14 PSIRT severity escalation, EUCC + module-attestation checks |
| **P3.3** | `8016f34` | `ComplianceLevel::CraOssSteward` (Article 24 lighter profile), `is_oss_steward` sidecar field, `--standard oss-steward` |
| **P3.1** | `0fcd9e9` | CSAF v2.0 (ISO/IEC 20153:2025) ingest with auto-detect priority CSAF → CycloneDX VEX → OpenVEX |
| **P5.1** | `eb40e63` | SARIF helpUri populated on rules + `properties.standardHelpUris` on results |
| **P4.1** | `ae1b26c` | `cra-docs` CLI subcommand → Annex V dossier (DoC + tech-doc + vuln-policy markdown) |
| **P5.3** | `64cfe51` | `docs/CRA_COMPLIANCE.md` reverse-mapping table + README link |
| **P4.2** | `823cd89` | CSAF v2.0 emitter + `vex export --format csaf` CLI; round-trip preserves VEX state |
| **P4.3** | `5afc263` | `ConformityAssessmentSummary` + per-route evidence checklist; rendered in markdown / HTML reports and TUI compliance view |
| **P4.4** | `e8994bf` | NIS2 / GDPR / AI Act / RED overlap section in cra-docs; 5 new sidecar flags |
| **P5.2/4/5/6/7** | `9e4ce78` | EuccSubstantial profile (`--standard eucc`), prEN 40000-1-2/1-4 controls-assertion sidecar block (`annex_i_part_i_controls`), `cra-standards-watch` CLI with curated 8-artefact catalogue, TUI presets for EUCC + OSS Steward, full golden fixtures (CDX compliant + 2 non-compliant) with regression tests |

## CRA plan: **all P1–P5 items shipped**

| Phase | Items                                                   | Status |
|-------|---------------------------------------------------------|--------|
| P1    | Sidecar wiring, prEN IDs, SWHID, vendor hashes, hardware | ✅ |
| P2    | BSI TR-03183-2, Art. 14, Art. 13(2), direct/transitive  | ✅ |
| P3.1  | CSAF v2.0 ingest                                        | ✅ |
| P3.2  | Annex III/IV product class                              | ✅ |
| P3.3  | Article 24 OSS steward                                  | ✅ |
| P4.1  | cra-docs dossier generator                              | ✅ |
| P4.2  | CSAF v2.0 emitter                                       | ✅ |
| P4.3  | Conformity-route surface                                | ✅ |
| P4.4  | NIS2 / GDPR / AI Act / RED overlap                      | ✅ |
| P5.1  | SARIF helpUri linking                                   | ✅ |
| P5.2  | CRA golden fixtures                                     | ✅ |
| P5.3  | docs/CRA_COMPLIANCE.md                                  | ✅ |
| P5.4  | EuccSubstantial profile                                 | ✅ |
| P5.5  | Controls-assertion sidecar block                        | ✅ |
| P5.6  | cra-standards-watch CLI                                 | ✅ |
| P5.7  | TUI presets (EUCC + OSS Steward)                        | ✅ |

Backwards compatible throughout: every new behaviour is opt-in (sidecar fields, `--cra-product-class`, `--standard {oss-steward,eucc,bsi,...}`, `vex export`, `cra-docs`, `cra-standards-watch`). When no class is pinned, existing `CraPhase1`/`CraPhase2` thresholds and severities are preserved verbatim.

## Test plan

- [x] `cargo test --lib --tests --bins` — **1,170 passing, 0 failed**
- [x] `cargo check --all-targets` — clean
- [x] `cargo clippy` — no new warnings on touched code
- [x] CRA-specific integration suites (12 of them) all green
- [x] Round-trip: ingest CSAF fixture → enrich → emit CSAF → re-ingest → identical VEX states
- [x] Golden fixtures: compliant fixture passes Phase2/BSI/OSS-steward without Errors; non-compliant fixtures fire expected violations
- [ ] Manual smoke test: `sbom-tools cra-docs <sbom> --output dossier/` produces a 3-file dossier; `--cra-sidecar` includes Annex I controls assertion + adjacent regulation sections
- [ ] Manual smoke test: `sbom-tools vex export <sbom> --format csaf` produces a `csaf-validator`-clean document
- [ ] Manual smoke test: `sbom-tools cra-standards-watch` (and `--check-online --timeout 30`) prints the curated catalogue
- [ ] Manual smoke test: TUI compliance tab shows EUCC + OSS Steward presets in the cycle, and the "Annex VIII: <route> (<class>) N/M evidence" line appears under the COMPLIANT/NON-COMPLIANT status when a sidecar pins productClass

## Notes for reviewers

- The reverse map in `docs/CRA_COMPLIANCE.md` is the single source of truth for the `Violation::derive_standard_refs()` lookup table.
- `StandardRef::new` auto-populates `help_uri` via `StandardKind::canonical_help_uri()`. prEN 40000-1-3 returns `None` because the draft is paywalled.
- `ConformityRoute::default_route()` per class (Default/Imp-1 → ModuleA, Imp-2 → ModuleBC, Critical → EUCC) is the *expected* route — manufacturers may pin a stricter route via sidecar `conformityAssessmentRoute`.
- `CraSidecarMetadata::has_cra_data` is no longer `const fn` because `BTreeMap::is_empty` isn't const-stable yet — internal-only API churn.
- Catalogue in `cra-standards-watch` is curated; update via PR when standards bodies publish new versions.
- Adjacent regulation, controls assertion, and EUCC sections in `technical-documentation.md` only render when the matching sidecar fields are populated — empty sidecars produce a clean dossier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)