### PR TITLE
chore(ci): correct & inline SHA-pin version comments, expand Dependabot coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,90 @@
 version: 2
+
 updates:
+  # ── GitHub Actions (all workflows) ─────────────────────────────
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    groups:
+      # Batch minor/patch action bumps into one PR; majors stay separate for review.
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
+  # ── Root Cargo workspace ───────────────────────────────────────
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"
+    cooldown:
+      # Let fresh releases settle before opening a PR (dampens yanked/regressed crates).
+      default-days: 5
+    groups:
+      cargo:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
+  # ── Fuzzing harness (independent workspace; see fuzz/Cargo.toml [workspace]) ──
+  - package-ecosystem: "cargo"
+    directory: "/fuzz"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"
+      - "fuzzing"
+    cooldown:
+      default-days: 5
+    groups:
+      fuzz-cargo:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ── Dagger CI pipeline SDK (excluded from the root workspace) ───
   - package-ecosystem: "cargo"
     directory: "/dagger/rust-sdk"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "rust"
+      - "ci"
+    cooldown:
+      default-days: 5
+    groups:
+      dagger-cargo:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # ── Go bindings module ─────────────────────────────────────────
+  - package-ecosystem: "gomod"
+    directory: "/bindings/go"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "go"

--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
       - name: Cache Rust
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Run Dagger Rust SDK pipeline
         run: cargo run --manifest-path dagger/rust-sdk/Cargo.toml -- ci-all
 
@@ -29,13 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
       - name: Cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build FFI library
         run: bash ./scripts/build-bindings-mvp.sh
       - name: Test FFI ABI
@@ -59,17 +59,17 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
       - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.22'
       - name: Cache Rust
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build Rust library
         run: bash ./scripts/build-bindings-mvp.sh
       - name: Test Go wrapper
@@ -83,9 +83,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
       - name: Build Rust library

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,16 +21,13 @@ jobs:
 
     steps:
       - name: Checkout
-        # v6.0.2
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Initialize CodeQL
-        # v4
-        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           languages: rust
           build-mode: none
 
       - name: Perform CodeQL Analysis
-        # v4
-        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -40,20 +40,17 @@ jobs:
           - fuzz_detect_format
     steps:
       - name: Checkout
-        # v6.0.2
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Install nightly toolchain
-        # nightly
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: nightly
 
       - name: Cache cargo registry and build
-        # v2.8.2
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           workspaces: fuzz -> target
           key: fuzz-${{ matrix.target }}

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -23,20 +23,18 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        # v6.0.2
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Install Rust stable
-        # stable
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
 
       - name: Cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Verify tag matches crate version
         id: version
@@ -73,8 +71,7 @@ jobs:
         run: cargo test --locked --all-features --verbose
 
       - name: cargo-deny
-        # v2
-        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
         with:
           arguments: --all-features
 
@@ -90,7 +87,7 @@ jobs:
           echo "hashes=$(sha256sum target/package/sbom-tools-*.crate | base64 -w0)" >> "$GITHUB_OUTPUT"
 
       - name: Authenticate to crates.io
-        uses: rust-lang/crates-io-auth-action@1d2b8f3552d69b407d7790fa3ec7c39041305a61 # v1
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
         id: auth
 
       - name: Publish crate
@@ -153,8 +150,7 @@ jobs:
             archive_name: windows-x86_64
     steps:
       - name: Checkout
-        # v6.0.2
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 
@@ -169,8 +165,7 @@ jobs:
           fi
 
       - name: Install Rust stable
-        # stable
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
@@ -181,7 +176,7 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           key: ${{ matrix.target }}
 
@@ -196,8 +191,7 @@ jobs:
           EOF
 
       - name: Install cosign
-        # v4.1.0
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Build release binary
         run: cargo build --release --locked --all-features --target ${{ matrix.target }}
@@ -242,14 +236,12 @@ jobs:
             "${{ env.ARCHIVE }}"
 
       - name: Attest build provenance
-        # v4.1.0
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: ${{ env.ARCHIVE }}
 
       - name: Upload binary artifact
-        # v4
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: binary-${{ matrix.archive_name }}
           path: |
@@ -267,18 +259,15 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        # v6.0.2
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Rust stable
-        # stable
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: stable
 
       - name: Install cosign
-        # v4.1.0
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Install cargo-sbom
         run: cargo install cargo-sbom --locked
@@ -289,15 +278,13 @@ jobs:
           cargo sbom --output-format spdx_json_2_3 > sbom-tools.spdx.json
 
       - name: Download SLSA provenance
-        # v4
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sbom-tools.intoto.jsonl
           path: provenance/
 
       - name: Download all binary artifacts
-        # v4
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: binary-*
           path: binaries/
@@ -442,8 +429,7 @@ jobs:
           echo "Source tarball SHA256: ${SHA256} (pinned to commit ${COMMIT})"
 
       - name: Checkout Homebrew tap
