### PR TITLE
feat(sarif): SBOM-AIBOM-* SARIF rule family for AI-readiness (closes #185)

### DIFF
--- a/src/cli/quality.rs
+++ b/src/cli/quality.rs
@@ -184,6 +184,30 @@ fn format_quality_json(report: &QualityReport, config: &QualityConfig) -> String
 
 /// Format quality report as SARIF 2.1.0
 fn format_quality_sarif(report: &QualityReport, config: &QualityConfig) -> String {
+    // AI-readiness uses a dedicated SBOM-AIBOM-* SARIF rule family (one result per
+    // failing model-card check), with a rule table and run-level properties.
+    if report.profile == ScoringProfile::AiReadiness
+        && let Some(metrics) = report.ai_readiness_metrics.as_ref()
+    {
+        let na = metrics.is_not_applicable();
+        let score = if na { None } else { Some(report.overall_score) };
+        let grade = if na { "N/A" } else { report.grade.letter() };
+        return crate::reports::generate_ai_readiness_sarif(
+            metrics,
+            &config
+                .sbom_path
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy(),
+            &config.profile,
+            score,
+            grade,
+        )
+        .unwrap_or_else(|_| {
+            serde_json::to_string_pretty(&serde_json::json!({ "runs": [] })).unwrap_or_default()
+        });
+    }
+
     let not_applicable = report
         .ai_readiness_metrics
         .as_ref()
@@ -706,9 +730,20 @@ mod tests {
         let report = QualityScorer::new(ScoringProfile::AiReadiness).score(&sbom);
         let out = format_quality_sarif(&report, &ai_config(ReportFormat::Sarif, None));
         let value: serde_json::Value = serde_json::from_str(&out).expect("valid SARIF JSON");
-        let props = &value["runs"][0]["properties"];
+        let run = &value["runs"][0];
+        let props = &run["properties"];
         assert_eq!(props["applicable"], json!(false));
         assert!(props["overall_score"].is_null());
         assert_eq!(props["grade"], json!("N/A"));
+        // The dedicated SBOM-AIBOM-* rule family is now emitted (was absent before),
+        // and N/A yields no findings.
+        let rules = run["tool"]["driver"]["rules"]
+            .as_array()
+            .expect("rules array");
+        assert!(
+            rules.iter().any(|r| r["id"] == json!("SBOM-AIBOM-001")),
+            "expected SBOM-AIBOM rule table"
+        );
+        assert!(run["results"].as_array().expect("results array").is_empty());
     }
 }

--- a/src/reports/mod.rs
+++ b/src/reports/mod.rs
@@ -34,7 +34,9 @@ pub use html::HtmlReporter;
 pub use json::JsonReporter;
 pub use markdown::MarkdownReporter;
 pub use sarif::SarifReporter;
-pub use sarif::{generate_compliance_sarif, generate_multi_compliance_sarif};
+pub use sarif::{
+    generate_ai_readiness_sarif, generate_compliance_sarif, generate_multi_compliance_sarif,
+};
 pub use sidebyside::SideBySideReporter;
 pub use streaming::{NdjsonReporter, NdjsonWriter, StreamingJsonReporter, StreamingJsonWriter};
 pub use summary::{SummaryReporter, TableReporter};

--- a/src/reports/sarif.rs
+++ b/src/reports/sarif.rs
@@ -252,6 +252,7 @@ impl ReportGenerator for SarifReporter {
                     },
                 },
                 results,
+                properties: None,
             }],
         };
 
@@ -316,6 +317,7 @@ impl ReportGenerator for SarifReporter {
                     },
                 },
                 results,
+                properties: None,
             }],
         };
 
