### PR TITLE
Compact CRA detail in diff reports

### DIFF
--- a/src/reports/html.rs
+++ b/src/reports/html.rs
@@ -677,17 +677,16 @@ fn write_compact_diff_violation_summary_html(
         return Ok(());
     }
 
-    let aggregated = aggregate_violations_html(&result.violations);
+    let group_count = count_violation_groups_html(&result.violations);
     writeln!(html, "    <h3>Violation Summary (New SBOM)</h3>")?;
     writeln!(
         html,
-        "    <p>{} total findings across {} distinct requirement groups.</p>",
+        "    <p>{} total findings across {group_count} distinct requirement groups.</p>",
         result.violations.len(),
-        aggregated.len()
     )?;
     writeln!(
         html,
-        "    <p><em>Use sbom-tools view or JSON/SARIF output for full CRA violation detail.</em></p>"
+        "    <p><em>Re-run with <code>sbom-tools diff ... -o json</code> or <code>-o sarif</code> for the full CRA violation detail.</em></p>"
     )?;
 
     Ok(())
@@ -855,6 +854,22 @@ fn channel_status_html(result: &ComplianceResult, needle: &str) -> ChannelStatus
             ViolationSeverity::Info => ChannelStatusHtml::MissingPreDeadline,
         },
     }
+}
+
+/// Count distinct `(severity, category, requirement)` violation groups without
+/// allocating the full aggregated representation.
+fn count_violation_groups_html(violations: &[crate::quality::Violation]) -> usize {
+    use std::collections::HashSet;
+    let mut groups: HashSet<(u8, &str, &str)> = HashSet::new();
+    for v in violations {
+        let sev_ord = match v.severity {
+            ViolationSeverity::Error => 0,
+            ViolationSeverity::Warning => 1,
+            ViolationSeverity::Info => 2,
+        };
+        groups.insert((sev_ord, v.category.name(), v.requirement.as_str()));
+    }
+    groups.len()
 }
 
 /// Aggregate violations by (severity, category, requirement) to reduce noise.

--- a/src/reports/html.rs
+++ b/src/reports/html.rs
@@ -660,16 +660,37 @@ fn write_cra_compliance_diff_html(
     write_conformity_assessment_html(html, new)?;
     write_reporting_channels_html(html, new)?;
 
-    if !new.violations.is_empty() {
-        writeln!(html, "    <h3>Violations (New SBOM)</h3>")?;
-        write_violation_table_html(html, &new.violations)?;
-    }
+    write_compact_diff_violation_summary_html(html, new)?;
 
     writeln!(html, "</div>")?;
     writeln!(
         html,
         "<a href=\"#top\" class=\"back-to-top\">Back to top</a>"
     )
+}
+
+fn write_compact_diff_violation_summary_html(
+    html: &mut String,
+    result: &ComplianceResult,
+) -> std::fmt::Result {
+    if result.violations.is_empty() {
+        return Ok(());
+    }
+
+    let aggregated = aggregate_violations_html(&result.violations);
+    writeln!(html, "    <h3>Violation Summary (New SBOM)</h3>")?;
+    writeln!(
+        html,
+        "    <p>{} total findings across {} distinct requirement groups.</p>",
+        result.violations.len(),
+        aggregated.len()
+    )?;
+    writeln!(
+        html,
+        "    <p><em>Use sbom-tools view or JSON/SARIF output for full CRA violation detail.</em></p>"
+    )?;
+
+    Ok(())
 }
 
 /// Write a CRA compliance section for view reports.

