### PR TITLE
feat(watch): route cra-standards-watch alerts through AlertSink

### DIFF
--- a/src/cli/cra_standards_watch.rs
+++ b/src/cli/cra_standards_watch.rs
@@ -28,6 +28,20 @@ pub struct TrackedStandard {
     pub watch_reason: &'static str,
 }
 
+/// Borrow the curated catalogue. Watch-loop integration probes these URLs
+/// on a configurable interval and surfaces status drift through
+/// [`crate::watch::alerts::AlertSink`].
+pub fn cra_catalogue() -> &'static [TrackedStandard] {
+    CATALOGUE
+}
+
+/// Probe each entry's URL with `timeout` and return the resulting
+/// [`OnlineProbe`] list. Without the `enrichment` feature the probes are
+/// returned with a static "feature disabled" status string.
+pub fn probe_cra_standards(entries: &[TrackedStandard], timeout: Duration) -> Vec<OnlineProbe> {
+    probe_urls(entries, timeout)
+}
+
 /// Curated catalogue. Update entries here when standards bodies publish a
 /// new draft or final version. Dates are last-confirmed by hand; the
 /// command does not mutate this list at runtime.
@@ -184,10 +198,13 @@ pub fn run_cra_standards_watch(
     Ok(())
 }
 
+/// Result of a single URL probe against the CRA standards catalogue.
+/// `status` is a verbatim HTTP status string (e.g. "200 OK") or an
+/// error description prefixed with `error:`.
 #[derive(Debug, Clone, Serialize)]
-struct OnlineProbe {
-    id: &'static str,
-    status: String,
+pub struct OnlineProbe {
+    pub id: &'static str,
+    pub status: String,
 }
 
 /// Fire HEAD requests at each catalogue URL with the supplied timeout.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,7 +21,10 @@ mod view;
 mod watch;
 
 pub use cra_docs::run_cra_docs;
-pub use cra_standards_watch::{WatchOutputFormat, run_cra_standards_watch};
+pub use cra_standards_watch::{
+    OnlineProbe, TrackedStandard, WatchOutputFormat, cra_catalogue, probe_cra_standards,
+    run_cra_standards_watch,
+};
 pub use diff::run_diff;
 #[cfg(feature = "enrichment")]
 pub use enrich::run_enrich;

--- a/src/main.rs
+++ b/src/main.rs
@@ -773,6 +773,20 @@ struct WatchArgs {
     /// Scan once and print discovered SBOMs, then exit (useful for testing watch configuration)
     #[arg(long)]
     dry_run: bool,
+
+    /// Periodically probe the curated CRA-standards catalogue and surface
+    /// drift through the configured watch sinks (stdout / NDJSON / webhook).
+    /// Requires the `enrichment` feature for live HTTP probes.
+    #[arg(long)]
+    cra_standards: bool,
+
+    /// Interval between CRA-standards probe cycles (e.g., 6h, 24h, 7d)
+    #[arg(long, default_value = "24h")]
+    cra_standards_interval: String,
+
+    /// Per-request timeout for CRA-standards HTTP probes (e.g., 5s, 10s)
+    #[arg(long, default_value = "10s")]
+    cra_standards_timeout: String,
 }
 
 #[derive(Subcommand)]
@@ -1613,6 +1627,9 @@ fn main() -> Result<()> {
                 max_snapshots: args.max_snapshots,
                 quiet: cli.quiet,
                 dry_run: args.dry_run,
+                cra_standards_enabled: args.cra_standards,
+                cra_standards_interval: parse_duration(&args.cra_standards_interval)?,
+                cra_standards_timeout: parse_duration(&args.cra_standards_timeout)?,
             };
 
             cli::run_watch(config)

--- a/src/watch/alerts.rs
+++ b/src/watch/alerts.rs
@@ -20,6 +20,34 @@ pub(crate) trait AlertSink {
 
     /// Called periodically with a session summary.
     fn on_status(&mut self, summary: &WatchSummary) -> anyhow::Result<()>;
+
+    /// Called when a CRA-standards probe surfaces a status change for an
+    /// entry in the curated catalogue. Default is a no-op so sinks that
+    /// don't care about standards drift compile unchanged.
+    fn on_cra_standard(&mut self, _event: &CraStandardEvent) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+/// One CRA-standards drift event produced by the watch loop's periodic
+/// catalogue probe. Carries enough metadata for sinks to render a
+/// human-readable line or a structured JSON record without re-resolving
+/// the catalogue.
+#[derive(Debug, Clone)]
+pub(crate) struct CraStandardEvent {
+    pub id: &'static str,
+    pub title: &'static str,
+    pub url: &'static str,
+    pub kind: CraEventKind,
+}
+
+/// Kind of CRA-standards drift the watch loop observed.
+#[derive(Debug, Clone)]
+pub(crate) enum CraEventKind {
+    /// First probe of this entry in the current watch session.
+    InitialBaseline { status: String },
+    /// HTTP probe status differs from the previous tick.
+    StatusChanged { from: String, to: String },
 }
 
 // ============================================================================
@@ -127,6 +155,27 @@ impl AlertSink for StdoutAlertSink {
         );
         Ok(())
     }
+
+    fn on_cra_standard(&mut self, event: &CraStandardEvent) -> anyhow::Result<()> {
+        let ts = chrono::Local::now().format("%H:%M:%S");
+        match &event.kind {
+            CraEventKind::InitialBaseline { status } => {
+                if !self.quiet {
+                    eprintln!(
+                        "[{ts}] cra-standard {}: baseline {} ({})",
+                        event.id, status, event.title
+                    );
+                }
+            }
+            CraEventKind::StatusChanged { from, to } => {
+                eprintln!(
+                    "[{ts}] cra-standard {}: status drift {from} -> {to} ({})",
+                    event.id, event.title
+                );
+            }
+        }
+        Ok(())
+    }
 }
 
 // ============================================================================