@@ -326,6 +328,186 @@ impl ReportGenerator for SarifReporter {
     fn format(&self) -> ReportFormat {
         ReportFormat::Sarif
     }
+}
+
+/// Map an AI-readiness check ID (`AI-001`..`AI-009`) to its SARIF rule ID.
+/// Unknown IDs fall back to the `SBOM-AIBOM-GENERAL` rule so a future tenth
+/// check never silently drops (`AiCheck`/`AiReadinessMetrics` are `#[non_exhaustive]`).
+fn ai_check_to_rule_id(check_id: &str) -> &'static str {
+    match check_id {
+        "AI-001" => "SBOM-AIBOM-001",
+        "AI-002" => "SBOM-AIBOM-002",
+        "AI-003" => "SBOM-AIBOM-003",
+        "AI-004" => "SBOM-AIBOM-004",
+        "AI-005" => "SBOM-AIBOM-005",
+        "AI-006" => "SBOM-AIBOM-006",
+        "AI-007" => "SBOM-AIBOM-007",
+        "AI-008" => "SBOM-AIBOM-008",
+        "AI-009" => "SBOM-AIBOM-009",
+        _ => "SBOM-AIBOM-GENERAL",
+    }
+}
+
+/// Default SARIF severity for each AI-readiness check. AI transparency is a
+/// best-practice (not a mandated minimum element), so there are no hard
+/// `error`s; documentation gaps are `warning`, softer/contextual gaps `note`.
+/// This is the single source of truth shared by the rule table and the results.
+fn aibom_level(check_id: &str) -> SarifLevel {
+    match check_id {
+        "AI-001" | "AI-002" | "AI-003" | "AI-005" | "AI-009" => SarifLevel::Warning,
+        _ => SarifLevel::Note,
+    }
+}
+
+/// SARIF rule table for the AI BOM model-card completeness checks. The
+/// `short_description` text matches the scorer's `CHECK_DEFS` names exactly.
+fn get_sarif_aibom_rules() -> Vec<SarifRule> {
+    // (rule id, AI check id for level lookup, PascalCase name, description).
+    // Descriptions match the scorer's CHECK_DEFS names exactly.
+    [
+        (
+            "SBOM-AIBOM-001",
+            "AI-001",
+            "AibomModelCardUrl",
+            "Model card URL present",
+        ),
+        (
+            "SBOM-AIBOM-002",
+            "AI-002",
+            "AibomArchitectureFamily",
+            "Architecture family declared",
+        ),
+        (
+            "SBOM-AIBOM-003",
+            "AI-003",
+            "AibomTrainingDatasets",
+            "Training datasets referenced",
+        ),
+        (
+            "SBOM-AIBOM-004",
+            "AI-004",
+            "AibomQuantitativeAnalysis",
+            "Quantitative analysis present",
+        ),
+        (
+            "SBOM-AIBOM-005",
+            "AI-005",
+            "AibomFairnessAssessment",
+            "Fairness assessments included",
+        ),
+        (
+            "SBOM-AIBOM-006",
+            "AI-006",
+            "AibomEnergyConsumption",
+            "Energy consumption disclosed",
+        ),
+        (
+            "SBOM-AIBOM-007",
+            "AI-007",
+            "AibomUseCases",
+            "Use-cases documented",
+        ),
+        (
+            "SBOM-AIBOM-008",
+            "AI-008",
+            "AibomLimitations",
+            "Known limitations stated",
+        ),
+        (
+            "SBOM-AIBOM-009",
+            "AI-009",
+            "AibomEthicalConsiderations",
+            "Ethical considerations present",
+        ),
+        (
+            "SBOM-AIBOM-GENERAL",
+            "AI-GENERAL",
+            "AibomGeneral",
+            "AI BOM model-card completeness",
+        ),
+    ]
+    .into_iter()
+    .map(|(rule_id, check_id, name, desc)| SarifRule {
+        id: rule_id.to_string(),
+        name: name.to_string(),
+        short_description: SarifMessage {
+            text: desc.to_string(),
+        },
+        default_configuration: SarifConfiguration {
+            level: aibom_level(check_id),
+        },
+    })
+    .collect()
+}
+
+/// Generate a SARIF 2.1.0 report for an AI-readiness assessment, emitting one
+/// `SBOM-AIBOM-*` result per failing check (findings-only, mirroring the
+/// compliance SARIF). The rule table and run-level properties are always
+/// emitted, including for the not-applicable (no ML components) case.
+pub fn generate_ai_readiness_sarif(
+    metrics: &crate::quality::AiReadinessMetrics,
+    sbom_name: &str,
+    profile: &str,
+    overall_score: Option<f32>,
+    grade: &str,
+) -> Result<String, ReportError> {
+    let results: Vec<SarifResult> = metrics
+        .checks
+        .iter()
+        .filter(|check| !check.passed)
+        .map(|check| {
+            let rule_id = ai_check_to_rule_id(&check.id);
+            let detail_suffix = check
+                .detail
+                .as_ref()
+                .map(|d| format!(" — {d}"))
+                .unwrap_or_default();
+            SarifResult {
+                rule_id: rule_id.to_string(),
+                level: aibom_level(&check.id),
+                message: SarifMessage {
+                    text: format!(
+                        "AIBOM check {} failed: {} ({:.0}% weight){detail_suffix}",
+                        check.id,
+                        check.name,
+                        check.weight * 100.0
+                    ),
+                },
+                locations: vec![],
+                properties: Some(SarifResultProperties {
+                    standard_ids: vec![format!("AIBOM:{}", check.id)],
+                    standard_help_uris: rule_help_uri(rule_id)
+                        .map(|u| vec![u.to_string()])
+                        .unwrap_or_default(),
+                }),
+            }
+        })
+        .collect();
+
+    let sarif = SarifReport {
+        schema: "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json".to_string(),
+        version: "2.1.0".to_string(),
+        runs: vec![SarifRun {
+            tool: SarifTool {
+                driver: SarifDriver {
+                    name: "sbom-tools".to_string(),
+                    version: env!("CARGO_PKG_VERSION").to_string(),
+                    information_uri: "https://github.com/binarly-io/sbom-tools".to_string(),
+                    rules: SarifRuleWithUri::wrap_all(get_sarif_aibom_rules()),
+                },
+            },
+            results,
+            properties: Some(SarifRunProperties {
+                applicable: !metrics.is_not_applicable(),
+                overall_score,
+                grade: grade.to_string(),
+                sbom: sbom_name.to_string(),
+                profile: profile.to_string(),
+            }),
+        }],
+    };
+
+    serde_json::to_string_pretty(&sarif).map_err(|e| ReportError::SerializationError(e.to_string()))
 }
 
 pub fn generate_compliance_sarif(result: &ComplianceResult) -> Result<String, ReportError> {
@@ -343,6 +525,7 @@ pub fn generate_compliance_sarif(result: &ComplianceResult) -> Result<String, Re
                 },
             },
             results: compliance_results_to_sarif(result, None),