--- a/src/reports/markdown.rs
+++ b/src/reports/markdown.rs
@@ -812,11 +812,31 @@ fn write_cra_compliance_diff(
     // Reporting channels (CRA Art. 14) — derived from new SBOM violations
     write_reporting_channels_md(md, new)?;
 
-    // Show new SBOM violations if any
-    if !new.violations.is_empty() {
-        writeln!(md, "### Violations (New SBOM)\n")?;
-        write_violation_table(md, &new.violations)?;
+    write_compact_diff_violation_summary(md, new)?;
+
+    Ok(())
+}
+
+fn write_compact_diff_violation_summary(
+    md: &mut String,
+    result: &ComplianceResult,
+) -> std::fmt::Result {
+    if result.violations.is_empty() {
+        return Ok(());
     }
+
+    let aggregated = aggregate_violations(&result.violations);
+    writeln!(md, "### Violation Summary (New SBOM)\n")?;
+    writeln!(
+        md,
+        "- {} total findings across {} distinct requirement groups.",
+        result.violations.len(),
+        aggregated.len()
+    )?;
+    writeln!(
+        md,
+        "- Use `sbom-tools view ... -o markdown|html` or JSON/SARIF output for full CRA violation detail.\n"
+    )?;
 
     Ok(())
 }

--- a/src/reports/markdown.rs
+++ b/src/reports/markdown.rs
@@ -825,17 +825,16 @@ fn write_compact_diff_violation_summary(
         return Ok(());
     }
 
-    let aggregated = aggregate_violations(&result.violations);
+    let group_count = count_violation_groups(&result.violations);
     writeln!(md, "### Violation Summary (New SBOM)\n")?;
     writeln!(
         md,
-        "- {} total findings across {} distinct requirement groups.",
+        "- {} total findings across {group_count} distinct requirement groups.",
         result.violations.len(),
-        aggregated.len()
     )?;
     writeln!(
         md,
-        "- Use `sbom-tools view ... -o markdown|html` or JSON/SARIF output for full CRA violation detail.\n"
+        "- Re-run with `sbom-tools diff ... -o json` or `-o sarif` for the full CRA violation detail.\n"
     )?;
 
     Ok(())
@@ -973,6 +972,22 @@ impl ChannelStatus {
             Self::MissingPostDeadline => "Missing",
         }
     }
+}
+
+/// Count distinct `(severity, category, requirement)` violation groups without
+/// allocating the full aggregated representation.
+fn count_violation_groups(violations: &[crate::quality::Violation]) -> usize {
+    use std::collections::HashSet;
+    let mut groups: HashSet<(u8, &str, &str)> = HashSet::new();
+    for v in violations {
+        let sev_ord = match v.severity {
+            ViolationSeverity::Error => 0,
+            ViolationSeverity::Warning => 1,
+            ViolationSeverity::Info => 2,
+        };
+        groups.insert((sev_ord, v.category.name(), v.requirement.as_str()));
+    }
+    groups.len()
 }
 
 /// Aggregate violations by (severity, category, requirement) to reduce noise.

--- a/tests/cra_readiness_tests.rs
+++ b/tests/cra_readiness_tests.rs
@@ -11,7 +11,9 @@ use sbom_tools::parsers::parse_sbom_str;
 use sbom_tools::quality::{
     ComplianceChecker, ComplianceLevel, ViolationCategory, ViolationSeverity,
 };
-use sbom_tools::reports::{JsonReporter, ReportConfig, ReportGenerator, SarifReporter};
+use sbom_tools::reports::{
+    HtmlReporter, JsonReporter, MarkdownReporter, ReportConfig, ReportGenerator, SarifReporter,
+};
 
 fn base_document_metadata() -> DocumentMetadata {
     DocumentMetadata {
@@ -255,4 +257,83 @@ fn diff_reports_include_cra_compliance() {
             .map(|s| s.starts_with("SBOM-CRA-"))
             .unwrap_or(false)
     }));