@@ -199,6 +248,32 @@ impl AlertSink for NdjsonAlertSink {
             "uptime_secs": summary.uptime_secs,
         });
         self.write_event(&event)
+    }
+
+    fn on_cra_standard(&mut self, event: &CraStandardEvent) -> anyhow::Result<()> {
+        let (kind, from, to, status) = match &event.kind {
+            CraEventKind::InitialBaseline { status } => {
+                ("baseline", None, None, Some(status.as_str()))
+            }
+            CraEventKind::StatusChanged { from, to } => (
+                "status_changed",
+                Some(from.as_str()),
+                Some(to.as_str()),
+                None,
+            ),
+        };
+        let payload = serde_json::json!({
+            "type": "cra_standard",
+            "kind": kind,
+            "id": event.id,
+            "title": event.title,
+            "url": event.url,
+            "from": from,
+            "to": to,
+            "status": status,
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+        });
+        self.write_event(&payload)
     }
 }
 
@@ -364,6 +439,84 @@ mod tests {
         assert_eq!(parsed["type"], "change");
         assert_eq!(parsed["added"], 3);
         assert_eq!(parsed["new_vulns"][0], "CVE-2026-1234");
+    }
+
+    #[test]
+    fn test_ndjson_sink_emits_cra_standard_event() {
+        let buffer = std::sync::Arc::new(std::sync::Mutex::new(Vec::<u8>::new()));
+        let writer = {
+            struct ArcWriter(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+            impl Write for ArcWriter {
+                fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+                    self.0.lock().unwrap().write(buf)
+                }
+                fn flush(&mut self) -> std::io::Result<()> {
+                    Ok(())
+                }
+            }
+            ArcWriter(buffer.clone())
+        };
+        let mut sink = NdjsonAlertSink::new(Box::new(writer));
+
+        let baseline = CraStandardEvent {
+            id: "BSI-TR-03183-2",
+            title: "BSI TR-03183-2",
+            url: "https://example.invalid/tr",
+            kind: CraEventKind::InitialBaseline {
+                status: "200 OK".to_string(),
+            },
+        };
+        sink.on_cra_standard(&baseline).unwrap();
+
+        let drift = CraStandardEvent {
+            id: "BSI-TR-03183-2",
+            title: "BSI TR-03183-2",
+            url: "https://example.invalid/tr",
+            kind: CraEventKind::StatusChanged {
+                from: "200 OK".to_string(),
+                to: "503 Service Unavailable".to_string(),
+            },
+        };
+        sink.on_cra_standard(&drift).unwrap();
+
+        let output = buffer.lock().unwrap();
+        let text = String::from_utf8_lossy(&output);
+        let mut lines = text.lines();
+
+        let line1: serde_json::Value = serde_json::from_str(lines.next().unwrap()).unwrap();
+        assert_eq!(line1["type"], "cra_standard");
+        assert_eq!(line1["kind"], "baseline");
+        assert_eq!(line1["id"], "BSI-TR-03183-2");
+        assert_eq!(line1["status"], "200 OK");
+
+        let line2: serde_json::Value = serde_json::from_str(lines.next().unwrap()).unwrap();
+        assert_eq!(line2["kind"], "status_changed");
+        assert_eq!(line2["from"], "200 OK");
+        assert_eq!(line2["to"], "503 Service Unavailable");
+    }
+
+    #[test]
+    fn test_stdout_sink_cra_standard_does_not_panic() {
+        let mut sink = StdoutAlertSink::new(false);
+        let event = CraStandardEvent {
+            id: "STAN4CRA",
+            title: "STAN4CRA hub",
+            url: "https://example.invalid/",
+            kind: CraEventKind::InitialBaseline {
+                status: "200 OK".to_string(),
+            },
+        };
+        sink.on_cra_standard(&event).unwrap();
+        let drift = CraStandardEvent {
+            id: "STAN4CRA",
+            title: "STAN4CRA hub",
+            url: "https://example.invalid/",
+            kind: CraEventKind::StatusChanged {
+                from: "200 OK".to_string(),
+                to: "404 Not Found".to_string(),
+            },
+        };
+        sink.on_cra_standard(&drift).unwrap();
     }
 
     #[test]

