### PR TITLE
Release v0.1.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2462,7 +2462,7 @@ dependencies = [
 
 [[package]]
 name = "sbom-tools"
-version = "0.1.19"
+version = "0.1.20"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["dagger/rust-sdk"]
 
 [package]
 name = "sbom-tools"
-version = "0.1.19"
+version = "0.1.20"
 edition = "2024"
 rust-version = "1.88"
 description = "Semantic SBOM diff and analysis tool"


### PR DESCRIPTION
## Summary

Bump `Cargo.toml` and `Cargo.lock` from 0.1.19 → 0.1.20 in preparation for the v0.1.20 release.

Headline content for this release: end-to-end EU CRA readiness — prEN 40000-1-3 IDs, CRA product-class severity calibration, Article 24 OSS steward profile, BSI TR-03183-2 §5/§6 checks, CSAF v2.0 ingest+emit, `cra-docs` Annex V dossier generator, `cra-standards-watch` CLI, AlertSink integration for periodic standards drift detection, SARIF helpUri linking, NIS2/GDPR/AI Act/RED overlap surfaces. 5 new ComplianceLevel variants (9 → 14). Full release notes drafted at `~/Documents/sbom-tools-RELEASE_NOTES-v0.1.20.md`.

## Test plan

- [x] `cargo check` — clean
- [x] All work shipped as part of PR #161 (CRA P1–P5) and PR #168 (AlertSink follow-up), each with green CI
- [ ] CI green on this PR
- [ ] After merge: `git tag -s v0.1.20 -m "Release v0.1.20" && git push origin v0.1.20` to trigger crates.io publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)