### PR TITLE
fix(mlbom): spec-compliant CycloneDX ML/AI BOM parsing (supersedes #138)

### DIFF
--- a/src/diff/changes/components.rs
+++ b/src/diff/changes/components.rs
@@ -17,6 +17,34 @@ impl ComponentChangeComputer {
         Self { cost_model }
     }
 
+    fn serialize_optional<T: serde::Serialize>(value: &Option<T>) -> Option<String> {
+        value.as_ref().map(|value| {
+            serde_json::to_string(value)
+                .unwrap_or_else(|_| String::from("\"<serialization-error>\""))
+        })
+    }
+
+    fn push_serialized_change<T: serde::Serialize>(
+        changes: &mut Vec<FieldChange>,
+        field: &str,
+        old: &Option<T>,
+        new: &Option<T>,
+        total_cost: &mut u32,
+        field_cost: u32,
+    ) {
+        let old_value = Self::serialize_optional(old);
+        let new_value = Self::serialize_optional(new);
+
+        if old_value != new_value {
+            changes.push(FieldChange {
+                field: field.to_string(),
+                old_value,
+                new_value,
+            });
+            *total_cost += field_cost;
+        }
+    }
+
     /// Compute individual field changes between two components.
     fn compute_field_changes(&self, old: &Component, new: &Component) -> (Vec<FieldChange>, u32) {
         let mut changes = Vec::new();
@@ -103,6 +131,23 @@ impl ComponentChangeComputer {
                 total_cost += self.cost_model.hash_mismatch;
             }
         }
+
+        Self::push_serialized_change(
+            &mut changes,
+            "ml_model",
+            &old.ml_model,
+            &new.ml_model,
+            &mut total_cost,
+            self.cost_model.supplier_changed,
+        );
+        Self::push_serialized_change(
+            &mut changes,
+            "dataset",
+            &old.dataset,
+            &new.dataset,
+            &mut total_cost,
+            self.cost_model.supplier_changed,
+        );
 
         // Cryptographic property changes
         if old.crypto_properties != new.crypto_properties {

--- a/src/diff/changes/components.rs
+++ b/src/diff/changes/components.rs
@@ -19,12 +19,11 @@ impl ComponentChangeComputer {
 
     fn serialize_optional<T: serde::Serialize>(value: &Option<T>) -> Option<String> {
         value.as_ref().map(|value| {
-            serde_json::to_string(value)
-                .unwrap_or_else(|_| String::from("\"<serialization-error>\""))
+            serde_json::to_string(value).expect("serializing diff value should be infallible")
         })
     }
 
-    fn push_serialized_change<T: serde::Serialize>(
+    fn push_structured_change<T: serde::Serialize + PartialEq>(
         changes: &mut Vec<FieldChange>,
         field: &str,
         old: &Option<T>,
@@ -32,14 +31,11 @@ impl ComponentChangeComputer {
         total_cost: &mut u32,
         field_cost: u32,
     ) {
-        let old_value = Self::serialize_optional(old);
-        let new_value = Self::serialize_optional(new);
-
-        if old_value != new_value {
+        if old != new {
             changes.push(FieldChange {
                 field: field.to_string(),
-                old_value,
-                new_value,
+                old_value: Self::serialize_optional(old),
+                new_value: Self::serialize_optional(new),
             });
             *total_cost += field_cost;
         }
@@ -132,21 +128,21 @@ impl ComponentChangeComputer {
             }
         }
 
-        Self::push_serialized_change(
+        Self::push_structured_change(
             &mut changes,
             "ml_model",
             &old.ml_model,
             &new.ml_model,
             &mut total_cost,
-            self.cost_model.supplier_changed,
+            self.cost_model.ml_model_changed,
         );
-        Self::push_serialized_change(
+        Self::push_structured_change(
             &mut changes,
             "dataset",
             &old.dataset,
             &new.dataset,
             &mut total_cost,
-            self.cost_model.supplier_changed,
+            self.cost_model.dataset_changed,
         );
 
         // Cryptographic property changes
@@ -372,6 +368,7 @@ impl ChangeComputer for ComponentChangeComputer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::{DatasetInfo, MlModelInfo};
 
     #[test]
     fn test_component_change_computer_default() {
@@ -388,5 +385,55 @@ mod tests {
 
         let result = computer.compute(&old, &new, &matches);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_ml_model_change_uses_dedicated_cost() {
+        let computer = ComponentChangeComputer::new(CostModel {
+            ml_model_changed: 42,
+            ..CostModel::default()
+        });
+        let mut old = Component::new("model".to_string(), "model@1".to_string());
+        let mut new = old.clone();
+
+        old.ml_model = Some(MlModelInfo {
+            quantization: Some("fp32".to_string()),
+            ..MlModelInfo::default()
+        });
+        new.ml_model = Some(MlModelInfo {
+            quantization: Some("int8".to_string()),
+            ..MlModelInfo::default()
+        });
+
+        let (changes, total_cost) = computer.compute_field_changes(&old, &new);
+
+        assert_eq!(total_cost, 42);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].field, "ml_model");
+    }
+
+    #[test]
+    fn test_dataset_change_uses_dedicated_cost() {
+        let computer = ComponentChangeComputer::new(CostModel {
+            dataset_changed: 17,
+            ..CostModel::default()
+        });
+        let mut old = Component::new("dataset".to_string(), "dataset@1".to_string());
+        let mut new = old.clone();
+
+        old.dataset = Some(DatasetInfo {
+            dataset_type: Some("training".to_string()),
+            ..DatasetInfo::default()
+        });
+        new.dataset = Some(DatasetInfo {
+            dataset_type: Some("validation".to_string()),
+            ..DatasetInfo::default()
+        });
+
+        let (changes, total_cost) = computer.compute_field_changes(&old, &new);
+
+        assert_eq!(total_cost, 17);
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].field, "dataset");
     }
 }

--- a/src/diff/cost.rs
+++ b/src/diff/cost.rs
@@ -22,6 +22,10 @@ pub struct CostModel {
     pub license_changed: u32,
     /// Cost for supplier change
     pub supplier_changed: u32,
+    /// Cost for ML model metadata change
+    pub ml_model_changed: u32,
+    /// Cost for dataset metadata change
+    pub dataset_changed: u32,
     /// Cost for introducing a vulnerability
     pub vulnerability_introduced: u32,
     /// Reward (negative cost) for resolving a vulnerability
@@ -56,6 +60,8 @@ impl Default for CostModel {
             version_major: 7,
             license_changed: 6,
             supplier_changed: 4,
+            ml_model_changed: 6,
+            dataset_changed: 5,
             vulnerability_introduced: 15,
             vulnerability_resolved: -3,
             dependency_added: 5,
@@ -162,6 +168,9 @@ mod tests {
         assert_eq!(model.version_minor, 4);
         assert_eq!(model.version_major, 7);
         assert_eq!(model.license_changed, 6);
+        assert_eq!(model.supplier_changed, 4);
+        assert_eq!(model.ml_model_changed, 6);
+        assert_eq!(model.dataset_changed, 5);
         assert_eq!(model.vulnerability_introduced, 15);
         assert_eq!(model.vulnerability_resolved, -3);
         assert_eq!(model.hash_mismatch, 8);

--- a/src/model/metadata.rs
+++ b/src/model/metadata.rs
@@ -516,3 +516,52 @@ pub struct Annotation {
     pub annotation_type: String,
     pub comment: String,
 }
+
+/// Machine learning model metadata (CycloneDX 1.5+)
+///
+/// Structured information about trained ML models, including architecture,
+/// approach, quantization, and environmental impact.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct MlModelInfo {
+    /// ML approach type: "supervised", "unsupervised", "reinforcement-learning", "semi-supervised"
+    pub approach: Option<String>,
+    /// Architecture family: "transformer", "cnn", "rnn", "llm", "gan", etc.
+    pub architecture_family: Option<String>,
+    /// Architecture name: "bert", "gpt", "resnet", etc.
+    pub architecture_name: Option<String>,
+    /// ML task: "nlp", "computer-vision", "audio", "tabular", etc.
+    pub task: Option<String>,
+    /// Quantization mode: "int4", "int8", "fp16", "bf16", "fp32", "mixed", etc.
+    pub quantization: Option<String>,
+    /// Limitations or known constraints of the model
+    pub limitations: Option<String>,
+    /// Training datasets used for this model
+    pub training_datasets: Vec<DatasetRef>,
+    /// Energy consumed during training in kWh (approximate)
+    pub energy_kwh_training: Option<f64>,
+    /// URL to detailed model card (from ExternalRefType::ModelCard)
+    pub model_card_url: Option<String>,
+}
+
+/// Reference to a dataset used for training or evaluation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DatasetRef {
+    /// Dataset name
+    pub name: Option<String>,
+    /// Package URL (PURL) if the dataset is packaged
+    pub purl: Option<String>,
+}
+
+/// Dataset component metadata (CycloneDX 1.5+ data type)
+///
+/// Structured information about datasets, including type, sensitivity,
+/// governance, and content properties.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DatasetInfo {
+    /// Dataset type: "training", "testing", "validation", "evaluation"
+    pub dataset_type: Option<String>,
+    /// Sensitivity classifications: "sensitive", "confidential", "pii", etc.
+    pub sensitivity_classifications: Vec<String>,
+    /// Data governance owners/custodians
+    pub governance_owners: Vec<String>,
+}

--- a/src/model/metadata.rs
+++ b/src/model/metadata.rs
@@ -521,7 +521,8 @@ pub struct Annotation {
 ///
 /// Structured information about trained ML models, including architecture,
 /// approach, quantization, and environmental impact.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct MlModelInfo {
     /// ML approach type: "supervised", "unsupervised", "reinforcement-learning", "semi-supervised"
     pub approach: Option<String>,
@@ -544,7 +545,8 @@ pub struct MlModelInfo {
 }
 
 /// Reference to a dataset used for training or evaluation
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DatasetRef {
     /// Dataset name
     pub name: Option<String>,
@@ -556,7 +558,8 @@ pub struct DatasetRef {
 ///
 /// Structured information about datasets, including type, sensitivity,
 /// governance, and content properties.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct DatasetInfo {
     /// Dataset type: "training", "testing", "validation", "evaluation"
     pub dataset_type: Option<String>,

--- a/src/model/metadata.rs
+++ b/src/model/metadata.rs
@@ -548,9 +548,12 @@ pub struct MlModelInfo {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct DatasetRef {
-    /// Dataset name
+    /// BOM-ref / BOM-Link to a dataset component (CycloneDX `modelParameters.datasets` `{ref}` form)
+    pub reference: Option<String>,
+    /// Dataset name (from an inline `componentData` dataset)
     pub name: Option<String>,
-    /// Package URL (PURL) if the dataset is packaged
+    /// Package URL (PURL). Not part of the CycloneDX spec for datasets; retained for
+    /// non-spec emitters and is `None` for spec-conformant input.
     pub purl: Option<String>,
 }
 

--- a/src/model/sbom.rs
+++ b/src/model/sbom.rs
@@ -621,6 +621,10 @@ pub struct Component {
     pub staleness: Option<StalenessInfo>,
     /// End-of-life information (populated by enrichment)
     pub eol: Option<EolInfo>,
+    /// ML model metadata (populated for MachineLearningModel components)
+    pub ml_model: Option<super::MlModelInfo>,
+    /// Dataset metadata (populated for Data components)
+    pub dataset: Option<super::DatasetInfo>,
     /// Cryptographic properties (CycloneDX 1.6+ cryptoProperties)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub crypto_properties: Option<CryptoProperties>,
@@ -657,6 +661,8 @@ impl Component {
             version_range: None,
             staleness: None,
             eol: None,
+            ml_model: None,
+            dataset: None,
             crypto_properties: None,
         }
     }
@@ -687,17 +693,54 @@ impl Component {
         self
     }
 
+    fn extend_with_optional_str(hasher_input: &mut Vec<u8>, value: &Option<String>) {
+        if let Some(value) = value {
+            hasher_input.extend(value.as_bytes());
+        }
+    }
+
+    fn extend_with_string_list(hasher_input: &mut Vec<u8>, values: &[String]) {
+        for value in values {
+            hasher_input.extend(value.as_bytes());
+        }
+    }
+
+    fn extend_with_ml_model(hasher_input: &mut Vec<u8>, ml_model: &Option<super::MlModelInfo>) {
+        if let Some(ml_model) = ml_model {
+            Self::extend_with_optional_str(hasher_input, &ml_model.approach);
+            Self::extend_with_optional_str(hasher_input, &ml_model.architecture_family);
+            Self::extend_with_optional_str(hasher_input, &ml_model.architecture_name);
+            Self::extend_with_optional_str(hasher_input, &ml_model.task);
+            Self::extend_with_optional_str(hasher_input, &ml_model.quantization);
+            Self::extend_with_optional_str(hasher_input, &ml_model.limitations);
+            Self::extend_with_optional_str(hasher_input, &ml_model.model_card_url);
+
+            if let Some(energy) = ml_model.energy_kwh_training {
+                hasher_input.extend(energy.to_le_bytes());
+            }
+
+            for dataset in &ml_model.training_datasets {
+                Self::extend_with_optional_str(hasher_input, &dataset.name);
+                Self::extend_with_optional_str(hasher_input, &dataset.purl);
+            }
+        }
+    }
+
+    fn extend_with_dataset(hasher_input: &mut Vec<u8>, dataset: &Option<super::DatasetInfo>) {
+        if let Some(dataset) = dataset {
+            Self::extend_with_optional_str(hasher_input, &dataset.dataset_type);
+            Self::extend_with_string_list(hasher_input, &dataset.sensitivity_classifications);
+            Self::extend_with_string_list(hasher_input, &dataset.governance_owners);
+        }
+    }
+
     /// Calculate and update content hash
     pub fn calculate_content_hash(&mut self) {
         let mut hasher_input = Vec::new();
 
         hasher_input.extend(self.name.as_bytes());
-        if let Some(v) = &self.version {
-            hasher_input.extend(v.as_bytes());
-        }
-        if let Some(purl) = &self.identifiers.purl {
-            hasher_input.extend(purl.as_bytes());
-        }
+        Self::extend_with_optional_str(&mut hasher_input, &self.version);
+        Self::extend_with_optional_str(&mut hasher_input, &self.identifiers.purl);
         for license in &self.licenses.declared {
             hasher_input.extend(license.expression.as_bytes());
         }
@@ -716,6 +759,9 @@ impl Component {
         if let Some(vr) = &self.version_range {
             hasher_input.extend(vr.as_bytes());
         }
+        Self::extend_with_ml_model(&mut hasher_input, &self.ml_model);
+        Self::extend_with_dataset(&mut hasher_input, &self.dataset);
+
         // Crypto properties: include fields that affect security semantics
         if let Some(cp) = &self.crypto_properties {
             hasher_input.extend(cp.asset_type.to_string().as_bytes());

--- a/src/model/sbom.rs
+++ b/src/model/sbom.rs
@@ -695,6 +695,20 @@ impl Component {
         self
     }
 
+    /// Attach ML model metadata (CycloneDX modelCard)
+    #[must_use]
+    pub fn with_ml_model(mut self, ml_model: crate::model::MlModelInfo) -> Self {
+        self.ml_model = Some(ml_model);
+        self
+    }
+
+    /// Attach dataset metadata (CycloneDX ML BOM dataset component)
+    #[must_use]
+    pub fn with_dataset(mut self, dataset: crate::model::DatasetInfo) -> Self {
+        self.dataset = Some(dataset);
+        self
+    }
+
     fn extend_with_optional_str(hasher_input: &mut Vec<u8>, value: &Option<String>) {
         if let Some(value) = value {
             hasher_input.extend(value.as_bytes());

--- a/src/model/sbom.rs
+++ b/src/model/sbom.rs
@@ -9,6 +9,8 @@ use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use xxhash_rust::xxh3::xxh3_64;
 
+const CANONICAL_NAN_BITS: u64 = 0x7ff8_0000_0000_0000;
+
 /// Normalized SBOM document - the canonical intermediate representation.
 ///
 /// This structure represents an SBOM in a format-agnostic way, allowing
@@ -622,9 +624,9 @@ pub struct Component {
     /// End-of-life information (populated by enrichment)
     pub eol: Option<EolInfo>,
     /// ML model metadata (populated for MachineLearningModel components)
-    pub ml_model: Option<super::MlModelInfo>,
+    pub ml_model: Option<crate::model::MlModelInfo>,
     /// Dataset metadata (populated for Data components)
-    pub dataset: Option<super::DatasetInfo>,
+    pub dataset: Option<crate::model::DatasetInfo>,
     /// Cryptographic properties (CycloneDX 1.6+ cryptoProperties)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub crypto_properties: Option<CryptoProperties>,
@@ -705,7 +707,23 @@ impl Component {
         }
     }
 
-    fn extend_with_ml_model(hasher_input: &mut Vec<u8>, ml_model: &Option<super::MlModelInfo>) {
+    fn extend_with_optional_f64(hasher_input: &mut Vec<u8>, value: Option<f64>) {
+        if let Some(value) = value {
+            let normalized = if value == 0.0 {
+                0.0
+            } else if value.is_nan() {
+                f64::from_bits(CANONICAL_NAN_BITS)
+            } else {
+                value
+            };
+            hasher_input.extend(normalized.to_bits().to_le_bytes());
+        }
+    }
+
+    fn extend_with_ml_model(
+        hasher_input: &mut Vec<u8>,
+        ml_model: &Option<crate::model::MlModelInfo>,
+    ) {
         if let Some(ml_model) = ml_model {
             Self::extend_with_optional_str(hasher_input, &ml_model.approach);
             Self::extend_with_optional_str(hasher_input, &ml_model.architecture_family);
@@ -714,10 +732,7 @@ impl Component {
             Self::extend_with_optional_str(hasher_input, &ml_model.quantization);
             Self::extend_with_optional_str(hasher_input, &ml_model.limitations);
             Self::extend_with_optional_str(hasher_input, &ml_model.model_card_url);
-
-            if let Some(energy) = ml_model.energy_kwh_training {
-                hasher_input.extend(energy.to_le_bytes());
-            }
+            Self::extend_with_optional_f64(hasher_input, ml_model.energy_kwh_training);
 
             for dataset in &ml_model.training_datasets {
                 Self::extend_with_optional_str(hasher_input, &dataset.name);
@@ -726,7 +741,10 @@ impl Component {
         }
     }
 
-    fn extend_with_dataset(hasher_input: &mut Vec<u8>, dataset: &Option<super::DatasetInfo>) {
+    fn extend_with_dataset(
+        hasher_input: &mut Vec<u8>,
+        dataset: &Option<crate::model::DatasetInfo>,
+    ) {
         if let Some(dataset) = dataset {
             Self::extend_with_optional_str(hasher_input, &dataset.dataset_type);
             Self::extend_with_string_list(hasher_input, &dataset.sensitivity_classifications);
@@ -850,5 +868,45 @@ impl DependencyEdge {
                 | DependencyType::TestDependsOn
                 | DependencyType::RuntimeDependsOn
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::MlModelInfo;
+
+    #[test]
+    fn test_content_hash_normalizes_ml_energy_zero_and_nan() {
+        let mut positive_zero = Component::new("model".to_string(), "model@1".to_string());
+        positive_zero.ml_model = Some(MlModelInfo {
+            energy_kwh_training: Some(0.0),
+            ..MlModelInfo::default()
+        });
+        positive_zero.calculate_content_hash();
+
+        let mut negative_zero = Component::new("model".to_string(), "model@1".to_string());
+        negative_zero.ml_model = Some(MlModelInfo {
+            energy_kwh_training: Some(-0.0),
+            ..MlModelInfo::default()
+        });
+        negative_zero.calculate_content_hash();
+
+        let mut nan_a = Component::new("model".to_string(), "model@1".to_string());
+        nan_a.ml_model = Some(MlModelInfo {
+            energy_kwh_training: Some(f64::NAN),
+            ..MlModelInfo::default()
+        });
+        nan_a.calculate_content_hash();
+
+        let mut nan_b = Component::new("model".to_string(), "model@1".to_string());
+        nan_b.ml_model = Some(MlModelInfo {
+            energy_kwh_training: Some(f64::from_bits(CANONICAL_NAN_BITS + 1)),
+            ..MlModelInfo::default()
+        });
+        nan_b.calculate_content_hash();
+
+        assert_eq!(positive_zero.content_hash, negative_zero.content_hash);
+        assert_eq!(nan_a.content_hash, nan_b.content_hash);
     }
 }

--- a/src/parsers/cyclonedx.rs
+++ b/src/parsers/cyclonedx.rs
@@ -433,6 +433,7 @@ impl CycloneDxParser {
                     "website" => ExternalRefType::Website,
                     "advisories" => ExternalRefType::Advisories,
                     "bom" => ExternalRefType::Bom,
+                    "model-card" => ExternalRefType::ModelCard,
                     "documentation" => ExternalRefType::Documentation,
                     "support" => ExternalRefType::Support,
                     "security-contact" => ExternalRefType::SecurityContact,
@@ -473,6 +474,106 @@ impl CycloneDxParser {
         // Set 1.7+ fields
         comp.is_external = cdx.is_external;
         comp.version_range.clone_from(&cdx.version_range);
+
+        // Set ML model metadata (CycloneDX 1.5+)
+        if let Some(ml_model) = &cdx.ml_model {
+            let mut ml_info = crate::model::MlModelInfo::default();
+            let model_card = ml_model
+                .model_card
+                .as_ref()
+                .and_then(|value| serde_json::from_value::<CdxMlModelCard>(value.clone()).ok());
+
+            if let Some(approach) = &ml_model.approach {
+                ml_info.approach = approach.approach_type.clone();
+            }
+
+            if let Some(arch_family) = &ml_model.architecture_family {
+                ml_info.architecture_family = Some(arch_family.clone());
+            }
+
+            let model_parameters = ml_model.model_parameters.as_ref().or_else(|| {
+                model_card
+                    .as_ref()
+                    .and_then(|card| card.model_parameters.as_ref())
+            });
+
+            if let Some(model_params) = model_parameters {
+                ml_info.task = model_params.task.clone();
+
+                if let Some(arch) = &model_params.architecture {
+                    ml_info.architecture_name = arch.name.clone();
+                }
+
+                // Collect training datasets
+                for dataset_ref in &model_params.datasets {
+                    ml_info.training_datasets.push(crate::model::DatasetRef {
+                        name: dataset_ref.name.clone(),
+                        purl: dataset_ref.purl.clone(),
+                    });
+                }
+            }
+
+            let quantization = ml_model.quantization.as_ref().or_else(|| {
+                model_card
+                    .as_ref()
+                    .and_then(|card| card.quantization.as_ref())
+            });
+
+            if let Some(quantization) = quantization {
+                ml_info.quantization = quantization.mode.clone();
+            }
+
+            let limitations = ml_model.limitations.as_ref().or_else(|| {
+                model_card
+                    .as_ref()
+                    .and_then(|card| card.limitations.as_ref())
+            });
+
+            if let Some(limitations) = limitations {
+                ml_info.limitations = Some(limitations.clone());
+            }
+
+            // Extract energy consumption from considerations
+            let considerations = ml_model.considerations.as_ref().or_else(|| {
+                model_card
+                    .as_ref()
+                    .and_then(|card| card.considerations.as_ref())
+            });
+
+            if let Some(considerations) = considerations {
+                if let Some(env_considerations) = &considerations.environmental_considerations {
+                    for energy in &env_considerations.energy_consumptions {
+                        if energy.activity.as_deref() == Some("training") {
+                            ml_info.energy_kwh_training = energy.energy_kwh;
+                        }
+                    }
+                }
+            }
+
+            // Extract model card URL from external references
+            for ext_ref in &comp.external_refs {
+                if ext_ref.ref_type == ExternalRefType::ModelCard {
+                    ml_info.model_card_url = Some(ext_ref.url.clone());
+                    break;
+                }
+            }
+
+            comp.ml_model = Some(ml_info);
+        }
+
+        // Set dataset metadata (CycloneDX 1.5+)
+        if let Some(data_component) = &cdx.data_component {
+            let dataset_info = crate::model::DatasetInfo {
+                dataset_type: data_component.data_type.clone(),
+                sensitivity_classifications: data_component.sensitivity_data.clone(),
+                governance_owners: data_component
+                    .governance
+                    .as_ref()
+                    .map_or_else(Vec::new, |governance| governance.owners.clone()),
+            };
+
+            comp.dataset = Some(dataset_info);
+        }
 
         // Set cryptographic properties (1.6+)
         if let Some(cdx_crypto) = &cdx.crypto_properties {
@@ -1330,6 +1431,12 @@ struct CdxComponent {
     is_external: bool,
     /// Package URL Version Range syntax (1.7+, mutually exclusive with version)
     version_range: Option<String>,
+    /// ML Model metadata (CycloneDX 1.5+)
+    #[serde(rename = "modelCard", alias = "mlModel")]
+    ml_model: Option<CdxMlModel>,
+    /// Dataset metadata (CycloneDX 1.5+, used when component type is "data")
+    #[serde(rename = "data")]
+    data_component: Option<CdxDataComponent>,
     /// Cryptographic properties (1.6+)
     crypto_properties: Option<CdxCryptoProperties>,
 }
@@ -1382,6 +1489,135 @@ struct CdxProperty {
     value: String,
 }
 
+// ML Model and Dataset structures (CycloneDX 1.5+ AI/ML BOM support)
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxMlModel {
+    approach: Option<CdxMlApproach>,
+    architecture_family: Option<String>,
+    model_card: Option<serde_json::Value>, // Preserve as raw JSON for now
+    model_parameters: Option<CdxModelParameters>,
+    quantization: Option<CdxQuantization>,
+    limitations: Option<String>,
+    considerations: Option<CdxConsiderations>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxMlModelCard {
+    model_parameters: Option<CdxModelParameters>,
+    quantization: Option<CdxQuantization>,
+    limitations: Option<String>,
+    considerations: Option<CdxConsiderations>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxMlApproach {
+    #[serde(rename = "type")]
+    approach_type: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxModelParameters {
+    task: Option<String>,
+    architecture: Option<CdxModelArchitecture>,
+    #[serde(default)]
+    datasets: Vec<CdxDatasetRef>,
+    objective_function: Option<Vec<serde_json::Value>>,
+    evaluation_metrics: Option<Vec<serde_json::Value>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxModelArchitecture {
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxDatasetRef {
+    #[serde(rename = "ref")]
+    ref_field: Option<String>,
+    name: Option<String>,
+    #[serde(default)]
+    purl: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxQuantization {
+    mode: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxConsiderations {
+    environmental_considerations: Option<CdxEnvironmentalConsiderations>,
+    #[serde(default)]
+    #[serde(rename = "fairnessConsiderations")]
+    fairness_considerations: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxEnvironmentalConsiderations {
+    #[serde(default)]
+    energy_consumptions: Vec<CdxEnergyConsumption>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxEnergyConsumption {
+    #[serde(alias = "type")]
+    activity: Option<String>,
+    energy_provider: Option<String>,
+    energy_source: Option<String>,
+    #[serde(rename = "energyKwh", alias = "value")]
+    energy_kwh: Option<f64>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxDataComponent {
+    #[serde(rename = "type")]
+    data_type: Option<String>,
+    name: Option<String>,
+    contents: Option<CdxDataContents>,
+    classification: Option<String>,
+    #[serde(default)]
+    sensitivity_data: Vec<String>,
+    governance: Option<CdxDataGovernance>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxDataContents {
+    #[serde(default)]
+    properties: Vec<CdxProperty>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[allow(dead_code)]
+struct CdxDataGovernance {
+    #[serde(default)]
+    owners: Vec<String>,
+}
+
 // ── CycloneDX Crypto Deserialization Structs (1.6+) ─────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -1397,7 +1633,6 @@ struct CdxCryptoProperties {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct CdxAlgorithmProperties {
     primitive: Option<String>,
     algorithm_family: Option<String>,

--- a/src/parsers/cyclonedx.rs
+++ b/src/parsers/cyclonedx.rs
@@ -476,28 +476,18 @@ impl CycloneDxParser {
         comp.version_range.clone_from(&cdx.version_range);
 
         // Set ML model metadata (CycloneDX 1.5+)
-        if let Some(ml_model) = &cdx.ml_model {
+        if let Some(model_card) = &cdx.model_card {
             let mut ml_info = crate::model::MlModelInfo::default();
-            let model_card = ml_model
-                .model_card
-                .as_ref()
-                .and_then(|value| serde_json::from_value::<CdxMlModelCard>(value.clone()).ok());
 
-            if let Some(approach) = &ml_model.approach {
+            if let Some(approach) = &model_card.approach {
                 ml_info.approach = approach.approach_type.clone();
             }
 
-            if let Some(arch_family) = &ml_model.architecture_family {
+            if let Some(arch_family) = &model_card.architecture_family {
                 ml_info.architecture_family = Some(arch_family.clone());
             }
 
-            let model_parameters = ml_model.model_parameters.as_ref().or_else(|| {
-                model_card
-                    .as_ref()
-                    .and_then(|card| card.model_parameters.as_ref())
-            });
-
-            if let Some(model_params) = model_parameters {
+            if let Some(model_params) = &model_card.model_parameters {
                 ml_info.task = model_params.task.clone();
 
                 if let Some(arch) = &model_params.architecture {
@@ -513,39 +503,26 @@ impl CycloneDxParser {
                 }
             }
 
-            let quantization = ml_model.quantization.as_ref().or_else(|| {
-                model_card
-                    .as_ref()
-                    .and_then(|card| card.quantization.as_ref())
-            });
-
-            if let Some(quantization) = quantization {
+            if let Some(quantization) = &model_card.quantization {
                 ml_info.quantization = quantization.mode.clone();
             }
 
-            let limitations = ml_model.limitations.as_ref().or_else(|| {
-                model_card
-                    .as_ref()
-                    .and_then(|card| card.limitations.as_ref())
-            });
-
-            if let Some(limitations) = limitations {
+            if let Some(limitations) = &model_card.limitations {
                 ml_info.limitations = Some(limitations.clone());
             }
 
             // Extract energy consumption from considerations
-            let considerations = ml_model.considerations.as_ref().or_else(|| {
-                model_card
-                    .as_ref()
-                    .and_then(|card| card.considerations.as_ref())
-            });
-
-            if let Some(considerations) = considerations {
+            if let Some(considerations) = &model_card.considerations {
                 if let Some(env_considerations) = &considerations.environmental_considerations {
-                    for energy in &env_considerations.energy_consumptions {
-                        if energy.activity.as_deref() == Some("training") {
-                            ml_info.energy_kwh_training = energy.energy_kwh;
-                        }
+                    let total_training_energy: f64 = env_considerations
+                        .energy_consumptions
+                        .iter()
+                        .filter(|energy| energy.activity.as_deref() == Some("training"))
+                        .filter_map(|energy| energy.energy_kwh)
+                        .sum();
+
+                    if total_training_energy > 0.0 {
+                        ml_info.energy_kwh_training = Some(total_training_energy);
                     }
                 }
             }
@@ -1432,8 +1409,8 @@ struct CdxComponent {
     /// Package URL Version Range syntax (1.7+, mutually exclusive with version)
     version_range: Option<String>,
     /// ML Model metadata (CycloneDX 1.5+)
-    #[serde(rename = "modelCard", alias = "mlModel")]
-    ml_model: Option<CdxMlModel>,
+    #[serde(rename = "modelCard")]
+    model_card: Option<CdxMlModelCard>,
     /// Dataset metadata (CycloneDX 1.5+, used when component type is "data")
     #[serde(rename = "data")]
     data_component: Option<CdxDataComponent>,
@@ -1490,13 +1467,11 @@ struct CdxProperty {
 }
 
 // ML Model and Dataset structures (CycloneDX 1.5+ AI/ML BOM support)
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
-struct CdxMlModel {
+struct CdxMlModelCard {
     approach: Option<CdxMlApproach>,
     architecture_family: Option<String>,
-    model_card: Option<serde_json::Value>, // Preserve as raw JSON for now
     model_parameters: Option<CdxModelParameters>,
     quantization: Option<CdxQuantization>,
     limitations: Option<String>,
@@ -1505,17 +1480,6 @@ struct CdxMlModel {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
-struct CdxMlModelCard {
-    model_parameters: Option<CdxModelParameters>,
-    quantization: Option<CdxQuantization>,
-    limitations: Option<String>,
-    considerations: Option<CdxConsiderations>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct CdxMlApproach {
     #[serde(rename = "type")]
     approach_type: Option<String>,
@@ -1523,29 +1487,22 @@ struct CdxMlApproach {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct CdxModelParameters {
     task: Option<String>,
     architecture: Option<CdxModelArchitecture>,
     #[serde(default)]
     datasets: Vec<CdxDatasetRef>,
-    objective_function: Option<Vec<serde_json::Value>>,
-    evaluation_metrics: Option<Vec<serde_json::Value>>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct CdxModelArchitecture {
     name: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct CdxDatasetRef {
-    #[serde(rename = "ref")]
-    ref_field: Option<String>,
     name: Option<String>,
     #[serde(default)]
     purl: Option<String>,
@@ -1553,24 +1510,18 @@ struct CdxDatasetRef {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct CdxQuantization {
     mode: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct CdxConsiderations {
     environmental_considerations: Option<CdxEnvironmentalConsiderations>,
-    #[serde(default)]
-    #[serde(rename = "fairnessConsiderations")]
-    fairness_considerations: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct CdxEnvironmentalConsiderations {
     #[serde(default)]
     energy_consumptions: Vec<CdxEnergyConsumption>,
@@ -1578,25 +1529,18 @@ struct CdxEnvironmentalConsiderations {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct CdxEnergyConsumption {
     #[serde(alias = "type")]
     activity: Option<String>,
-    energy_provider: Option<String>,
-    energy_source: Option<String>,
     #[serde(rename = "energyKwh", alias = "value")]
     energy_kwh: Option<f64>,
 }
 
 #[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct CdxDataComponent {
     #[serde(rename = "type")]
     data_type: Option<String>,
-    name: Option<String>,
-    contents: Option<CdxDataContents>,
-    classification: Option<String>,
     #[serde(default)]
     sensitivity_data: Vec<String>,
     governance: Option<CdxDataGovernance>,
@@ -1604,15 +1548,6 @@ struct CdxDataComponent {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
-struct CdxDataContents {
-    #[serde(default)]
-    properties: Vec<CdxProperty>,
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-#[allow(dead_code)]
 struct CdxDataGovernance {
     #[serde(default)]
     owners: Vec<String>,

--- a/src/parsers/cyclonedx.rs
+++ b/src/parsers/cyclonedx.rs
@@ -484,46 +484,44 @@ impl CycloneDxParser {
         if let Some(model_card) = &cdx.model_card {
             let mut ml_info = crate::model::MlModelInfo::default();
 
-            if let Some(approach) = &model_card.approach {
-                ml_info.approach = approach.approach_type.clone();
-            }
-
-            if let Some(arch_family) = &model_card.architecture_family {
-                ml_info.architecture_family = Some(arch_family.clone());
-            }
-
+            // Per the CycloneDX 1.6 schema, `approach`, `architectureFamily`,
+            // `modelArchitecture`, `task` and `datasets` all live under `modelParameters`.
             if let Some(model_params) = &model_card.model_parameters {
+                if let Some(approach) = &model_params.approach {
+                    ml_info.approach = approach.approach_type.clone();
+                }
+                ml_info.architecture_family = model_params.architecture_family.clone();
                 ml_info.task = model_params.task.clone();
 
-                if let Some(arch) = &model_params.architecture {
-                    ml_info.architecture_name = arch.name.clone();
+                // Spec: `modelArchitecture` is a string; fall back to the non-spec
+                // `architecture.name` object only if the string form is absent.
+                ml_info.architecture_name = model_params.model_architecture.clone().or_else(|| {
+                    model_params
+                        .architecture
+                        .as_ref()
+                        .and_then(|arch| arch.name.clone())
+                });
+
+                for dataset in &model_params.datasets {
+                    ml_info.training_datasets.push(dataset.to_model());
                 }
-
-                // Collect training datasets
-                for dataset_ref in &model_params.datasets {
-                    ml_info.training_datasets.push(crate::model::DatasetRef {
-                        name: dataset_ref.name.clone(),
-                        purl: dataset_ref.purl.clone(),
-                    });
-                }
             }
 
-            if let Some(quantization) = &model_card.quantization {
-                ml_info.quantization = quantization.mode.clone();
-            }
+            // `quantization` has no home in the CycloneDX 1.6 modelCard schema, so it is
+            // intentionally not parsed (left as None) rather than read from a non-existent field.
 
-            if let Some(limitations) = &model_card.limitations {
-                ml_info.limitations = Some(limitations.clone());
-            }
-
-            // Extract energy consumption from considerations
             if let Some(considerations) = &model_card.considerations {
+                // Spec: limitations live in `considerations.technicalLimitations` (array).
+                if !considerations.technical_limitations.is_empty() {
+                    ml_info.limitations = Some(considerations.technical_limitations.join("; "));
+                }
+
                 if let Some(env_considerations) = &considerations.environmental_considerations {
                     let total_training_energy: f64 = env_considerations
                         .energy_consumptions
                         .iter()
                         .filter(|energy| energy.activity.as_deref() == Some("training"))
-                        .filter_map(|energy| energy.energy_kwh)
+                        .filter_map(CdxEnergyConsumption::training_energy_kwh)
                         .sum();
 
                     if total_training_energy > 0.0 {
@@ -543,18 +541,28 @@ impl CycloneDxParser {
             comp.ml_model = Some(ml_info);
         }
 
-        // Set dataset metadata (CycloneDX 1.5+)
-        if let Some(data_component) = &cdx.data_component {
-            let dataset_info = crate::model::DatasetInfo {
-                dataset_type: data_component.data_type.clone(),
-                sensitivity_classifications: data_component.sensitivity_data.clone(),
-                governance_owners: data_component
+        // Set dataset metadata (CycloneDX 1.5+). Per spec `component.data` is an array of
+        // componentData; a `data` component is represented by its first entry.
+        if let Some(data_component) = cdx.data_components.first() {
+            let governance_owners =
+                data_component
                     .governance
                     .as_ref()
-                    .map_or_else(Vec::new, |governance| governance.owners.clone()),
-            };
+                    .map_or_else(Vec::new, |governance| {
+                        governance
+                            .owners
+                            .iter()
+                            .chain(governance.custodians.iter())
+                            .chain(governance.stewards.iter())
+                            .filter_map(CdxGovParty::display_name)
+                            .collect()
+                    });
 
-            comp.dataset = Some(dataset_info);
+            comp.dataset = Some(crate::model::DatasetInfo {
+                dataset_type: data_component.data_type.clone(),
+                sensitivity_classifications: data_component.sensitivity_data.clone(),
+                governance_owners,
+            });
         }
 
         // Set cryptographic properties (1.6+)
@@ -1420,9 +1428,14 @@ struct CdxComponent {
     /// ML Model metadata (CycloneDX 1.5+)
     #[serde(rename = "modelCard")]
     model_card: Option<CdxMlModelCard>,
-    /// Dataset metadata (CycloneDX 1.5+, used when component type is "data")
-    #[serde(rename = "data")]
-    data_component: Option<CdxDataComponent>,
+    /// Dataset metadata (CycloneDX 1.5+). Per spec `data` is an array of componentData;
+    /// a single object is also accepted for non-spec emitters.
+    #[serde(
+        rename = "data",
+        default,
+        deserialize_with = "deserialize_component_data"
+    )]
+    data_components: Vec<CdxDataComponent>,
     /// Cryptographic properties (1.6+)
     crypto_properties: Option<CdxCryptoProperties>,
 }
@@ -1479,11 +1492,7 @@ struct CdxProperty {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct CdxMlModelCard {
-    approach: Option<CdxMlApproach>,
-    architecture_family: Option<String>,
     model_parameters: Option<CdxModelParameters>,
-    quantization: Option<CdxQuantization>,
-    limitations: Option<String>,
     considerations: Option<CdxConsiderations>,
 }
 
@@ -1497,10 +1506,15 @@ struct CdxMlApproach {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct CdxModelParameters {
+    approach: Option<CdxMlApproach>,
     task: Option<String>,
+    architecture_family: Option<String>,
+    /// Spec: `modelArchitecture` is a string (e.g. "ResNet-50").
+    model_architecture: Option<String>,
+    /// Non-spec object form `{ name }`, retained as a fallback only.
     architecture: Option<CdxModelArchitecture>,
     #[serde(default)]
-    datasets: Vec<CdxDatasetRef>,
+    datasets: Vec<CdxDatasetChoice>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1509,23 +1523,48 @@ struct CdxModelArchitecture {
     name: Option<String>,
 }
 
+/// A `modelParameters.datasets` item: the spec data-reference form `{ "ref": ... }`, or an
+/// inline dataset (spec `componentData` carrying a `name`, or the non-spec `{ name, purl }`).
 #[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct CdxDatasetRef {
-    name: Option<String>,
-    #[serde(default)]
-    purl: Option<String>,
+#[serde(untagged)]
+enum CdxDatasetChoice {
+    Reference {
+        #[serde(rename = "ref")]
+        reference: String,
+    },
+    Inline(CdxDatasetInline),
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct CdxQuantization {
-    mode: Option<String>,
+struct CdxDatasetInline {
+    name: Option<String>,
+    /// Non-spec; spec `componentData` datasets have no purl.
+    purl: Option<String>,
+}
+
+impl CdxDatasetChoice {
+    fn to_model(&self) -> crate::model::DatasetRef {
+        match self {
+            Self::Reference { reference } => crate::model::DatasetRef {
+                reference: Some(reference.clone()),
+                name: None,
+                purl: None,
+            },
+            Self::Inline(inline) => crate::model::DatasetRef {
+                reference: None,
+                name: inline.name.clone(),
+                purl: inline.purl.clone(),
+            },
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct CdxConsiderations {
+    #[serde(default)]
+    technical_limitations: Vec<String>,
     environmental_considerations: Option<CdxEnvironmentalConsiderations>,
 }
 
@@ -1541,8 +1580,43 @@ struct CdxEnvironmentalConsiderations {
 struct CdxEnergyConsumption {
     #[serde(alias = "type")]
     activity: Option<String>,
+    /// Spec: `activityEnergyCost` is an energyMeasure `{ value, unit }`.
+    activity_energy_cost: Option<CdxEnergyMeasure>,
+    /// Non-spec flat kWh value; fallback only.
     #[serde(rename = "energyKwh", alias = "value")]
     energy_kwh: Option<f64>,
+}
+
+impl CdxEnergyConsumption {
+    /// Training energy in kWh: prefer the spec `activityEnergyCost` (unit-normalized),
+    /// otherwise the non-spec flat value.
+    fn training_energy_kwh(&self) -> Option<f64> {
+        self.activity_energy_cost
+            .as_ref()
+            .map(CdxEnergyMeasure::as_kwh)
+            .or(self.energy_kwh)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CdxEnergyMeasure {
+    value: f64,
+    unit: Option<String>,
+}
+
+impl CdxEnergyMeasure {
+    /// Normalize the measure to kWh based on its unit (defaults to kWh when unspecified).
+    fn as_kwh(&self) -> f64 {
+        match self.unit.as_deref() {
+            Some("Wh") => self.value / 1_000.0,
+            Some("MWh") => self.value * 1_000.0,
+            Some("J") => self.value / 3_600_000.0,
+            Some("kJ") => self.value / 3_600.0,
+            Some("MJ") => self.value / 3.6,
+            _ => self.value,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -1550,16 +1624,88 @@ struct CdxEnergyConsumption {
 struct CdxDataComponent {
     #[serde(rename = "type")]
     data_type: Option<String>,
-    #[serde(default)]
+    /// Spec key is `sensitiveData`; `sensitivityData` accepted for non-spec emitters.
+    #[serde(rename = "sensitiveData", alias = "sensitivityData", default)]
     sensitivity_data: Vec<String>,
     governance: Option<CdxDataGovernance>,
 }
 
-#[derive(Debug, Deserialize)]
+/// Accept `component.data` as either the spec array of componentData or a single object.
+fn deserialize_component_data<'de, D>(deserializer: D) -> Result<Vec<CdxDataComponent>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        Many(Vec<CdxDataComponent>),
+        One(CdxDataComponent),
+    }
+
+    Ok(match Option::<OneOrMany>::deserialize(deserializer)? {
+        None => Vec::new(),
+        Some(OneOrMany::Many(items)) => items,
+        Some(OneOrMany::One(item)) => vec![item],
+    })
+}
+
+#[derive(Debug, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 struct CdxDataGovernance {
     #[serde(default)]
-    owners: Vec<String>,
+    owners: Vec<CdxGovParty>,
+    #[serde(default)]
+    custodians: Vec<CdxGovParty>,
+    #[serde(default)]
+    stewards: Vec<CdxGovParty>,
+}
+
+/// A data-governance responsible party: the spec object `{ organization | contact }`,
+/// or a bare string for non-spec emitters.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum CdxGovParty {
+    Text(String),
+    Structured(CdxGovPartyObj),
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct CdxGovPartyObj {
+    organization: Option<CdxGovOrganization>,
+    contact: Option<CdxGovContact>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CdxGovOrganization {
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CdxGovContact {
+    name: Option<String>,
+    email: Option<String>,
+}
+
+impl CdxGovParty {
+    /// A human-readable display name for a governance party.
+    fn display_name(&self) -> Option<String> {
+        match self {
+            Self::Text(text) => Some(text.clone()),
+            Self::Structured(party) => party
+                .organization
+                .as_ref()
+                .and_then(|org| org.name.clone())
+                .or_else(|| {
+                    party
+                        .contact
+                        .as_ref()
+                        .and_then(|contact| contact.name.clone().or_else(|| contact.email.clone()))
+                }),
+        }
+    }
 }
 
 // ── CycloneDX Crypto Deserialization Structs (1.6+) ─────────────────────

--- a/tests/fixtures/cyclonedx/minimal-dataset.cdx.json
+++ b/tests/fixtures/cyclonedx/minimal-dataset.cdx.json
@@ -1,0 +1,87 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-03-27T00:00:00Z",
+    "tools": [
+      {
+        "vendor": "sbom-tools",
+        "name": "sbom-tools",
+        "version": "0.1.17"
+      }
+    ],
+    "component": {
+      "bom-ref": "root",
+      "type": "application",
+      "name": "test-dataset-app",
+      "version": "1.0.0"
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "dataset-training-1",
+      "type": "data",
+      "name": "training-dataset-v1",
+      "version": "1.0.0",
+      "description": "Primary training dataset for model development",
+      "data": {
+        "type": "training",
+        "contents": {
+          "properties": [
+            {
+              "name": "size",
+              "value": "500GB"
+            },
+            {
+              "name": "records",
+              "value": "10M"
+            },
+            {
+              "name": "format",
+              "value": "parquet"
+            }
+          ]
+        },
+        "sensitivityData": [
+          "pii",
+          "phi"
+        ],
+        "governance": {
+          "owners": [
+            "data-team@example.com",
+            "ml-ops@example.com"
+          ]
+        }
+      }
+    },
+    {
+      "bom-ref": "dataset-validation-1",
+      "type": "data",
+      "name": "validation-dataset-v1",
+      "version": "1.0.0",
+      "description": "Validation dataset for model evaluation",
+      "data": {
+        "type": "validation",
+        "sensitivityData": [
+          "pii"
+        ]
+      }
+    },
+    {
+      "bom-ref": "dataset-test-1",
+      "type": "data",
+      "name": "test-dataset-v1",
+      "version": "1.0.0",
+      "description": "Test dataset for final model evaluation",
+      "data": {
+        "type": "testing",
+        "governance": {
+          "owners": [
+            "qa-team@example.com"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/cyclonedx/minimal-dataset.cdx.json
+++ b/tests/fixtures/cyclonedx/minimal-dataset.cdx.json
@@ -25,35 +25,45 @@
       "name": "training-dataset-v1",
       "version": "1.0.0",
       "description": "Primary training dataset for model development",
-      "data": {
-        "type": "training",
-        "contents": {
-          "properties": [
-            {
-              "name": "size",
-              "value": "500GB"
-            },
-            {
-              "name": "records",
-              "value": "10M"
-            },
-            {
-              "name": "format",
-              "value": "parquet"
-            }
-          ]
-        },
-        "sensitivityData": [
-          "pii",
-          "phi"
-        ],
-        "governance": {
-          "owners": [
-            "data-team@example.com",
-            "ml-ops@example.com"
-          ]
+      "data": [
+        {
+          "type": "dataset",
+          "name": "training-corpus",
+          "sensitiveData": [
+            "pii",
+            "phi"
+          ],
+          "governance": {
+            "owners": [
+              {
+                "organization": {
+                  "name": "Data Platform Team"
+                }
+              },
+              {
+                "contact": {
+                  "name": "Jane Doe",
+                  "email": "jane@example.com"
+                }
+              }
+            ],
+            "custodians": [
+              {
+                "organization": {
+                  "name": "ML Ops"
+                }
+              }
+            ],
+            "stewards": [
+              {
+                "contact": {
+                  "email": "steward@example.com"
+                }
+              }
+            ]
+          }
         }
-      }
+      ]
     },
     {
       "bom-ref": "dataset-validation-1",
@@ -61,24 +71,30 @@
       "name": "validation-dataset-v1",
       "version": "1.0.0",
       "description": "Validation dataset for model evaluation",
-      "data": {
-        "type": "validation",
-        "sensitivityData": [
-          "pii"
-        ]
-      }
+      "data": [
+        {
+          "type": "dataset",
+          "name": "validation-corpus",
+          "sensitiveData": [
+            "pii"
+          ]
+        }
+      ]
     },
     {
-      "bom-ref": "dataset-test-1",
+      "bom-ref": "dataset-legacy-1",
       "type": "data",
-      "name": "test-dataset-v1",
+      "name": "legacy-dataset-v1",
       "version": "1.0.0",
-      "description": "Test dataset for final model evaluation",
+      "description": "Legacy emitter: single-object data, sensitivityData, string owners (tolerated)",
       "data": {
-        "type": "testing",
+        "type": "dataset",
+        "sensitivityData": [
+          "confidential"
+        ],
         "governance": {
           "owners": [
-            "qa-team@example.com"
+            "legacy-team@example.com"
           ]
         }
       }

--- a/tests/fixtures/cyclonedx/minimal-mlbom.cdx.json
+++ b/tests/fixtures/cyclonedx/minimal-mlbom.cdx.json
@@ -25,41 +25,39 @@
       "name": "bert-base",
       "version": "1.0.0",
       "description": "BERT base model for NLP tasks",
-      "mlModel": {
+      "modelCard": {
         "approach": {
           "type": "supervised"
         },
         "architectureFamily": "transformer",
-        "modelCard": {
-          "modelParameters": {
-            "task": "nlp",
-            "architecture": {
-              "name": "bert"
+        "modelParameters": {
+          "task": "nlp",
+          "architecture": {
+            "name": "bert"
+          },
+          "datasets": [
+            {
+              "name": "wikipedia-2.5B",
+              "purl": "pkg:generic/wikipedia/2.5B"
             },
-            "datasets": [
+            {
+              "name": "bookscorpus-800M",
+              "purl": "pkg:generic/bookscorpus/800M"
+            }
+          ]
+        },
+        "quantization": {
+          "mode": "fp32"
+        },
+        "limitations": "Optimized for English text; may not generalize to non-English languages.",
+        "considerations": {
+          "environmentalConsiderations": {
+            "energyConsumptions": [
               {
-                "name": "wikipedia-2.5B",
-                "purl": "pkg:generic/wikipedia/2.5B"
-              },
-              {
-                "name": "bookscorpus-800M",
-                "purl": "pkg:generic/bookscorpus/800M"
+                "type": "training",
+                "value": 1500.0
               }
             ]
-          },
-          "quantization": {
-            "mode": "fp32"
-          },
-          "limitations": "Optimized for English text; may not generalize to non-English languages.",
-          "considerations": {
-            "environmentalConsiderations": {
-              "energyConsumptions": [
-                {
-                  "type": "training",
-                  "value": 1500.0
-                }
-              ]
-            }
           }
         }
       },
@@ -76,23 +74,21 @@
       "name": "gpt-2",
       "version": "2.0.0",
       "description": "GPT-2 language model",
-      "mlModel": {
+      "modelCard": {
         "approach": {
           "type": "unsupervised"
         },
         "architectureFamily": "transformer",
-        "modelCard": {
-          "modelParameters": {
-            "task": "nlp",
-            "architecture": {
-              "name": "gpt"
-            }
-          },
-          "quantization": {
-            "mode": "int8"
-          },
-          "limitations": "May generate biased or harmful content."
-        }
+        "modelParameters": {
+          "task": "nlp",
+          "architecture": {
+            "name": "gpt"
+          }
+        },
+        "quantization": {
+          "mode": "int8"
+        },
+        "limitations": "May generate biased or harmful content."
       }
     }
   ]

--- a/tests/fixtures/cyclonedx/minimal-mlbom.cdx.json
+++ b/tests/fixtures/cyclonedx/minimal-mlbom.cdx.json
@@ -1,0 +1,99 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-03-27T00:00:00Z",
+    "tools": [
+      {
+        "vendor": "sbom-tools",
+        "name": "sbom-tools",
+        "version": "0.1.17"
+      }
+    ],
+    "component": {
+      "bom-ref": "root",
+      "type": "application",
+      "name": "test-mlbom-app",
+      "version": "1.0.0"
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "ml-model-1",
+      "type": "machine-learning-model",
+      "name": "bert-base",
+      "version": "1.0.0",
+      "description": "BERT base model for NLP tasks",
+      "mlModel": {
+        "approach": {
+          "type": "supervised"
+        },
+        "architectureFamily": "transformer",
+        "modelCard": {
+          "modelParameters": {
+            "task": "nlp",
+            "architecture": {
+              "name": "bert"
+            },
+            "datasets": [
+              {
+                "name": "wikipedia-2.5B",
+                "purl": "pkg:generic/wikipedia/2.5B"
+              },
+              {
+                "name": "bookscorpus-800M",
+                "purl": "pkg:generic/bookscorpus/800M"
+              }
+            ]
+          },
+          "quantization": {
+            "mode": "fp32"
+          },
+          "limitations": "Optimized for English text; may not generalize to non-English languages.",
+          "considerations": {
+            "environmentalConsiderations": {
+              "energyConsumptions": [
+                {
+                  "type": "training",
+                  "value": 1500.0
+                }
+              ]
+            }
+          }
+        }
+      },
+      "externalReferences": [
+        {
+          "type": "model-card",
+          "url": "https://huggingface.co/google-bert/bert-base-uncased"
+        }
+      ]
+    },
+    {
+      "bom-ref": "ml-model-2",
+      "type": "machine-learning-model",
+      "name": "gpt-2",
+      "version": "2.0.0",
+      "description": "GPT-2 language model",
+      "mlModel": {
+        "approach": {
+          "type": "unsupervised"
+        },
+        "architectureFamily": "transformer",
+        "modelCard": {
+          "modelParameters": {
+            "task": "nlp",
+            "architecture": {
+              "name": "gpt"
+            }
+          },
+          "quantization": {
+            "mode": "int8"
+          },
+          "limitations": "May generate biased or harmful content."
+        }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/cyclonedx/minimal-mlbom.cdx.json
+++ b/tests/fixtures/cyclonedx/minimal-mlbom.cdx.json
@@ -26,36 +26,35 @@
       "version": "1.0.0",
       "description": "BERT base model for NLP tasks",
       "modelCard": {
-        "approach": {
-          "type": "supervised"
-        },
-        "architectureFamily": "transformer",
         "modelParameters": {
-          "task": "nlp",
-          "architecture": {
-            "name": "bert"
+          "approach": {
+            "type": "supervised"
           },
+          "task": "nlp",
+          "architectureFamily": "transformer",
+          "modelArchitecture": "bert",
           "datasets": [
             {
-              "name": "wikipedia-2.5B",
-              "purl": "pkg:generic/wikipedia/2.5B"
+              "ref": "data-wikipedia"
             },
             {
-              "name": "bookscorpus-800M",
-              "purl": "pkg:generic/bookscorpus/800M"
+              "type": "dataset",
+              "name": "bookscorpus-800M"
             }
           ]
         },
-        "quantization": {
-          "mode": "fp32"
-        },
-        "limitations": "Optimized for English text; may not generalize to non-English languages.",
         "considerations": {
+          "technicalLimitations": [
+            "Optimized for English text; may not generalize to non-English languages."
+          ],
           "environmentalConsiderations": {
             "energyConsumptions": [
               {
-                "type": "training",
-                "value": 1500.0
+                "activity": "training",
+                "activityEnergyCost": {
+                  "value": 1500.0,
+                  "unit": "kWh"
+                }
               }
             ]
           }
@@ -75,21 +74,43 @@
       "version": "2.0.0",
       "description": "GPT-2 language model",
       "modelCard": {
-        "approach": {
-          "type": "unsupervised"
-        },
-        "architectureFamily": "transformer",
         "modelParameters": {
+          "approach": {
+            "type": "unsupervised"
+          },
           "task": "nlp",
-          "architecture": {
-            "name": "gpt"
-          }
+          "architectureFamily": "transformer",
+          "modelArchitecture": "gpt"
         },
-        "quantization": {
-          "mode": "int8"
-        },
-        "limitations": "May generate biased or harmful content."
+        "considerations": {
+          "technicalLimitations": [
+            "May generate biased or harmful content."
+          ]
+        }
       }
+    },
+    {
+      "bom-ref": "data-wikipedia",
+      "type": "data",
+      "name": "wikipedia-2.5B",
+      "data": [
+        {
+          "type": "dataset",
+          "name": "wikipedia-dump",
+          "sensitiveData": [
+            "none"
+          ],
+          "governance": {
+            "owners": [
+              {
+                "organization": {
+                  "name": "Wikimedia Foundation"
+                }
+              }
+            ]
+          }
+        }
+      ]
     }
   ]
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -336,6 +336,66 @@ mod parser_tests {
         }
     }
 
+    #[test]
+    fn test_parse_cyclonedx_mlbom_fixture() {
+        let path = fixture_path("cyclonedx/minimal-mlbom.cdx.json");
+        let sbom = parse_sbom(&path).expect("Failed to parse CycloneDX ML BOM fixture");
+
+        assert_eq!(sbom.component_count(), 3);
+
+        let bert = sbom
+            .components
+            .values()
+            .find(|c| c.name == "bert-base")
+            .expect("bert-base not found");
+        assert_eq!(
+            bert.component_type,
+            sbom_tools::model::ComponentType::MachineLearningModel
+        );
+
+        let ml_info = bert.ml_model.as_ref().expect("ML metadata missing");
+        assert_eq!(ml_info.approach.as_deref(), Some("supervised"));
+        assert_eq!(ml_info.architecture_family.as_deref(), Some("transformer"));
+        assert_eq!(ml_info.architecture_name.as_deref(), Some("bert"));
+        assert_eq!(ml_info.task.as_deref(), Some("nlp"));
+        assert_eq!(ml_info.quantization.as_deref(), Some("fp32"));
+        assert_eq!(ml_info.energy_kwh_training, Some(1500.0));
+        assert_eq!(ml_info.training_datasets.len(), 2);
+        assert_eq!(
+            ml_info.model_card_url.as_deref(),
+            Some("https://huggingface.co/google-bert/bert-base-uncased")
+        );
+    }
+
+    #[test]
+    fn test_parse_cyclonedx_dataset_fixture() {
+        let path = fixture_path("cyclonedx/minimal-dataset.cdx.json");
+        let sbom = parse_sbom(&path).expect("Failed to parse CycloneDX dataset fixture");
+
+        assert_eq!(sbom.component_count(), 4);
+
+        let training_dataset = sbom
+            .components
+            .values()
+            .find(|c| c.name == "training-dataset-v1")
+            .expect("training dataset not found");
+        assert_eq!(
+            training_dataset.component_type,
+            sbom_tools::model::ComponentType::Data
+        );
+
+        let dataset = training_dataset
+            .dataset
+            .as_ref()
+            .expect("dataset metadata missing");
+        assert_eq!(dataset.dataset_type.as_deref(), Some("training"));
+        assert_eq!(dataset.sensitivity_classifications, vec!["pii", "phi"]);
+        assert_eq!(
+            dataset.governance_owners,
+            vec!["data-team@example.com", "ml-ops@example.com"]
+        );
+    }
+
     // ========================================================================
     // SPDX 3.0 Parser Tests
     // ========================================================================
@@ -747,6 +807,42 @@ mod diff_engine_tests {
                 "After filtering, only critical vulns should remain"
             );
         }
+    }
+
+    #[test]
+    fn test_diff_detects_ml_model_metadata_changes() {
+        let path = fixture_path("cyclonedx/minimal-mlbom.cdx.json");
+        let old = parse_sbom(&path).expect("Failed to parse ML BOM fixture");
+        let mut new = old.clone();
+
+        let model = new
+            .components
+            .values_mut()
+            .find(|c| c.name == "bert-base")
+            .expect("bert-base not found");
+        let ml_info = model.ml_model.as_mut().expect("ML metadata missing");
+        ml_info.quantization = Some("int4".to_string());
+        model.calculate_content_hash();
+        new.calculate_content_hash();
+
+        let engine = DiffEngine::new();
+        let result = engine.diff(&old, &new).expect("diff should succeed");
+
+        assert_eq!(result.summary.components_modified, 1);
+        let change = result
+            .components
+            .modified
+            .iter()
+            .find(|change| change.name == "bert-base")
+            .expect("bert-base change not found");
+        assert!(
+            change
+                .field_changes
+                .iter()
+                .any(|field| field.field == "ml_model"),
+            "Expected ml_model field change, got {:?}",
+            change.field_changes
+        );
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -368,6 +368,45 @@ mod parser_tests {
     }
 
     #[test]
+    fn test_parse_cyclonedx_model_card_sums_training_energy() {
+        let content = r#"{
+                    "bomFormat": "CycloneDX",
+                    "specVersion": "1.6",
+                    "version": 1,
+                    "components": [
+                        {
+                            "bom-ref": "ml-model-1",
+                            "type": "machine-learning-model",
+                            "name": "bert-base",
+                            "modelCard": {
+                                "approach": { "type": "supervised" },
+                                "architectureFamily": "transformer",
+                                "considerations": {
+                                    "environmentalConsiderations": {
+                                        "energyConsumptions": [
+                                            { "type": "training", "value": 100.0 },
+                                            { "type": "inference", "value": 5.0 },
+                                            { "type": "training", "value": 25.0 }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }"#;
+
+        let sbom = parse_sbom_str(content).expect("Failed to parse CycloneDX model card");
+        let model = sbom
+            .components
+            .values()
+            .find(|c| c.name == "bert-base")
+            .expect("bert-base not found");
+        let ml_info = model.ml_model.as_ref().expect("ML metadata missing");
+
+        assert_eq!(ml_info.energy_kwh_training, Some(125.0));
+    }
+
+    #[test]
     fn test_parse_cyclonedx_dataset_fixture() {
         let path = fixture_path("cyclonedx/minimal-dataset.cdx.json");
         let sbom = parse_sbom(&path).expect("Failed to parse CycloneDX dataset fixture");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -341,7 +341,7 @@ mod parser_tests {
         let path = fixture_path("cyclonedx/minimal-mlbom.cdx.json");
         let sbom = parse_sbom(&path).expect("Failed to parse CycloneDX ML BOM fixture");
 
-        assert_eq!(sbom.component_count(), 3);
+        assert_eq!(sbom.component_count(), 4);
 
         let bert = sbom
             .components
@@ -354,13 +354,32 @@ mod parser_tests {
         );
 
         let ml_info = bert.ml_model.as_ref().expect("ML metadata missing");
+        // Spec nesting: approach/architectureFamily/modelArchitecture/task live under modelParameters.
         assert_eq!(ml_info.approach.as_deref(), Some("supervised"));
         assert_eq!(ml_info.architecture_family.as_deref(), Some("transformer"));
+        // architecture_name is read from the spec `modelArchitecture` string.
         assert_eq!(ml_info.architecture_name.as_deref(), Some("bert"));
         assert_eq!(ml_info.task.as_deref(), Some("nlp"));
-        assert_eq!(ml_info.quantization.as_deref(), Some("fp32"));
+        // `quantization` has no home in the CycloneDX 1.6 modelCard schema → never populated.
+        assert_eq!(ml_info.quantization, None);
+        // Limitations come from considerations.technicalLimitations (array).
+        assert_eq!(
+            ml_info.limitations.as_deref(),
+            Some("Optimized for English text; may not generalize to non-English languages.")
+        );
+        // Energy from considerations.environmentalConsiderations[].activityEnergyCost.value (kWh).
         assert_eq!(ml_info.energy_kwh_training, Some(1500.0));
+        // datasets: one spec `{ref}` data-reference and one inline componentData.
         assert_eq!(ml_info.training_datasets.len(), 2);
+        assert_eq!(
+            ml_info.training_datasets[0].reference.as_deref(),
+            Some("data-wikipedia")
+        );
+        assert_eq!(ml_info.training_datasets[0].name, None);
+        assert_eq!(
+            ml_info.training_datasets[1].name.as_deref(),
+            Some("bookscorpus-800M")
+        );
         assert_eq!(
             ml_info.model_card_url.as_deref(),
             Some("https://huggingface.co/google-bert/bert-base-uncased")
@@ -369,6 +388,8 @@ mod parser_tests {
 
     #[test]
     fn test_parse_cyclonedx_model_card_sums_training_energy() {
+        // Spec shape: energyConsumption.activity + activityEnergyCost { value, unit }.
+        // Only "training" activities are summed; other activities are excluded.
         let content = r#"{
                     "bomFormat": "CycloneDX",
                     "specVersion": "1.6",
@@ -379,14 +400,16 @@ mod parser_tests {
                             "type": "machine-learning-model",
                             "name": "bert-base",
                             "modelCard": {
-                                "approach": { "type": "supervised" },
-                                "architectureFamily": "transformer",
+                                "modelParameters": {
+                                    "approach": { "type": "supervised" },
+                                    "architectureFamily": "transformer"
+                                },
                                 "considerations": {
                                     "environmentalConsiderations": {
                                         "energyConsumptions": [
-                                            { "type": "training", "value": 100.0 },
-                                            { "type": "inference", "value": 5.0 },
-                                            { "type": "training", "value": 25.0 }
+                                            { "activity": "training", "activityEnergyCost": { "value": 100.0, "unit": "kWh" } },
+                                            { "activity": "inference", "activityEnergyCost": { "value": 5.0, "unit": "kWh" } },
+                                            { "activity": "training", "activityEnergyCost": { "value": 25.0, "unit": "kWh" } }
                                         ]
                                     }
                                 }
@@ -427,11 +450,83 @@ mod parser_tests {
             .dataset
             .as_ref()
             .expect("dataset metadata missing");
-        assert_eq!(dataset.dataset_type.as_deref(), Some("training"));
+        // componentData.type uses the spec enum ("dataset"), parsed from the `data` array.
+        assert_eq!(dataset.dataset_type.as_deref(), Some("dataset"));
+        // Spec key is `sensitiveData`.
         assert_eq!(dataset.sensitivity_classifications, vec!["pii", "phi"]);
+        // owners + custodians + stewards are folded in, as display names (org name, else
+        // contact name, else contact email), preserving owners -> custodians -> stewards order.
         assert_eq!(
             dataset.governance_owners,
-            vec!["data-team@example.com", "ml-ops@example.com"]
+            vec![
+                "Data Platform Team",
+                "Jane Doe",
+                "ML Ops",
+                "steward@example.com"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_cyclonedx_data_component_array_and_tolerance() {
+        // Regression: spec `component.data` is an ARRAY of componentData. A spec-compliant
+        // array previously failed to parse the ENTIRE SBOM; assert it now parses end-to-end
+        // and that object-form governance parties + sensitiveData are extracted.
+        let content = r#"{
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.6",
+            "version": 1,
+            "components": [
+                {
+                    "bom-ref": "ds-spec",
+                    "type": "data",
+                    "name": "spec-array-dataset",
+                    "data": [
+                        {
+                            "type": "dataset",
+                            "name": "corpus",
+                            "sensitiveData": ["pii"],
+                            "governance": {
+                                "owners": [ { "organization": { "name": "Acme AI" } } ],
+                                "custodians": [ { "contact": { "name": "Custodian C" } } ]
+                            }
+                        }
+                    ]
+                }
+            ]
+        }"#;
+
+        let sbom = parse_sbom_str(content).expect("spec array-form `data` must parse");
+        let ds = sbom
+            .components
+            .values()
+            .find(|c| c.name == "spec-array-dataset")
+            .expect("dataset component not found");
+        let info = ds.dataset.as_ref().expect("dataset metadata missing");
+        assert_eq!(info.dataset_type.as_deref(), Some("dataset"));
+        assert_eq!(info.sensitivity_classifications, vec!["pii"]);
+        assert_eq!(info.governance_owners, vec!["Acme AI", "Custodian C"]);
+
+        // Backward-compat: the legacy single-object `data`, the `sensitivityData` key, and
+        // bare-string governance owners are still tolerated (see the fixture's legacy component).
+        let legacy_path = fixture_path("cyclonedx/minimal-dataset.cdx.json");
+        let legacy_sbom = parse_sbom(&legacy_path).expect("Failed to parse dataset fixture");
+        let legacy = legacy_sbom
+            .components
+            .values()
+            .find(|c| c.name == "legacy-dataset-v1")
+            .expect("legacy dataset not found");
+        let legacy_info = legacy
+            .dataset
+            .as_ref()
+            .expect("legacy dataset metadata missing");
+        assert_eq!(
+            legacy_info.sensitivity_classifications,
+            vec!["confidential"]
+        );
+        assert_eq!(
+            legacy_info.governance_owners,
+            vec!["legacy-team@example.com"]
         );
     }
 


### PR DESCRIPTION
## Summary

Delivers the CycloneDX ML/AI BOM parser/model from #138 (by @MChorfa) **with the spec-compliance regressions fixed**. A multi-agent review of #138 against the official CycloneDX 1.6 schema confirmed all four maintainer blockers + five nits were resolved, but uncovered new defects: the parser **hard-failed on spec-valid input** and silently extracted nothing for real ML BOMs. This PR keeps #138's (superior) design — dedicated diff cost fields, `#[non_exhaustive]`/`PartialEq`/`Eq`, deterministic float-canonical hashing — and corrects the deserialization shapes + fixtures.

**Supersedes #138.** Schema shapes verified directly against `CycloneDX/specification@1.6/schema/bom-1.6.schema.json`.

## Fixes

| Sev | Fix |
|-----|-----|
| **blocker** | `component.data` is an **array** of componentData; was a single object, so a spec `"data":[…]` made serde fail the **entire document** (regression vs main, which ignored the field). Now accepts array or single object. |
| high | `dataGovernance` owners/custodians/stewards are **party objects** `{organization\|contact}`, not strings — object owners previously failed the whole parse. Now parsed as objects (bare strings still tolerated), folded into `governance_owners` as display names. |
| high | modelCard nesting: `approach`/`architectureFamily`/`modelArchitecture`/`task`/`datasets` read from `modelParameters`; `limitations` from `considerations.technicalLimitations`. |
| high | training energy read from `activityEnergyCost.value` (unit-normalized to kWh), flat `energyKwh`/`value` kept as fallback. |
| med | architecture name from spec `modelArchitecture` (string); `sensitiveData` key (with `sensitivityData` alias); dataset `{ref}` + inline forms handled; fabricated `purl` dropped. |
| — | `quantization` has no home in the 1.6 modelCard schema → no longer parsed. |

`DatasetRef` gains a `reference` field (`#[non_exhaustive]`, non-breaking) for the `{ref}` form.

## Tolerance
Every fix prefers the spec shape but keeps an alias/object-or-array fallback so non-spec emitters (and the original fixtures' shapes) still parse — see `test_parse_cyclonedx_data_component_array_and_tolerance`.

## Tests / fixtures
`minimal-mlbom` and `minimal-dataset` re-derived from spec-valid shapes (array `data`, `modelParameters` nesting, `activityEnergyCost`, `sensitiveData`, governance party objects). Tests assert spec extraction; a new regression test guards the array-`data` hard-fail and legacy tolerance.

## Verification (pinned 1.88 toolchain = CI)
- `cargo test --all-features` — **0 failed** (lib 790, integration 105, all other binaries green; 5 ML BOM tests pass)
- `cargo clippy -- -D warnings` **and** `--all-features` — clean, no new `#[allow]`
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)