--- a/src/watch/config.rs
+++ b/src/watch/config.rs
@@ -31,6 +31,13 @@ pub struct WatchConfig {
     pub quiet: bool,
     /// Dry-run mode: do initial scan only, then exit
     pub dry_run: bool,
+    /// Periodically probe the curated CRA-standards catalogue and surface
+    /// status drift through the configured [`super::alerts::AlertSink`]s.
+    pub cra_standards_enabled: bool,
+    /// Interval between CRA-standards probe cycles
+    pub cra_standards_interval: Duration,
+    /// Per-request timeout for CRA-standards HTTP probes
+    pub cra_standards_timeout: Duration,
 }
 
 /// Parse a human-readable duration string into a [`Duration`].

--- a/src/watch/loop_impl.rs
+++ b/src/watch/loop_impl.rs
@@ -3,13 +3,15 @@
 //! Coordinates file monitoring, parsing, diffing, enrichment, and alerting.
 
 use super::WatchError;
-use super::alerts::{AlertSink, build_alert_sinks};
+use super::alerts::{AlertSink, CraEventKind, CraStandardEvent, build_alert_sinks};
 use super::config::WatchConfig;
 use super::monitor::{FileChange, FileMonitor};
 use super::state::{DiffSnapshot, MonitorStatus, WatchState, WatchSummary};
