### PR TITLE
fix(diff): populate per-component license changes

### DIFF
--- a/src/diff/changes/licenses.rs
+++ b/src/diff/changes/licenses.rs
@@ -1,9 +1,9 @@
 //! License change computer implementation.
 
-use crate::diff::LicenseChange;
 use crate::diff::traits::{ChangeComputer, ComponentMatches, LicenseChangeSet};
+use crate::diff::{ComponentLicenseChange, LicenseChange};
 use crate::model::NormalizedSbom;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 
 /// Computes license-level changes between SBOMs.
 pub struct LicenseChangeComputer;
@@ -25,11 +25,17 @@ impl Default for LicenseChangeComputer {
 impl ChangeComputer for LicenseChangeComputer {
     type ChangeSet = LicenseChangeSet;
 
+    /// Computes global license-set changes plus per-component license
+    /// transitions for matched pairs.
+    ///
+    /// Only declared licenses are compared: parsers for SPDX documents
+    /// populate both declared and concluded, so including concluded would
+    /// double-flag the same transition.
     fn compute(
         &self,
         old: &NormalizedSbom,
         new: &NormalizedSbom,
-        _matches: &ComponentMatches,
+        matches: &ComponentMatches,
     ) -> LicenseChangeSet {
         let mut result = LicenseChangeSet::new();
 
@@ -77,6 +83,45 @@ impl ChangeComputer for LicenseChangeComputer {
             }
         }
 
+        // Per-component license transitions for matched pairs
+        for (old_id, new_id_opt) in matches {
+            if let Some(new_id) = new_id_opt
+                && let (Some(old_comp), Some(new_comp)) =
+                    (old.components.get(old_id), new.components.get(new_id))
+            {
+                // Content hash covers declared licenses; equal hashes mean no change
+                if old_comp.content_hash == new_comp.content_hash {
+                    continue;
+                }
+
+                let old_set: BTreeSet<&str> = old_comp
+                    .licenses
+                    .declared
+                    .iter()
+                    .map(|lic| lic.expression.as_str())
+                    .collect();
+                let new_set: BTreeSet<&str> = new_comp
+                    .licenses
+                    .declared
+                    .iter()
+                    .map(|lic| lic.expression.as_str())
+                    .collect();
+
+                if old_set != new_set {
+                    result.component_changes.push(ComponentLicenseChange {
+                        component_id: new_id.to_string(),
+                        component_name: new_comp.name.clone(),
+                        old_licenses: old_set.into_iter().map(String::from).collect(),
+                        new_licenses: new_set.into_iter().map(String::from).collect(),
+                    });
+                }
+            }
+        }
+
+        result.component_changes.sort_by(|a, b| {
+            (&a.component_name, &a.component_id).cmp(&(&b.component_name, &b.component_id))
+        });
+
         result
     }
 
@@ -88,6 +133,26 @@ impl ChangeComputer for LicenseChangeComputer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::{Component, LicenseExpression};
+
+    fn component_with_licenses(name: &str, format_id: &str, licenses: &[&str]) -> Component {
+        let mut comp = Component::new(name.to_string(), format_id.to_string());
+        for lic in licenses {
+            comp.licenses
+                .add_declared(LicenseExpression::new((*lic).to_string()));
+        }
+        // Mirror parser behavior: the hash-skip guard requires real hashes
+        comp.calculate_content_hash();
+        comp
+    }
+
+    fn sbom_with(components: Vec<Component>) -> NormalizedSbom {
+        let mut sbom = NormalizedSbom::default();
+        for comp in components {
+            sbom.add_component(comp);
+        }
+        sbom
+    }
 
     #[test]
     fn test_license_change_computer_default() {
@@ -104,5 +169,85 @@ mod tests {
 
         let result = computer.compute(&old, &new, &matches);
         assert!(result.is_empty());
+    }
+
+    #[test]
+    fn matched_pair_license_transition() {
+        let old_comp = component_with_licenses("a", "a@1.0", &["MIT"]);
+        let new_comp = component_with_licenses("a", "a@1.0", &["GPL-3.0-only"]);
+        let mut matches = ComponentMatches::new();
+        matches.insert(
+            old_comp.canonical_id.clone(),
+            Some(new_comp.canonical_id.clone()),
+        );
+        let old = sbom_with(vec![old_comp]);
+        let new = sbom_with(vec![new_comp]);
+
+        let result = LicenseChangeComputer::new().compute(&old, &new, &matches);
+
+        assert_eq!(result.component_changes.len(), 1);
+        let change = &result.component_changes[0];
+        assert_eq!(change.component_name, "a");
+        assert_eq!(change.old_licenses, vec!["MIT".to_string()]);
+        assert_eq!(change.new_licenses, vec!["GPL-3.0-only".to_string()]);
+        assert_eq!(result.new_licenses.len(), 1);
+        assert_eq!(result.new_licenses[0].license, "GPL-3.0-only");
+        assert_eq!(result.removed_licenses.len(), 1);
+        assert_eq!(result.removed_licenses[0].license, "MIT");
+    }
+
+    #[test]
+    fn renamed_but_matched_component_included() {
+        let old_comp = component_with_licenses("a-old", "a-old@1.0", &["MIT"]);
+        let new_comp = component_with_licenses("a-new", "a-new@1.0", &["Apache-2.0"]);
+        let mut matches = ComponentMatches::new();
+        matches.insert(
+            old_comp.canonical_id.clone(),
+            Some(new_comp.canonical_id.clone()),
+        );
+        let new_id = new_comp.canonical_id.clone();
+        let old = sbom_with(vec![old_comp]);
+        let new = sbom_with(vec![new_comp]);
+
+        let result = LicenseChangeComputer::new().compute(&old, &new, &matches);
+
+        assert_eq!(result.component_changes.len(), 1);
+        assert_eq!(result.component_changes[0].component_name, "a-new");
+        assert_eq!(result.component_changes[0].component_id, new_id.to_string());
+    }
+
+    #[test]
+    fn unmatched_add_remove_not_in_component_changes() {
+        let old_comp = component_with_licenses("a", "a@1.0", &["MIT"]);
+        let new_comp = component_with_licenses("b", "b@1.0", &["Apache-2.0"]);
+        let mut matches = ComponentMatches::new();
+        matches.insert(old_comp.canonical_id.clone(), None);
+        let old = sbom_with(vec![old_comp]);
+        let new = sbom_with(vec![new_comp]);
+
+        let result = LicenseChangeComputer::new().compute(&old, &new, &matches);
+
+        assert!(result.component_changes.is_empty());
+        assert_eq!(result.new_licenses.len(), 1);
+        assert_eq!(result.removed_licenses.len(), 1);
+    }
+
+    #[test]
+    fn identical_license_sets_not_reported() {
+        let old_comp = component_with_licenses("a", "a@1.0", &["MIT"]);
+        let mut new_comp = component_with_licenses("a", "a@1.0", &["MIT"]);
+        new_comp.version = Some("2.0.0".to_string());
+        new_comp.calculate_content_hash();
+        let mut matches = ComponentMatches::new();
+        matches.insert(
+            old_comp.canonical_id.clone(),
+            Some(new_comp.canonical_id.clone()),
+        );
+        let old = sbom_with(vec![old_comp]);
+        let new = sbom_with(vec![new_comp]);
+
+        let result = LicenseChangeComputer::new().compute(&old, &new, &matches);
+
+        assert!(result.component_changes.is_empty());
     }
 }

--- a/src/diff/engine.rs
+++ b/src/diff/engine.rs
@@ -278,6 +278,7 @@ impl DiffEngine {
         let lic_changes = lic_computer.compute(old, new, &match_result.matches);
         result.licenses.new_licenses = lic_changes.new_licenses;
         result.licenses.removed_licenses = lic_changes.removed_licenses;
+        result.licenses.component_changes = lic_changes.component_changes;
 
         // Vulnerability changes
         let vuln_computer = VulnerabilityChangeComputer::new();
@@ -386,6 +387,7 @@ impl DiffEngine {
                 lic_computer.compute(&old_filtered, &new_filtered, &component_matches.matches);
             result.licenses.new_licenses = lic_changes.new_licenses;
             result.licenses.removed_licenses = lic_changes.removed_licenses;
+            result.licenses.component_changes = lic_changes.component_changes;
         }
 
         if sections.vulnerabilities {

--- a/src/diff/traits.rs
+++ b/src/diff/traits.rs
@@ -4,7 +4,8 @@
 //! enabling modular and testable diff operations.
 
 use super::{
-    ComponentChange, DependencyChange, LicenseChange, VexStatusChange, VulnerabilityDetail,
+    ComponentChange, ComponentLicenseChange, DependencyChange, LicenseChange, VexStatusChange,
+    VulnerabilityDetail,
 };
 use crate::model::{CanonicalId, NormalizedSbom};
 use std::collections::HashMap;
@@ -86,7 +87,7 @@ impl DependencyChangeSet {
 pub struct LicenseChangeSet {
     pub new_licenses: Vec<LicenseChange>,
     pub removed_licenses: Vec<LicenseChange>,
-    pub component_changes: Vec<(String, String, String)>, // (component, old_license, new_license)
+    pub component_changes: Vec<ComponentLicenseChange>,
 }
 
 impl LicenseChangeSet {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -955,6 +955,42 @@ mod diff_engine_tests {
     }
 
     #[test]
+    fn test_diff_detects_component_license_changes() {
+        let old_content = r#"{
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "version": 1,
+            "components": [
+                {"type": "library", "bom-ref": "a@1.0", "name": "a", "version": "1.0.0",
+                 "licenses": [{"license": {"id": "MIT"}}]}
+            ]
+        }"#;
+
+        let new_content = r#"{
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "version": 1,
+            "components": [
+                {"type": "library", "bom-ref": "a@1.0", "name": "a", "version": "1.0.0",
+                 "licenses": [{"license": {"id": "Apache-2.0"}}]}
+            ]
+        }"#;
+
+        let old = parse_sbom_str(old_content).unwrap();
+        let new = parse_sbom_str(new_content).unwrap();
+
+        let engine = DiffEngine::new();
+        let result = engine.diff(&old, &new).expect("diff should succeed");
+
+        assert_eq!(result.licenses.component_changes.len(), 1);
+        let change = &result.licenses.component_changes[0];
+        assert_eq!(change.component_name, "a");
+        assert_eq!(change.old_licenses, vec!["MIT".to_string()]);
+        assert_eq!(change.new_licenses, vec!["Apache-2.0".to_string()]);
+        assert!(result.semantic_score < 100.0);
+    }
+
+    #[test]
     fn test_diff_detects_version_changes() {
         let old_content = r#"{
             "bomFormat": "CycloneDX",


### PR DESCRIPTION
## Summary
- **Root cause:** `LicenseChangeComputer::compute` (src/diff/changes/licenses.rs) ignored the component match map (parameter `_matches`) and only diffed global license-set presence. `DiffResult.licenses.component_changes` (src/diff/result.rs:766) had zero writes anywhere, so the semantic-score input at src/diff/engine.rs:418 and the TUI summary license-changed count (src/tui/views/summary.rs:1158) were always 0 — even when a matched component switched licenses.
- **Fix:**
  - `LicenseChangeSet.component_changes` (src/diff/traits.rs:89) changed from the dead `Vec<(String, String, String)>` (zero in-repo readers) to `Vec<ComponentLicenseChange>`.
  - The computer now iterates matched pairs (same pattern as src/diff/changes/components.rs:340-358), skips pairs with equal content hashes (the hash covers declared licenses, src/model/sbom.rs:836-838), compares `BTreeSet`s of declared license expressions, and emits entries named after the new-side component. Results are sorted by `(component_name, component_id)` for deterministic JSON output.
  - `DiffEngine` copies `component_changes` into the result in both `compute_all_changes` and the incremental `diff_sections` licenses branch.
  - **Declared only:** concluded licenses would double-flag SPDX documents where parsers populate both (doc-commented on the computer).

## Behavior changes to note
- `semantic_score` drops slightly for diffs containing license transitions — these were previously uncounted (cost `license_changed=6`, src/diff/cost.rs).
- JSON reports and the TUI summary now populate a previously-always-empty field.

## Test plan
- New unit tests in `src/diff/changes/licenses.rs`: `matched_pair_license_transition`, `renamed_but_matched_component_included`, `unmatched_add_remove_not_in_component_changes`, `identical_license_sets_not_reported` (test components call `calculate_content_hash()` to mirror parser behavior, so the hash-skip guard is exercised).
- New engine-level test `test_diff_detects_component_license_changes` in tests/integration_tests.rs: same name/version MIT -> Apache-2.0 yields exactly one `component_changes` entry and `semantic_score < 100.0`.
- `cargo fmt`, `cargo clippy --all-targets` (no new warnings), full `cargo test`: all suites pass (807 lib + integration), no existing tests required updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)