### PR TITLE
Fix semantic similarity percentage overflow

### DIFF
--- a/src/diff/engine.rs
+++ b/src/diff/engine.rs
@@ -134,7 +134,7 @@ impl DiffEngine {
 
         // Quick check: if content hashes match, SBOMs are identical
         if old.content_hash == new.content_hash && old.content_hash != 0 {
-            result.semantic_score = 100.0;
+            result.semantic_score = PERCENT_MAX;
             return Ok(result);
         }
 
@@ -425,6 +425,25 @@ impl DiffEngine {
         self.normalize_semantic_score(raw_cost, result, old_sbom, new_sbom)
     }
 
+    /// Normalize `raw_cost` to a 0–100 similarity percentage against an
+    /// SBOM-derived upper-bound budget.
+    ///
+    /// For each cost axis we compute the worst-case contribution given the
+    /// inputs (e.g. every component on both sides being added or removed) and
+    /// sum them to form `total_budget`. The score is then
+    /// `PERCENT_MAX * (1 - raw_cost / total_budget)`, clamped to `[0, PERCENT_MAX]`
+    /// to defend against future cost-model changes where the bound might no
+    /// longer dominate. When both SBOMs are empty the budget collapses to ~0
+    /// and the function returns `PERCENT_MAX` (an empty diff is fully similar).
+    ///
+    /// Note: `modification_budget` uses the actual `modified.len()` rather
+    /// than `min(old, new)`. The actual count is still a valid upper bound on
+    /// `raw_modification_cost` (each modification contributes at most
+    /// `max(version_major, license_changed)`), and using it keeps the per-axis
+    /// scoring sensitive to the modifications that actually occurred.
+    /// `vulnerability_resolved` is intentionally excluded from the budget: it
+    /// is a reward (negative cost in `CostModel`), so it can only reduce
+    /// `raw_cost`, never push it above the bound.
     fn normalize_semantic_score(
         &self,
         raw_cost: f64,
@@ -458,12 +477,16 @@ impl DiffEngine {
             component_budget + dependency_budget + vulnerability_budget + modification_budget;
 
         if total_budget <= f64::EPSILON {
-            return 100.0;
+            return PERCENT_MAX;
         }
 
-        (100.0 * (1.0 - (raw_cost / total_budget))).clamp(0.0, 100.0)
+        (PERCENT_MAX * (1.0 - (raw_cost / total_budget))).clamp(0.0, PERCENT_MAX)
     }
 }
+
+/// Upper bound of the 0–100 similarity percentage emitted by
+/// [`DiffEngine::normalize_semantic_score`].
+const PERCENT_MAX: f64 = 100.0;
 
 impl Default for DiffEngine {
     fn default() -> Self {

--- a/src/diff/engine.rs
+++ b/src/diff/engine.rs
@@ -399,8 +399,7 @@ impl DiffEngine {
         }
 
         // Always recompute summary and semantic score since they depend on all sections
-        result.semantic_score =
-            self.compute_semantic_score(&result, &old_filtered, &new_filtered);
+        result.semantic_score = self.compute_semantic_score(&result, &old_filtered, &new_filtered);
         result.calculate_summary();
         Ok(result)
     }
@@ -434,9 +433,17 @@ impl DiffEngine {
         new_sbom: &NormalizedSbom,
     ) -> f64 {
         let component_budget = (old_sbom.component_count() + new_sbom.component_count()) as f64
-            * f64::from(self.cost_model.component_added.max(self.cost_model.component_removed));
+            * f64::from(
+                self.cost_model
+                    .component_added
+                    .max(self.cost_model.component_removed),
+            );
         let dependency_budget = (old_sbom.edges.len() + new_sbom.edges.len()) as f64
-            * f64::from(self.cost_model.dependency_added.max(self.cost_model.dependency_removed));
+            * f64::from(
+                self.cost_model
+                    .dependency_added
+                    .max(self.cost_model.dependency_removed),
+            );
         let vulnerability_budget = (old_sbom.vulnerability_counts().total()
             + new_sbom.vulnerability_counts().total()) as f64
             * f64::from(self.cost_model.vulnerability_introduced);
@@ -447,10 +454,8 @@ impl DiffEngine {
                     .max(self.cost_model.license_changed),
             );
 
-        let total_budget = component_budget
-            + dependency_budget
-            + vulnerability_budget
-            + modification_budget;
+        let total_budget =
+            component_budget + dependency_budget + vulnerability_budget + modification_budget;
 
         if total_budget <= f64::EPSILON {
             return 100.0;

--- a/src/diff/engine.rs
+++ b/src/diff/engine.rs
@@ -134,6 +134,7 @@ impl DiffEngine {
 
         // Quick check: if content hashes match, SBOMs are identical
         if old.content_hash == new.content_hash && old.content_hash != 0 {
+            result.semantic_score = 100.0;
             return Ok(result);
         }
 
@@ -220,7 +221,7 @@ impl DiffEngine {
         }
 
         // Calculate semantic score
-        result.semantic_score = self.compute_semantic_score(&result);
+        result.semantic_score = self.compute_semantic_score(&result, old, new);
 
         result.calculate_summary();
         Ok(result)
@@ -398,14 +399,20 @@ impl DiffEngine {
         }
 
         // Always recompute summary and semantic score since they depend on all sections
-        result.semantic_score = self.compute_semantic_score(&result);
+        result.semantic_score =
+            self.compute_semantic_score(&result, &old_filtered, &new_filtered);
         result.calculate_summary();
         Ok(result)
     }
 
     /// Compute the semantic score from a `DiffResult`.
-    fn compute_semantic_score(&self, result: &DiffResult) -> f64 {
-        self.cost_model.calculate_semantic_score(
+    fn compute_semantic_score(
+        &self,
+        result: &DiffResult,
+        old_sbom: &NormalizedSbom,
+        new_sbom: &NormalizedSbom,
+    ) -> f64 {
+        let raw_cost = self.cost_model.calculate_semantic_score(
             result.components.added.len(),
             result.components.removed.len(),
             result.components.modified.len(),
@@ -414,7 +421,42 @@ impl DiffEngine {
             result.vulnerabilities.resolved.len(),
             result.dependencies.added.len(),
             result.dependencies.removed.len(),
-        )
+        );
+
+        self.normalize_semantic_score(raw_cost, result, old_sbom, new_sbom)
+    }
+
+    fn normalize_semantic_score(
+        &self,
+        raw_cost: f64,
+        result: &DiffResult,
+        old_sbom: &NormalizedSbom,
+        new_sbom: &NormalizedSbom,
+    ) -> f64 {
+        let component_budget = (old_sbom.component_count() + new_sbom.component_count()) as f64
+            * f64::from(self.cost_model.component_added.max(self.cost_model.component_removed));
+        let dependency_budget = (old_sbom.edges.len() + new_sbom.edges.len()) as f64
+            * f64::from(self.cost_model.dependency_added.max(self.cost_model.dependency_removed));
+        let vulnerability_budget = (old_sbom.vulnerability_counts().total()
+            + new_sbom.vulnerability_counts().total()) as f64
+            * f64::from(self.cost_model.vulnerability_introduced);
+        let modification_budget = result.components.modified.len() as f64
+            * f64::from(
+                self.cost_model
+                    .version_major
+                    .max(self.cost_model.license_changed),
+            );
+
+        let total_budget = component_budget
+            + dependency_budget
+            + vulnerability_budget
+            + modification_budget;
+
+        if total_budget <= f64::EPSILON {
+            return 100.0;
+        }
+
+        (100.0 * (1.0 - (raw_cost / total_budget))).clamp(0.0, 100.0)
     }
 }
 

--- a/tests/pipeline_tests.rs
+++ b/tests/pipeline_tests.rs
@@ -227,7 +227,9 @@ mod diff_stage {
             new.add_component(updated);
         }
 
-        let result = DiffEngine::new().diff(&old, &new).expect("diff should succeed");
+        let result = DiffEngine::new()
+            .diff(&old, &new)
+            .expect("diff should succeed");
 
         assert!(
             (0.0..=100.0).contains(&result.semantic_score),
@@ -254,8 +256,12 @@ mod diff_stage {
             new.add_component(updated);
         }
 
-        let forward = DiffEngine::new().diff(&old, &new).expect("forward diff should succeed");
-        let reverse = DiffEngine::new().diff(&new, &old).expect("reverse diff should succeed");
+        let forward = DiffEngine::new()
+            .diff(&old, &new)
+            .expect("forward diff should succeed");
+        let reverse = DiffEngine::new()
+            .diff(&new, &old)
+            .expect("reverse diff should succeed");
 
         for (label, score) in [
             ("forward", forward.semantic_score),

--- a/tests/pipeline_tests.rs
+++ b/tests/pipeline_tests.rs
@@ -120,6 +120,8 @@ mod parse_stage {
 
 mod diff_stage {
     use super::*;
+    use sbom_tools::diff::DiffEngine;
+    use sbom_tools::model::{Component, DocumentMetadata, NormalizedSbom};
 
     fn demo_diff_config(old: &str, new: &str) -> sbom_tools::DiffConfig {
         DiffConfigBuilder::new()
@@ -128,6 +130,21 @@ mod diff_stage {
             .output_format(ReportFormat::Json)
             .build()
             .expect("valid config")
+    }
+
+    fn synthetic_sbom(range: std::ops::Range<usize>, version: &str) -> NormalizedSbom {
+        let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
+
+        for index in range {
+            let component = Component::new(
+                format!("component-{index}"),
+                format!("component-{index}-ref"),
+            )
+            .with_version(version.to_string());
+            sbom.add_component(component);
+        }
+
+        sbom
     }
 
     #[test]
@@ -168,6 +185,10 @@ mod diff_stage {
             result.summary.total_changes, 0,
             "Identical SBOMs should have no changes"
         );
+        assert_eq!(
+            result.semantic_score, 100.0,
+            "Identical SBOMs should report full similarity"
+        );
     }
 
     #[test]
@@ -189,6 +210,70 @@ mod diff_stage {
         assert!(
             result.semantic_score > 0.0,
             "Cross-format diff should find some similarity"
+        );
+    }
+
+    #[test]
+    fn compute_diff_large_change_set_stays_within_similarity_bounds() {
+        let old = synthetic_sbom(0..138, "1.0.0");
+        let mut new = synthetic_sbom(26..138, "1.0.0");
+
+        for index in 26..60 {
+            let updated = Component::new(
+                format!("component-{index}"),
+                format!("component-{index}-ref"),
+            )
+            .with_version("2.0.0".to_string());
+            new.add_component(updated);
+        }
+
+        let result = DiffEngine::new().diff(&old, &new).expect("diff should succeed");
+
+        assert!(
+            (0.0..=100.0).contains(&result.semantic_score),
+            "similarity should stay within 0..=100, got {}",
+            result.semantic_score
+        );
+        assert!(
+            result.semantic_score < 100.0,
+            "large change sets should not report perfect similarity"
+        );
+    }
+
+    #[test]
+    fn compute_diff_similarity_is_bounded_in_both_directions() {
+        let old = synthetic_sbom(0..138, "1.0.0");
+        let mut new = synthetic_sbom(26..138, "1.0.0");
+
+        for index in 26..60 {
+            let updated = Component::new(
+                format!("component-{index}"),
+                format!("component-{index}-ref"),
+            )
+            .with_version("2.0.0".to_string());
+            new.add_component(updated);
+        }
+
+        let forward = DiffEngine::new().diff(&old, &new).expect("forward diff should succeed");
+        let reverse = DiffEngine::new().diff(&new, &old).expect("reverse diff should succeed");
+
+        for (label, score) in [
+            ("forward", forward.semantic_score),
+            ("reverse", reverse.semantic_score),
+        ] {
+            assert!(
+                (0.0..=100.0).contains(&score),
+                "{label} similarity should stay within 0..=100, got {score}"
+            );
+            assert!(
+                score < 100.0,
+                "{label} large change set should not report perfect similarity"
+            );
+        }
+
+        assert!(
+            (forward.semantic_score - reverse.semantic_score).abs() < f64::EPSILON,
+            "similarity should be direction-independent for symmetric change costs"
         );
     }
 

--- a/tests/pipeline_tests.rs
+++ b/tests/pipeline_tests.rs
@@ -277,9 +277,15 @@ mod diff_stage {
             );
         }
 
+        // Tolerance is loose enough to survive future reorderings of the
+        // floating-point ops in `normalize_semantic_score` but tight enough
+        // that any genuine direction-dependent skew gets caught.
         assert!(
-            (forward.semantic_score - reverse.semantic_score).abs() < f64::EPSILON,
-            "similarity should be direction-independent for symmetric change costs"
+            (forward.semantic_score - reverse.semantic_score).abs() < 1e-9,
+            "similarity should be direction-independent for symmetric change costs: \
+             forward={forward_score}, reverse={reverse_score}",
+            forward_score = forward.semantic_score,
+            reverse_score = reverse.semantic_score,
         );
     }
 


### PR DESCRIPTION
## Summary
- normalize semantic diff output to a bounded 0-100 similarity percentage
- set identical-content fast paths to 100%% similarity
- add bidirectional regression coverage so forward and reverse comparisons stay bounded and stable

## Testing
- cargo test --locked compute_diff_identical_sboms --test pipeline_tests
- cargo test --locked compute_diff_cross_format --test pipeline_tests
- cargo test --locked compute_diff_large_change_set_stays_within_similarity_bounds --test pipeline_tests
- cargo test --locked compute_diff_similarity_is_bounded_in_both_directions --test pipeline_tests

Closes #180