+}
+
+#[test]
+fn diff_markdown_and_html_reports_compact_cra_details() {
+    let old_doc = base_document_metadata();
+    let new_doc = base_document_metadata();
+
+    let mut old_sbom = NormalizedSbom::new(old_doc);
+    old_sbom.add_component(cra_ready_component("lib-old"));
+    old_sbom.calculate_content_hash();
+
+    let mut new_sbom = NormalizedSbom::new(new_doc);
+    for index in 0..40 {
+        let comp = Component::new(format!("lib-{index}"), format!("lib-{index}-ref"));
+        new_sbom.add_component(comp);
+    }
+    new_sbom.calculate_content_hash();
+
+    let diff = DiffEngine::new()
+        .diff(&old_sbom, &new_sbom)
+        .expect("diff should succeed");
+    let config = ReportConfig::default();
+
+    let markdown = MarkdownReporter::new()
+        .generate_diff_report(&diff, &old_sbom, &new_sbom, &config)
+        .expect("Markdown diff report failed");
+    assert!(markdown.contains("## CRA Compliance"));
+    assert!(markdown.contains("### Violation Summary (New SBOM)"));
+    assert!(markdown.contains("full CRA violation detail"));
+    assert!(!markdown.contains("### Violations (New SBOM)"));
+    assert!(!markdown.contains("| Severity | Category | Standard refs | Requirement | Message | Remediation |"));
+
+    let html = HtmlReporter::new()
+        .generate_diff_report(&diff, &old_sbom, &new_sbom, &config)
+        .expect("HTML diff report failed");
+    assert!(html.contains("<h2>CRA Compliance</h2>"));
+    assert!(html.contains("Violation Summary (New SBOM)"));
+    assert!(html.contains("full CRA violation detail"));
+    assert!(!html.contains("Violations (New SBOM)</h3>"));
+    assert!(!html.contains("<th>Severity</th>"));
+}
+
+#[test]
+fn diff_markdown_and_html_reports_stay_compact_in_both_directions() {
+    let old_doc = base_document_metadata();
+    let new_doc = base_document_metadata();
+
+    let mut old_sbom = NormalizedSbom::new(old_doc);
+    old_sbom.add_component(cra_ready_component("lib-old"));
+    old_sbom.calculate_content_hash();
+
+    let mut new_sbom = NormalizedSbom::new(new_doc);
+    for index in 0..40 {
+        let comp = Component::new(format!("lib-{index}"), format!("lib-{index}-ref"));
+        new_sbom.add_component(comp);
+    }
+    new_sbom.calculate_content_hash();
+
+    let config = ReportConfig::default();
+
+    for (from, to) in [(&old_sbom, &new_sbom), (&new_sbom, &old_sbom)] {
+        let diff = DiffEngine::new()
+            .diff(from, to)
+            .expect("diff should succeed in either direction");
+
+        let markdown = MarkdownReporter::new()
+            .generate_diff_report(&diff, from, to, &config)
+            .expect("Markdown diff report failed");
+        assert!(markdown.contains("### Violation Summary (New SBOM)"));
+        assert!(!markdown.contains("### Violations (New SBOM)"));
+        assert!(!markdown.contains("| Severity | Category | Standard refs | Requirement | Message | Remediation |"));
+
+        let html = HtmlReporter::new()
+            .generate_diff_report(&diff, from, to, &config)
+            .expect("HTML diff report failed");
+        assert!(html.contains("Violation Summary (New SBOM)"));
+        assert!(!html.contains("Violations (New SBOM)</h3>"));
+        assert!(!html.contains("<th>Severity</th>"));
+    }
 }

--- a/tests/cra_readiness_tests.rs
+++ b/tests/cra_readiness_tests.rs
@@ -287,7 +287,11 @@ fn diff_markdown_and_html_reports_compact_cra_details() {
     assert!(markdown.contains("### Violation Summary (New SBOM)"));
     assert!(markdown.contains("full CRA violation detail"));
     assert!(!markdown.contains("### Violations (New SBOM)"));
-    assert!(!markdown.contains("| Severity | Category | Standard refs | Requirement | Message | Remediation |"));
+    assert!(
+        !markdown.contains(
+            "| Severity | Category | Standard refs | Requirement | Message | Remediation |"
+        )
+    );
 
     let html = HtmlReporter::new()
         .generate_diff_report(&diff, &old_sbom, &new_sbom, &config)
@@ -327,7 +331,9 @@ fn diff_markdown_and_html_reports_stay_compact_in_both_directions() {
             .expect("Markdown diff report failed");
         assert!(markdown.contains("### Violation Summary (New SBOM)"));
         assert!(!markdown.contains("### Violations (New SBOM)"));
-        assert!(!markdown.contains("| Severity | Category | Standard refs | Requirement | Message | Remediation |"));
+        assert!(!markdown.contains(
+            "| Severity | Category | Standard refs | Requirement | Message | Remediation |"
+        ));
 
         let html = HtmlReporter::new()
             .generate_diff_report(&diff, from, to, &config)


### PR DESCRIPTION
## Summary
- keep CRA compliance context in human-readable diff reports while replacing detailed violation dumps with compact summaries
- preserve full CRA detail in JSON and SARIF outputs for machine consumers
- add bidirectional regression coverage so compact diff output holds in both diff directions

## Testing
- cargo test --locked diff_reports_include_cra_compliance --test cra_readiness_tests
- cargo test --locked diff_markdown_and_html_reports_compact_cra_details --test cra_readiness_tests
- cargo test --locked diff_markdown_and_html_reports_stay_compact_in_both_directions --test cra_readiness_tests

Closes #181