+            properties: None,
         }],
     };
 
@@ -376,6 +559,7 @@ pub fn generate_multi_compliance_sarif(
                 },
             },
             results: all_results,
+            properties: None,
         }],
     };
 
@@ -681,6 +865,8 @@ fn rule_help_uri(rule_id: &str) -> Option<&'static str> {
         )
     } else if rule_id.starts_with("SBOM-CSAF-") {
         Some("https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html")
+    } else if rule_id.starts_with("SBOM-AIBOM-") {
+        Some("https://cyclonedx.org/capabilities/mlbom/")
     } else {
         None
     }
@@ -1428,6 +1614,23 @@ struct SarifReport {
 struct SarifRun {
     tool: SarifTool,
     results: Vec<SarifResult>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    properties: Option<SarifRunProperties>,
+}
+
+/// Run-level properties for an AI-readiness SARIF report. Mirrors the run
+/// properties the hand-rolled quality SARIF emitted (minus `compliant`, which
+/// is not meaningful for an AI-only report). `overall_score` is always emitted
+/// (as `null` for the not-applicable case) so machine consumers can distinguish
+/// "score 0" from "not applicable".
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SarifRunProperties {
+    applicable: bool,
+    overall_score: Option<f32>,
+    grade: String,
+    sbom: String,
+    profile: String,
 }
 
 #[derive(Serialize)]

--- a/tests/sarif_aibom_tests.rs
+++ b/tests/sarif_aibom_tests.rs
@@ -1,0 +1,179 @@
+//! Integration tests for the SBOM-AIBOM-* SARIF rule family (#185).
+//!
+//! Builds ML BOM components via the public API, scores them with the
+//! AI-readiness profile, and renders SARIF via `generate_ai_readiness_sarif`.
+//!
+//! Note: `MlModelInfo` is `#[non_exhaustive]`, so an external crate cannot use
+//! struct-literal construction — these tests use `Default::default()` plus public
+//! field assignment. `DatasetRef` is `#[non_exhaustive]` with no `Default`, so it
+//! is not constructible here; AI-003 (training datasets) is therefore exercised as
+//! the single documentation gap rather than populated.
+
+use sbom_tools::model::{Component, ComponentType, DocumentMetadata, MlModelInfo, NormalizedSbom};
+use sbom_tools::quality::{QualityScorer, ScoringProfile};
+use sbom_tools::reports::generate_ai_readiness_sarif;
+
+fn render_sarif(sbom: &NormalizedSbom) -> serde_json::Value {
+    let report = QualityScorer::new(ScoringProfile::AiReadiness).score(sbom);
+    let metrics = report
+        .ai_readiness_metrics
+        .as_ref()
+        .expect("AI readiness metrics");
+    let na = metrics.is_not_applicable();
+    let out = generate_ai_readiness_sarif(
+        metrics,
+        "model.cdx.json",
+        "ai-readiness",
+        if na { None } else { Some(report.overall_score) },
+        if na { "N/A" } else { report.grade.letter() },
+    )
+    .expect("SARIF generation");
+    serde_json::from_str(&out).expect("valid SARIF JSON")
+}
+
+/// A `MachineLearningModel` component whose `MlModelInfo` is built via the given
+/// closure (Default + field assignment, since the type is `#[non_exhaustive]`).
+fn ml_component(configure: impl FnOnce(&mut MlModelInfo, &mut Component)) -> Component {
+    let mut component = Component::new("bert-base".to_string(), "ml-1".to_string())
+        .with_version("1.0.0".to_string());
+    component.component_type = ComponentType::MachineLearningModel;
+    let mut ml = MlModelInfo::default();
+    configure(&mut ml, &mut component);
+    component.ml_model = Some(ml);
+    component
+}
+
+fn rule_ids(value: &serde_json::Value) -> Vec<String> {
+    value["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .expect("rules array")
+        .iter()
+        .map(|r| r["id"].as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+fn result_rule_ids(value: &serde_json::Value) -> Vec<String> {
+    value["runs"][0]["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .map(|r| r["ruleId"].as_str().unwrap_or_default().to_string())
+        .collect()
+}
+
+#[test]
+fn aibom_rule_table_is_complete_with_help_uris() {
+    let value = render_sarif(&NormalizedSbom::new(DocumentMetadata::default()));
+    let ids = rule_ids(&value);
+    for n in 1..=9 {
+        assert!(
+            ids.contains(&format!("SBOM-AIBOM-{n:03}")),
+            "missing SBOM-AIBOM-{n:03}"
+        );
+    }
+    assert!(ids.contains(&"SBOM-AIBOM-GENERAL".to_string()));
+
+    for rule in value["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .unwrap()
+    {
+        assert_eq!(
+            rule["helpUri"],
+            serde_json::json!("https://cyclonedx.org/capabilities/mlbom/"),
+            "rule {} missing helpUri",
+            rule["id"]
+        );
+    }
+}
+
+#[test]
+fn aibom_not_applicable_emits_table_no_results() {
+    // No ML components → not applicable: rule table present, zero findings.
+    let value = render_sarif(&NormalizedSbom::new(DocumentMetadata::default()));
+    let run = &value["runs"][0];
+    assert_eq!(run["properties"]["applicable"], serde_json::json!(false));
+    assert!(run["properties"]["overall_score"].is_null());
+    assert_eq!(run["properties"]["grade"], serde_json::json!("N/A"));
+    assert!(run["results"].as_array().unwrap().is_empty());
+    assert!(!rule_ids(&value).is_empty());
+}
+
+#[test]
+fn aibom_emits_result_per_failing_check() {
+    // A model documenting only the URL + architecture family: AI-001/002 pass,
+    // the rest fail → seven findings with the matching rule IDs.
+    let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
+    sbom.add_component(ml_component(|ml, _comp| {
+        ml.architecture_family = Some("transformer".to_string());
+        ml.model_card_url = Some("https://example.test/card".to_string());
+    }));
+
+    let value = render_sarif(&sbom);
+    assert_eq!(
+        value["runs"][0]["properties"]["applicable"],
+        serde_json::json!(true)
+    );
+
+    let ids = result_rule_ids(&value);
+    // AI-001 (URL) and AI-002 (family) pass → no result for them.
+    assert!(!ids.contains(&"SBOM-AIBOM-001".to_string()));
+    assert!(!ids.contains(&"SBOM-AIBOM-002".to_string()));
+    // The remaining seven checks fail.
+    for n in 3..=9 {
+        assert!(
+            ids.contains(&format!("SBOM-AIBOM-{n:03}")),
+            "expected a finding for SBOM-AIBOM-{n:03}"
+        );
+    }
+
+    // A failing result carries level, message, and standard-id properties.
+    let datasets = value["runs"][0]["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["ruleId"] == serde_json::json!("SBOM-AIBOM-003"))
+        .expect("AI-003 finding");
+    assert_eq!(datasets["level"], serde_json::json!("warning"));
+    assert!(
+        datasets["message"]["text"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("AI-003")
+    );
+    assert_eq!(
+        datasets["properties"]["standardIds"][0],
+        serde_json::json!("AIBOM:AI-003")
+    );
+}
+
+#[test]
+fn aibom_passing_checks_produce_no_result() {
+    // Document everything except training datasets (AI-003): the typed checks
+    // AI-001/002/006/008 and the raw-pointer checks AI-004/005/007/009 all pass,
+    // so the ONLY finding is SBOM-AIBOM-003. Confirms passing checks are skipped.
+    let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
+    sbom.add_component(ml_component(|ml, comp| {
+        ml.architecture_family = Some("transformer".to_string());
+        ml.model_card_url = Some("https://example.test/card".to_string());
+        ml.energy_kwh_training = Some(12.5);
+        ml.limitations = Some("English only".to_string());
+        comp.extensions.raw = Some(serde_json::json!({
+            "mlModel": { "modelCard": {
+                "quantitativeAnalysis": { "performanceMetrics": [{ "type": "accuracy", "value": 0.97 }] },
+                "considerations": {
+                    "fairnessConsiderations": ["Reviewed"],
+                    "useCases": ["Classification"],
+                    "ethicalConsiderations": ["Human review required"]
+                }
+            }}
+        }));
+    }));
+
+    let value = render_sarif(&sbom);
+    let ids = result_rule_ids(&value);
+    assert_eq!(
+        ids,
+        vec!["SBOM-AIBOM-003".to_string()],
+        "only the training-datasets gap should be reported"
+    );
+}


### PR DESCRIPTION
## Summary

Closes #185. Replaces the generic `QUALITY-REC-*` output for the AI-readiness profile with a dedicated **`SBOM-AIBOM-001…009`** SARIF rule family mapped 1:1 to the nine model-card checks (AI-001…AI-009 from #205), plus an `SBOM-AIBOM-GENERAL` fallback — each with a stable PascalCase name, default severity, and **help URI**, emitted in a proper `tool.driver.rules` table.

## Changes
- **`src/reports/sarif.rs`**
  - `get_sarif_aibom_rules()` — ten-rule table; `short_description` matches the scorer's `CHECK_DEFS` names exactly.
  - `aibom_level()` + `ai_check_to_rule_id()` — single source of truth for severity + ID mapping. No hard `error` (AI transparency is best-practice): documentation gaps are `warning`, softer ones `note`.
  - `rule_help_uri()` → `SBOM-AIBOM-*` maps to the CycloneDX ML-BOM spec page.
  - `generate_ai_readiness_sarif()` — full typed `SarifReport`, **one result per failing check** (findings-only, like compliance SARIF), with `standardIds: ["AIBOM:AI-00N"]` + help URIs.
  - `SarifRun` gains an optional `properties` field (`skip_serializing_if`), so the four existing compliance/view callers stay byte-identical; AI runs carry `applicable / overall_score / grade / sbom / profile`.
- **`src/reports/mod.rs`** — re-export `generate_ai_readiness_sarif`.
- **`src/cli/quality.rs`** — `format_quality_sarif` delegates to the typed generator for `AiReadiness`; all other profiles unchanged. N/A → rule table + `applicable:false` / `overall_score:null` / `grade:"N/A"`, no findings.
- **`tests/sarif_aibom_tests.rs`** — new integration tests: rule table + help URIs, N/A behavior, one result per failing check, and passing checks skipped.

## Defaults used (from the reviewed plan)
- **helpUri** → `https://cyclonedx.org/capabilities/mlbom/` (4 of 9 checks read CycloneDX modelCard fields).
- **Severities** → no `error`; AI-001/002/003/005/009 `warning`, the rest `note`.

## Note
`MlModelInfo`/`DatasetRef` are `#[non_exhaustive]`, so the integration tests build models via `Default` + field assignment and exercise AI-003 (datasets) as the documentation gap rather than constructing `DatasetRef` across the crate boundary.

## Verification (pinned 1.88 = CI)
- `cargo test --all-features` — **0 failed** across all binaries (incl. 4 new tests)
- `cargo clippy -- -D warnings` **and** `--all-features` — clean, no new `#[allow]`
- `cargo fmt --all -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)