-        # v6.0.2
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           repository: sbom-tool/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,16 +23,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # v6.0.2
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust
-        # 1.88 (matches rust-toolchain.toml)
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        # toolchain "1.88" below matches rust-toolchain.toml; action pinned to master (no releases)
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.88"
           components: clippy, rustfmt
       - name: Cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check formatting
@@ -48,14 +47,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust 1.88
-        # 1.88
-        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9
+        uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: "1.88"
       - name: Cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: msrv
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -78,13 +76,13 @@ jobs:
             toolchain: beta
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install Rust ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
           toolchain: ${{ matrix.toolchain }}
       - name: Cache
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: ${{ matrix.toolchain }}
           save-if: ${{ github.ref == 'refs/heads/main' }}
@@ -106,10 +104,9 @@ jobs:
     continue-on-error: ${{ matrix.checks == 'advisories' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: cargo-deny
-        # v2
-        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
         with:
           command: check ${{ matrix.checks }}
           arguments: --all-features
@@ -120,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install cargo-audit
         run: cargo install cargo-audit --locked
       - name: Run cargo-audit

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,29 +22,25 @@ jobs:
 
     steps:
       - name: Checkout
-        # v6.0.2
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Run analysis
-        # v2.4.3
-        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload artifact
-        # v6.0.0
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: scorecard-sarif
           path: results.sarif
           retention-days: 5
 
       - name: Upload to code-scanning
-        # v3
-        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463
+        uses: github/codeql-action/upload-sarif@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/tag-integrity.yml
+++ b/.github/workflows/tag-integrity.yml
@@ -18,8 +18,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        # v6.0.2
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -104,8 +103,7 @@ jobs:
       contents: read
     steps:
       - name: Install cosign
-        # v4.1.0
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Verify release asset checksums against signed manifests
         env:


### PR DESCRIPTION
## Summary

A critical retrospective on the recently-merged Dependabot PRs (#199 codeql-action, #200 checkout, #201 dagger-sdk) found the bumps were **safe to merge** — every new SHA verified against its upstream release tag, all Rust bumps non-breaking patches (the one 0.x-minor `dagger-sdk` crossing is CI-only). But they exposed a structural hygiene gap and left stale annotations behind. This PR fixes the root cause.

### Root cause
The repo annotated SHA pins with a comment on the line **above** `uses:`. Dependabot only rewrites **inline same-line** comments, so every bump silently drifted the annotation. The checkout 6.0.2→6.0.3 bump left **9 `# v6.0.2` comments now sitting above the 6.0.3 SHA** — actively false annotations.

### What changed

**SHA-pin comments (no change to which SHA runs):**
- Migrated all 53 SHA-pin annotations to **inline `# vX.Y.Z`** so future Dependabot bumps self-correct.
- Corrected every stale/wrong comment against the actual pinned SHA (resolved via the GitHub tags API):

  | action | now | was |
  |---|---|---|
  | actions/checkout | `v6.0.3` | `v6.0.2` (×9) + 8 unannotated |
  | actions/upload-artifact | `v7.0.1` | `v4` / `v6.0.0` — both wrong |
  | actions/download-artifact | `v8.0.1` | `v4` |
  | github/codeql-action | `v4.36.1` | `v4` / `v3` (scorecard wrong) |
  | sigstore/cosign-installer | `v4.1.2` | `v4.1.0` |
  | Swatinem/rust-cache | `v2.9.1` | `v2` / `v2.8.2` |
  | cargo-deny-action `v2.0.20`, scorecard-action `v2.4.3`, setup-go `v6.4.0`, attest-build-provenance `v4.1.0` | | |
  | dtolnay/rust-toolchain | `# master` | `1.88`/`stable`/`nightly` (no semver releases; toolchain set via input) |

- `bindings.yml`: annotated all 12 previously-unannotated pins.

**⚠️ Security re-pin (please review):**
- `rust-lang/crates-io-auth-action` was pinned to an **unreleased `main` HEAD commit** (`1d2b8f3`, 2026-05-18) — 85 commits ahead of the latest release and mislabeled `# v1` (no `v1` tag exists in that repo). Re-pinned to the **v1.0.4 release SHA** in the credentialed crates.io publish step. This is the only change to executed code.

**Dependabot config:**
- **New coverage** for two previously-unmonitored manifests: the independent `fuzz/` Cargo workspace (libfuzzer harness) and the `bindings/go` Go module.
- **Grouping** of minor/patch updates per ecosystem (majors stay separate) to cut per-update PR/CI churn (this window produced 9 single-dep PRs).
- **5-day cooldown** on cargo entries, consistent open-PR limits, and triage **labels** (created the missing `github-actions`/`go`/`ci`/`fuzzing` labels).

The SLSA generator reusable workflow stays tag-pinned (`@v2.1.0`) by design.

### Validation
- All 8 YAML files parse cleanly.
- Every SHA pin now carries an inline comment; zero above-line/stale comments remain (`grep` verified).
- No functional workflow change except the auth-action re-pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)