+use crate::cli::{cra_catalogue, probe_cra_standards};
 use crate::diff::DiffEngine;
 use crate::matching::FuzzyMatchConfig;
 use crate::model::NormalizedSbom;
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -25,6 +27,9 @@ pub fn run_watch_loop(config: &WatchConfig) -> anyhow::Result<()> {
     let mut state = WatchState::new(config.max_snapshots);
     let mut sinks = build_alert_sinks(config)?;
     let engine = DiffEngine::new().with_fuzzy_config(FuzzyMatchConfig::balanced());
+
+    let mut cra_status: HashMap<&'static str, String> = HashMap::new();
+    let mut cra_last_probe: Option<Instant> = None;
 
     // Graceful shutdown flag
     let stop = Arc::new(AtomicBool::new(false));
@@ -52,6 +57,11 @@ pub fn run_watch_loop(config: &WatchConfig) -> anyhow::Result<()> {
 
     // Emit initial status
     emit_status(&state, &mut sinks);
+
+    // CRA-standards baseline probe at startup (if enabled).
+    if config.cra_standards_enabled {
+        run_cra_standards_cycle(config, &mut cra_status, &mut cra_last_probe, &mut sinks);
+    }
 
     // Dry-run mode: print discovered files and exit
     if config.dry_run {
@@ -135,6 +145,13 @@ pub fn run_watch_loop(config: &WatchConfig) -> anyhow::Result<()> {
             .is_none_or(|t| t.elapsed() >= config.enrich_interval);
         if should_enrich && config.enrichment.enabled {
             run_enrichment_cycle(config, &mut state, &mut sinks);
+        }
+
+        // Periodic CRA-standards drift check
+        if config.cra_standards_enabled
+            && cra_last_probe.is_none_or(|t| t.elapsed() >= config.cra_standards_interval)
+        {
+            run_cra_standards_cycle(config, &mut cra_status, &mut cra_last_probe, &mut sinks);
         }
 
         // Periodic status
@@ -515,4 +532,48 @@ fn count_vulns(sbom: &NormalizedSbom) -> usize {
 
 fn count_eol(sbom: &NormalizedSbom) -> usize {
     sbom.components.values().filter(|c| c.eol.is_some()).count()
+}
+
+/// Probe the curated CRA-standards catalogue and emit
+/// [`CraStandardEvent`] alerts for new entries (`InitialBaseline`) and
+/// status drift (`StatusChanged`). Mutates `last_status` so the next
+/// tick can compare. No-op when no entries are available.
+fn run_cra_standards_cycle(
+    config: &WatchConfig,
+    last_status: &mut HashMap<&'static str, String>,
+    last_probe: &mut Option<Instant>,
+    sinks: &mut [Box<dyn AlertSink>],
+) {
+    *last_probe = Some(Instant::now());
+    let catalogue = cra_catalogue();
+    if catalogue.is_empty() {
+        return;
+    }
+    let probes = probe_cra_standards(catalogue, config.cra_standards_timeout);
+    for probe in probes {
+        let entry = catalogue.iter().find(|e| e.id == probe.id);
+        let Some(entry) = entry else { continue };
+        let kind = match last_status.get(probe.id) {
+            None => CraEventKind::InitialBaseline {
+                status: probe.status.clone(),
+            },
+            Some(prev) if prev == &probe.status => continue,
+            Some(prev) => CraEventKind::StatusChanged {
+                from: prev.clone(),
+                to: probe.status.clone(),
+            },
+        };
+        last_status.insert(probe.id, probe.status.clone());
+        let event = CraStandardEvent {
+            id: entry.id,
+            title: entry.title,
+            url: entry.url,
+            kind,
+        };
+        for sink in sinks.iter_mut() {
+            if let Err(e) = sink.on_cra_standard(&event) {
+                tracing::warn!("Alert sink error: {e}");
+            }
+        }
+    }
 }

--- a/tests/watch_tests.rs
+++ b/tests/watch_tests.rs
@@ -60,6 +60,9 @@ fn test_watch_loop_no_files_returns_error() {
         max_snapshots: 10,
         quiet: true,
         dry_run: false,
+        cra_standards_enabled: false,
+        cra_standards_interval: Duration::from_secs(86_400),
+        cra_standards_timeout: Duration::from_secs(10),
     };
 
     let result = sbom_tools::watch::run_watch_loop(&config);
@@ -85,6 +88,9 @@ fn test_watch_loop_nonexistent_dir() {
         max_snapshots: 10,
         quiet: true,
         dry_run: false,
+        cra_standards_enabled: false,
+        cra_standards_interval: Duration::from_secs(86_400),
+        cra_standards_timeout: Duration::from_secs(10),
     };
 
     // The cli handler checks for dir existence; the loop itself may still
@@ -114,6 +120,9 @@ fn test_watch_loop_exit_on_change() {
         max_snapshots: 10,
         quiet: true,
         dry_run: false,
+        cra_standards_enabled: false,
+        cra_standards_interval: Duration::from_secs(86_400),
+        cra_standards_timeout: Duration::from_secs(10),
     };
 
     // Spawn the watch loop in a thread, modify the file, then verify it exits
@@ -173,6 +182,9 @@ fn test_watch_loop_initial_scan_parses_fixtures() {
         max_snapshots: 10,
         quiet: true,
         dry_run: false,
+        cra_standards_enabled: false,
+        cra_standards_interval: Duration::from_secs(86_400),
+        cra_standards_timeout: Duration::from_secs(10),
     };
 
     let config_clone = config.clone();
@@ -221,6 +233,9 @@ fn test_watch_ndjson_output_produces_valid_json() {
         max_snapshots: 10,
         quiet: true,
         dry_run: false,
+        cra_standards_enabled: false,
+        cra_standards_interval: Duration::from_secs(86_400),
+        cra_standards_timeout: Duration::from_secs(10),
     };
 
     let config_clone = config.clone();


### PR DESCRIPTION
## Summary

Follow-up to PR #161. Wires the curated CRA-standards catalogue (added in P5.6) into the existing `watch` daemon so status drift is reported alongside SBOM file changes and vulnerability discoveries — no new TUI tab, no new sink type.

- New `AlertSink::on_cra_standard` (default no-op) carries `CraStandardEvent` with `InitialBaseline` / `StatusChanged` variants.
- `StdoutAlertSink` emits a timestamped human-readable line per drift; `NdjsonAlertSink` emits `{\"type\":\"cra_standard\", ...}`.
- `WatchConfig` gains `cra_standards_enabled` / `cra_standards_interval` (default 24h) / `cra_standards_timeout` (default 10s).
- `watch` CLI gains `--cra-standards`, `--cra-standards-interval=<dur>`, `--cra-standards-timeout=<dur>`.

## Why this shape

- Operators already keep `watch` running for SBOM monitoring; this reuses that infra rather than adding a separate background daemon or a dedicated TUI tab.
- Catalogue stays the single source of truth (in `cli/cra_standards_watch.rs`); the watch loop borrows it, doesn't duplicate.
- Default no-op trait method means existing third-party sinks (if any) keep compiling.
- Webhook sink stays at the default — drift signals are low-value to spam to webhooks; can be enabled later if requested.

## Test plan

- [x] `cargo test --lib watch::alerts` — 4 passed (2 new: NDJSON event shape, stdout no-panic)
- [x] `cargo test --test watch_tests` — 11 passed (5 literals updated for new config fields)
- [x] `cargo test --lib` — 787 passed, 0 failed
- [x] `cargo clippy -- -D warnings` (default features) — clean
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI green on PR

## Notes

- Bumps watch infra by ~280 LOC (impl + tests + config plumbing). Slightly above the ~100-LOC estimate; the extra is from extending the trait with default impl + JSON sink + propagating 3 config fields through tests.
- No behavior change for anyone not passing `--cra-standards`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)