### PR TITLE
fix(reports): emit structured vulnerabilities in JSON view (#178)

### DIFF
--- a/src/reports/json.rs
+++ b/src/reports/json.rs
@@ -2,9 +2,9 @@
 
 use super::{ReportConfig, ReportError, ReportFormat, ReportGenerator, ReportType};
 use crate::diff::DiffResult;
-use crate::model::NormalizedSbom;
+use crate::model::{Component, NormalizedSbom, VulnerabilityRef};
 use crate::quality::{ComplianceChecker, ComplianceLevel, ComplianceResult};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 
 /// JSON report generator
@@ -172,6 +172,46 @@ impl ReportGenerator for JsonReporter {
             .unwrap_or_else(|| ComplianceChecker::new(ComplianceLevel::CraPhase2).check(sbom));
         let compliance = CraComplianceDetail::from_result(cra_result);
 
+        let direct_ids = sbom.direct_dependency_ids();
+        let primary_id = sbom.primary_component_id.as_ref();
+
+        let components: Vec<ComponentView> = sbom
+            .components
+            .values()
+            .map(|c| {
+                let kind = classify_dependency(&c.canonical_id, primary_id, &direct_ids);
+                ComponentView {
+                    name: c.name.clone(),
+                    version: c.version.clone(),
+                    ecosystem: c.ecosystem.as_ref().map(std::string::ToString::to_string),
+                    licenses: c
+                        .licenses
+                        .declared
+                        .iter()
+                        .map(|l| l.expression.clone())
+                        .collect(),
+                    supplier: c.supplier.as_ref().map(|s| s.name.clone()),
+                    dependency_kind: kind,
+                    vulnerability_count: c.vulnerabilities.len(),
+                    vulnerabilities: c.vulnerabilities.iter().map(VulnerabilityView::from).collect(),
+                    eol_status: c.eol.as_ref().map(|e| e.status.label().to_string()),
+                    eol_date: c
+                        .eol
+                        .as_ref()
+                        .and_then(|e| e.eol_date.map(|d| d.to_string())),
+                    eol_product: c.eol.as_ref().map(|e| e.product.clone()),
+                }
+            })
+            .collect();
+
+        let mut vulnerabilities: Vec<FlatVulnerabilityView> = Vec::new();
+        for comp in sbom.components.values() {
+            let kind = classify_dependency(&comp.canonical_id, primary_id, &direct_ids);
+            for v in &comp.vulnerabilities {
+                vulnerabilities.push(FlatVulnerabilityView::from_pair(comp, v, kind));
+            }
+        }
+
         let report = JsonViewReport {
             metadata: JsonViewMetadata {
                 tool: ToolInfo {
@@ -196,29 +236,8 @@ impl ReportGenerator for JsonReporter {
                 vulnerability_counts: sbom.vulnerability_counts(),
             },
             compliance,
-            components: sbom
-                .components
-                .values()
-                .map(|c| ComponentView {
-                    name: c.name.clone(),
-                    version: c.version.clone(),
-                    ecosystem: c.ecosystem.as_ref().map(std::string::ToString::to_string),
-                    licenses: c
-                        .licenses
-                        .declared
-                        .iter()
-                        .map(|l| l.expression.clone())
-                        .collect(),
-                    supplier: c.supplier.as_ref().map(|s| s.name.clone()),
-                    vulnerabilities: c.vulnerabilities.len(),
-                    eol_status: c.eol.as_ref().map(|e| e.status.label().to_string()),
-                    eol_date: c
-                        .eol
-                        .as_ref()
-                        .and_then(|e| e.eol_date.map(|d| d.to_string())),
-                    eol_product: c.eol.as_ref().map(|e| e.product.clone()),
-                })
-                .collect(),
+            components,
+            vulnerabilities,
         };
 
         let json = if self.pretty {
@@ -463,6 +482,10 @@ struct JsonViewReport {
     summary: ViewSummary,
     compliance: CraComplianceDetail,
     components: Vec<ComponentView>,
+    /// Flattened list of every vulnerability across all components,
+    /// annotated with the package it affects and whether that package is
+    /// a direct or transitive dependency of the primary component.
+    vulnerabilities: Vec<FlatVulnerabilityView>,
 }
 
 #[derive(Serialize)]
@@ -487,11 +510,165 @@ struct ComponentView {
     ecosystem: Option<String>,
     licenses: Vec<String>,
     supplier: Option<String>,
-    vulnerabilities: usize,
+    /// "primary", "direct", or "transitive" relative to the SBOM's primary component.
+    dependency_kind: DependencyKind,
+    /// Number of vulnerabilities affecting this component.
+    vulnerability_count: usize,
+    /// Structured vulnerability details (empty when none).
+    vulnerabilities: Vec<VulnerabilityView>,
     #[serde(skip_serializing_if = "Option::is_none")]
     eol_status: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     eol_date: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     eol_product: Option<String>,
+}
+
+#[derive(Serialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+enum DependencyKind {
+    Primary,
+    Direct,
+    Transitive,
+}
+
+fn classify_dependency(
+    id: &crate::model::CanonicalId,
+    primary: Option<&crate::model::CanonicalId>,
+    direct: &std::collections::HashSet<crate::model::CanonicalId>,
+) -> DependencyKind {
+    if primary == Some(id) {
+        DependencyKind::Primary
+    } else if direct.contains(id) {
+        DependencyKind::Direct
+    } else {
+        DependencyKind::Transitive
+    }
+}
+
+/// Per-component vulnerability detail (used both in `components[].vulnerabilities`
+/// and as the body of `vulnerabilities[]` at the top level of the view report).
+#[derive(Serialize, Clone)]
+struct VulnerabilityView {
+    /// Vulnerability identifier (CVE, GHSA, OSV, etc.).
+    id: String,
+    /// Source database (NVD, OSV, GHSA, ...).
+    source: String,
+    /// Severity label ("Critical", "High", ...) when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    severity: Option<String>,
+    /// Highest CVSS base score across attached CVSS records.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cvss_score: Option<f32>,
+    /// CVSS vector string of the highest-scoring record, if any.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cvss_vector: Option<String>,
+    /// First non-empty fixed version reported across the vulnerability's
+    /// remediation records, when available.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fixed_version: Option<String>,
+    /// CWE identifiers.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    cwes: Vec<String>,
+    /// `true` when listed in CISA's Known Exploited Vulnerabilities catalog.
+    kev: bool,
+    /// KEV catalog metadata (due date, ransomware flag, ...).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kev_info: Option<KevInfoView>,
+    /// VEX status when an applicable VEX statement is attached.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    vex_status: Option<String>,
+    /// Short description, when supplied by the source.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    /// Publication date (RFC 3339), when supplied.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    published: Option<String>,
+    /// Last-modified date (RFC 3339), when supplied.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    modified: Option<String>,
+}
+
+#[derive(Serialize, Clone)]
+struct KevInfoView {
+    date_added: String,
+    due_date: String,
+    known_ransomware_use: bool,
+}
+
+impl From<&VulnerabilityRef> for VulnerabilityView {
+    fn from(v: &VulnerabilityRef) -> Self {
+        let (cvss_score, cvss_vector) = v
+            .cvss
+            .iter()
+            .max_by(|a, b| {
+                a.base_score
+                    .partial_cmp(&b.base_score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map_or((None, None), |c| (Some(c.base_score), c.vector.clone()));
+
+        Self {
+            id: v.id.clone(),
+            source: v.source.to_string(),
+            severity: v.severity.as_ref().map(ToString::to_string),
+            cvss_score,
+            cvss_vector,
+            fixed_version: v
+                .remediation
+                .as_ref()
+                .and_then(|r| r.fixed_version.clone()),
+            cwes: v.cwes.clone(),
+            kev: v.is_kev,
+            kev_info: v.kev_info.as_ref().map(|k| KevInfoView {
+                date_added: rfc3339(k.date_added),
+                due_date: rfc3339(k.due_date),
+                known_ransomware_use: k.known_ransomware_use,
+            }),
+            vex_status: v.vex_status.as_ref().map(|s| format!("{s:?}")),
+            description: v.description.clone(),
+            published: v.published.map(rfc3339),
+            modified: v.modified.map(rfc3339),
+        }
+    }
+}
+
+fn rfc3339(dt: DateTime<Utc>) -> String {
+    dt.to_rfc3339()
+}
+
+/// Top-level flattened vulnerability entry: a `VulnerabilityView` joined with
+/// the affected package, so consumers can iterate vulnerabilities without
+/// walking the components array.
+#[derive(Serialize)]
+struct FlatVulnerabilityView {
+    /// Vulnerability details.
+    #[serde(flatten)]
+    vuln: VulnerabilityView,
+    /// Affected package name.
+    package: String,
+    /// Affected package version, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    package_version: Option<String>,
+    /// Ecosystem of the affected package, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ecosystem: Option<String>,
+    /// Direct/transitive classification of the affected package.
+    dependency_kind: DependencyKind,
+    /// Convenience boolean — `true` when `dependency_kind` is `direct` or `primary`.
+    is_direct: bool,
+}
+
+impl FlatVulnerabilityView {
+    fn from_pair(comp: &Component, v: &VulnerabilityRef, kind: DependencyKind) -> Self {
+        let is_direct = matches!(kind, DependencyKind::Direct | DependencyKind::Primary);
+        Self {
+            vuln: VulnerabilityView::from(v),
+            package: comp.name.clone(),
+            package_version: comp.version.clone(),
+            ecosystem: comp.ecosystem.as_ref().map(ToString::to_string),
+            dependency_kind: kind,
+            is_direct,
+        }
+    }
 }

--- a/src/reports/json.rs
+++ b/src/reports/json.rs
@@ -193,7 +193,11 @@ impl ReportGenerator for JsonReporter {
                     supplier: c.supplier.as_ref().map(|s| s.name.clone()),
                     dependency_kind: kind,
                     vulnerability_count: c.vulnerabilities.len(),
-                    vulnerabilities: c.vulnerabilities.iter().map(VulnerabilityView::from).collect(),
+                    vulnerabilities: c
+                        .vulnerabilities
+                        .iter()
+                        .map(VulnerabilityView::from)
+                        .collect(),
                     eol_status: c.eol.as_ref().map(|e| e.status.label().to_string()),
                     eol_date: c
                         .eol
@@ -614,10 +618,7 @@ impl From<&VulnerabilityRef> for VulnerabilityView {
             severity: v.severity.as_ref().map(ToString::to_string),
             cvss_score,
             cvss_vector,
-            fixed_version: v
-                .remediation
-                .as_ref()
-                .and_then(|r| r.fixed_version.clone()),
+            fixed_version: v.remediation.as_ref().and_then(|r| r.fixed_version.clone()),
             cwes: v.cwes.clone(),
             kev: v.is_kev,
             kev_info: v.kev_info.as_ref().map(|k| KevInfoView {

--- a/tests/json_view_vulnerabilities_tests.rs
+++ b/tests/json_view_vulnerabilities_tests.rs
@@ -1,0 +1,180 @@
+//! Tests for the JSON `view` reporter's structured vulnerability output
+//! and direct/transitive dependency classification (issue #178).
+
+use chrono::{TimeZone, Utc};
+use sbom_tools::model::{
+    CompletenessDeclaration, Component, Creator, CreatorType, DependencyEdge, DependencyType,
+    DocumentMetadata, KevInfo, NormalizedSbom, Remediation, RemediationType, SbomFormat, Severity,
+    VulnerabilityRef, VulnerabilitySource,
+};
+use sbom_tools::reports::{JsonReporter, ReportConfig, ReportGenerator};
+
+fn base_document_metadata() -> DocumentMetadata {
+    DocumentMetadata {
+        format: SbomFormat::CycloneDx,
+        format_version: "1.6".to_string(),
+        spec_version: "1.6".to_string(),
+        serial_number: Some("urn:uuid:00000000-0000-0000-0000-000000000000".to_string()),
+        created: Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap(),
+        creators: vec![Creator {
+            creator_type: CreatorType::Organization,
+            name: "Acme Corp".to_string(),
+            email: None,
+        }],
+        name: Some("Acme Product".to_string()),
+        security_contact: None,
+        vulnerability_disclosure_url: None,
+        support_end_date: None,
+        lifecycle_phase: None,
+        completeness_declaration: CompletenessDeclaration::Unknown,
+        signature: None,
+        distribution_classification: None,
+        citations_count: 0,
+    }
+}
+
+fn vulnerable_component(name: &str, version: &str, vuln_id: &str) -> Component {
+    let mut comp = Component::new(name.to_string(), format!("{name}-ref"))
+        .with_version(version.to_string());
+
+    let mut v = VulnerabilityRef::new(vuln_id.to_string(), VulnerabilitySource::Osv);
+    v.severity = Some(Severity::High);
+    v.cwes = vec!["CWE-79".to_string()];
+    v.is_kev = true;
+    v.kev_info = Some(KevInfo::new(
+        Utc.with_ymd_and_hms(2025, 1, 1, 0, 0, 0).unwrap(),
+        Utc.with_ymd_and_hms(2025, 2, 1, 0, 0, 0).unwrap(),
+        "Apply vendor patch".to_string(),
+    ));
+    v.remediation = Some(Remediation {
+        remediation_type: RemediationType::Upgrade,
+        description: Some("Upgrade to fixed release".to_string()),
+        fixed_version: Some("2.0.0".to_string()),
+    });
+    v.description = Some("XSS in template renderer".to_string());
+
+    comp.vulnerabilities.push(v);
+    comp
+}
+
+#[test]
+fn json_view_emits_structured_vulnerability_details() {
+    let mut sbom = NormalizedSbom::new(base_document_metadata());
+    sbom.add_component(vulnerable_component("acme-web", "1.0.0", "CVE-2025-0001"));
+
+    let json = JsonReporter::new()
+        .generate_view_report(&sbom, &ReportConfig::default())
+        .expect("view report");
+    let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+
+    let comp = value["components"]
+        .as_array()
+        .and_then(|arr| arr.first())
+        .expect("at least one component");
+    assert_eq!(comp["vulnerability_count"], 1);
+
+    let vuln = comp["vulnerabilities"]
+        .as_array()
+        .and_then(|arr| arr.first())
+        .expect("vuln entry on component");
+    assert_eq!(vuln["id"], "CVE-2025-0001");
+    assert_eq!(vuln["source"], "OSV");
+    assert_eq!(vuln["severity"], "High");
+    assert_eq!(vuln["fixed_version"], "2.0.0");
+    assert_eq!(vuln["kev"], true);
+    assert_eq!(vuln["cwes"][0], "CWE-79");
+    assert!(vuln["kev_info"]["due_date"].is_string());
+    assert_eq!(vuln["description"], "XSS in template renderer");
+
+    let flat = value["vulnerabilities"]
+        .as_array()
+        .expect("top-level vulnerabilities array");
+    assert_eq!(flat.len(), 1);
+    assert_eq!(flat[0]["id"], "CVE-2025-0001");
+    assert_eq!(flat[0]["package"], "acme-web");
+    assert_eq!(flat[0]["package_version"], "1.0.0");
+}
+
+#[test]
+fn json_view_classifies_direct_vs_transitive() {
+    let mut sbom = NormalizedSbom::new(base_document_metadata());
+
+    let root = Component::new("root".to_string(), "root-ref".to_string());
+    let direct = vulnerable_component("direct-dep", "1.0.0", "CVE-2025-DIRECT");
+    let transitive = vulnerable_component("trans-dep", "0.9.0", "CVE-2025-TRANS");
+
+    let root_id = root.canonical_id.clone();
+    let direct_id = direct.canonical_id.clone();
+    let trans_id = transitive.canonical_id.clone();
+
+    sbom.add_component(root);
+    sbom.add_component(direct);
+    sbom.add_component(transitive);
+    sbom.set_primary_component(root_id.clone());
+
+    sbom.add_edge(DependencyEdge::new(
+        root_id,
+        direct_id.clone(),
+        DependencyType::DependsOn,
+    ));
+    sbom.add_edge(DependencyEdge::new(
+        direct_id,
+        trans_id,
+        DependencyType::DependsOn,
+    ));
+
+    let json = JsonReporter::new()
+        .generate_view_report(&sbom, &ReportConfig::default())
+        .expect("view report");
+    let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+
+    let kinds: std::collections::HashMap<String, String> = value["components"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|c| {
+            (
+                c["name"].as_str().unwrap().to_string(),
+                c["dependency_kind"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect();
+
+    assert_eq!(kinds.get("root").map(String::as_str), Some("primary"));
+    assert_eq!(kinds.get("direct-dep").map(String::as_str), Some("direct"));
+    assert_eq!(
+        kinds.get("trans-dep").map(String::as_str),
+        Some("transitive")
+    );
+
+    let flat = value["vulnerabilities"].as_array().unwrap();
+    let direct_vuln = flat
+        .iter()
+        .find(|v| v["id"] == "CVE-2025-DIRECT")
+        .expect("direct vuln present");
+    assert_eq!(direct_vuln["dependency_kind"], "direct");
+    assert_eq!(direct_vuln["is_direct"], true);
+
+    let trans_vuln = flat
+        .iter()
+        .find(|v| v["id"] == "CVE-2025-TRANS")
+        .expect("transitive vuln present");
+    assert_eq!(trans_vuln["dependency_kind"], "transitive");
+    assert_eq!(trans_vuln["is_direct"], false);
+}
+
+#[test]
+fn json_view_empty_vulnerabilities_when_none() {
+    let mut sbom = NormalizedSbom::new(base_document_metadata());
+    sbom.add_component(Component::new("clean".to_string(), "clean-ref".to_string()));
+
+    let json = JsonReporter::new()
+        .generate_view_report(&sbom, &ReportConfig::default())
+        .expect("view report");
+    let value: serde_json::Value = serde_json::from_str(&json).expect("valid JSON");
+
+    let comp = &value["components"][0];
+    assert_eq!(comp["vulnerability_count"], 0);
+    assert_eq!(comp["vulnerabilities"].as_array().unwrap().len(), 0);
+    assert_eq!(value["vulnerabilities"].as_array().unwrap().len(), 0);
+}

--- a/tests/json_view_vulnerabilities_tests.rs
+++ b/tests/json_view_vulnerabilities_tests.rs
@@ -34,8 +34,8 @@ fn base_document_metadata() -> DocumentMetadata {
 }
 
 fn vulnerable_component(name: &str, version: &str, vuln_id: &str) -> Component {
-    let mut comp = Component::new(name.to_string(), format!("{name}-ref"))
-        .with_version(version.to_string());
+    let mut comp =
+        Component::new(name.to_string(), format!("{name}-ref")).with_version(version.to_string());
 
     let mut v = VulnerabilityRef::new(vuln_id.to_string(), VulnerabilitySource::Osv);
     v.severity = Some(Severity::High);


### PR DESCRIPTION
## Summary
- `view -o json` now emits the full vulnerability details (id, source, severity, CVSS, `fixed_version`, CWEs, KEV info, VEX status, description, dates) per component instead of just a count, fixing #178.
- Adds a top-level `vulnerabilities[]` array flattened across all components for easy consumption.
- Each component (and each flattened vulnerability) is tagged with `dependency_kind` — `primary`, `direct`, or `transitive` — so consumers can distinguish vulnerabilities in direct vs transitive dependencies. The flattened entries also expose a convenience `is_direct` boolean.

## JSON shape (excerpt)

```jsonc
{
  "components": [{
    "name": "acme-web",
    "version": "1.0.0",
    "dependency_kind": "direct",
    "vulnerability_count": 1,
    "vulnerabilities": [{
      "id": "CVE-2025-0001",
      "source": "OSV",
      "severity": "High",
      "fixed_version": "2.0.0",
      "kev": true,
      "kev_info": { "due_date": "...", "known_ransomware_use": false },
      "cwes": ["CWE-79"]
    }]
  }],
  "vulnerabilities": [{
    "id": "CVE-2025-0001",
    "package": "acme-web",
    "package_version": "1.0.0",
    "dependency_kind": "direct",
    "is_direct": true
  }]
}
```

Direct/transitive classification reuses the existing `NormalizedSbom::direct_dependency_ids()` helper (already used for CRA prEN 40000-1-3 enforcement), so no new graph traversal logic is introduced.

Closes #178.

## Test plan
- [x] `cargo test --features enrichment --test json_view_vulnerabilities_tests` (3 new tests: structured vuln details, direct/transitive classification, empty case)
- [x] `cargo test --features enrichment --test cra_readiness_tests` (no regression in existing view-report tests)
- [x] `cargo test --features enrichment` (full suite passes)
- [x] `cargo build --features enrichment` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)