### PR TITLE
fix(license): conflict gating, concluded licenses, SPDX-expression-aware policy

### DIFF
--- a/src/license/policy.rs
+++ b/src/license/policy.rs
@@ -2,6 +2,17 @@
 //!
 //! Checks component licenses against allow/deny/review lists,
 //! with glob pattern matching for license families.
+//!
+//! SPDX expressions are evaluated operand-by-operand:
+//! - `OR` is the licensee's choice — an expression is only denied if *every*
+//!   alternative hits the deny list ("MIT OR GPL-3.0-only" passes a `GPL-*`
+//!   deny; "GPL-2.0-only OR GPL-3.0-only" does not).
+//! - `AND` requires every operand to comply — one denied operand denies the
+//!   whole expression.
+//! - `WITH` exceptions match patterns against the base license ID
+//!   ("Apache-2.0 WITH LLVM-exception" matches an `Apache-2.0` pattern).
+//!
+//! Non-parseable expressions fall back to whole-string pattern matching.
 
 use crate::model::{LicenseExpression, LicenseFamily, NormalizedSbom};
 use serde::{Deserialize, Serialize};
@@ -117,44 +128,82 @@ pub struct LicensePolicyResult {
 /// Check if a license ID matches a pattern (supports `*` glob at end)
 fn matches_pattern(license_id: &str, pattern: &str) -> bool {
     if let Some(prefix) = pattern.strip_suffix('*') {
-        license_id.starts_with(prefix)
+        license_id
+            .get(..prefix.len())
+            .is_some_and(|head| head.eq_ignore_ascii_case(prefix))
     } else {
         license_id.eq_ignore_ascii_case(pattern)
     }
 }
 
-/// Evaluate a single license expression against the policy
-fn evaluate_expression(expr: &LicenseExpression, config: &LicensePolicyConfig) -> PolicyDecision {
-    let license_id = &expr.expression;
+/// Check if a license ID matches any pattern in the list
+fn matches_any(license_id: &str, patterns: &[String]) -> bool {
+    patterns
+        .iter()
+        .any(|pattern| matches_pattern(license_id, pattern))
+}
 
-    // Check deny list first (highest priority)
-    for pattern in &config.deny {
-        if matches_pattern(license_id, pattern) {
-            return PolicyDecision::Denied;
-        }
+/// Extract the operand license ID (without any WITH exception)
+fn req_license_id(req: &spdx::LicenseReq) -> String {
+    req.license.to_string()
+}
+
+/// Evaluate a single license ID (or non-parseable expression) against the policy
+fn evaluate_license_id(license_id: &str, config: &LicensePolicyConfig) -> PolicyDecision {
+    if matches_any(license_id, &config.deny) {
+        return PolicyDecision::Denied;
     }
 
-    // Check review list
-    for pattern in &config.review {
-        if matches_pattern(license_id, pattern) {
-            return PolicyDecision::NeedsReview;
-        }
+    if matches_any(license_id, &config.review) {
+        return PolicyDecision::NeedsReview;
     }
 
-    // Check allow list
     if config.allow.is_empty() {
         // No allow list means everything not denied/review is allowed
         return PolicyDecision::Unspecified;
     }
 
-    for pattern in &config.allow {
-        if matches_pattern(license_id, pattern) {
-            return PolicyDecision::Allowed;
-        }
+    if matches_any(license_id, &config.allow) {
+        return PolicyDecision::Allowed;
     }
 
     // If allow list exists but license didn't match, it needs review
     PolicyDecision::NeedsReview
+}
+
+/// Evaluate a single license expression against the policy
+fn evaluate_expression(expr: &LicenseExpression, config: &LicensePolicyConfig) -> PolicyDecision {
+    let Ok(parsed) = spdx::Expression::parse_mode(&expr.expression, spdx::ParseMode::LAX) else {
+        return evaluate_license_id(&expr.expression, config);
+    };
+
+    // Denied iff the expression cannot be satisfied while avoiding denied
+    // operands (OR alternatives are the licensee's choice)
+    if !parsed.evaluate(|req| !matches_any(&req_license_id(req), &config.deny)) {
+        return PolicyDecision::Denied;
+    }
+
+    if config.allow.is_empty() {
+        let clean = parsed.evaluate(|req| {
+            let id = req_license_id(req);
+            !matches_any(&id, &config.deny) && !matches_any(&id, &config.review)
+        });
+        if clean {
+            PolicyDecision::Unspecified
+        } else {
+            PolicyDecision::NeedsReview
+        }
+    } else {
+        let allowed = parsed.evaluate(|req| {
+            let id = req_license_id(req);
+            !matches_any(&id, &config.deny) && matches_any(&id, &config.allow)
+        });
+        if allowed {
+            PolicyDecision::Allowed
+        } else {
+            PolicyDecision::NeedsReview
+        }
+    }
 }
 
 /// Evaluate all component licenses against a policy.
@@ -185,7 +234,7 @@ pub fn evaluate_license_policy(
         let mut component_denied = false;
         let mut component_review = false;
 
-        for license in &comp.licenses.declared {
+        for license in comp.licenses.all_licenses() {
             let decision = evaluate_expression(license, config);
             match decision {
                 PolicyDecision::Denied => {
@@ -213,34 +262,31 @@ pub fn evaluate_license_policy(
             }
         }
 
+        // Copyleft/proprietary conflicts deny the component, counted at most once
+        if config.fail_on_conflict && comp.licenses.has_conflicts() {
+            component_denied = true;
+            let license_str = comp
+                .licenses
+                .all_licenses()
+                .iter()
+                .map(|l| l.expression.as_str())
+                .collect::<Vec<_>>()
+                .join(" + ");
+            violations.push(LicensePolicyViolation {
+                component: comp.name.clone(),
+                version: comp.version.clone(),
+                license: format!("CONFLICT: {license_str}"),
+                decision: PolicyDecision::Denied,
+                family: LicenseFamily::Other,
+            });
+        }
+
         if component_denied {
             denied_count += 1;
         } else if component_review {
             review_count += 1;
         } else {
             allowed_count += 1;
-        }
-    }
-
-    // Check for copyleft/proprietary conflicts
-    if config.fail_on_conflict {
-        for comp in sbom.components.values() {
-            if comp.licenses.has_conflicts() {
-                let license_str = comp
-                    .licenses
-                    .declared
-                    .iter()
-                    .map(|l| l.expression.as_str())
-                    .collect::<Vec<_>>()
-                    .join(" + ");
-                violations.push(LicensePolicyViolation {
-                    component: comp.name.clone(),
-                    version: comp.version.clone(),
-                    license: format!("CONFLICT: {license_str}"),
-                    decision: PolicyDecision::Denied,
-                    family: LicenseFamily::Other,
-                });
-            }
         }
     }
 
@@ -272,6 +318,18 @@ mod tests {
             }
             sbom.components.insert(comp.canonical_id.clone(), comp);
         }
+        sbom
+    }
+
+    fn make_sbom_with_component(declared: &[&str], concluded: Option<&str>) -> NormalizedSbom {
+        let mut sbom = NormalizedSbom::default();
+        let mut comp = Component::new("comp-0".to_string(), "id-0".to_string());
+        for lic in declared {
+            comp.licenses
+                .add_declared(LicenseExpression::new((*lic).to_string()));
+        }
+        comp.licenses.concluded = concluded.map(|c| LicenseExpression::new(c.to_string()));
+        sbom.components.insert(comp.canonical_id.clone(), comp);
         sbom
     }
 
@@ -314,9 +372,122 @@ mod tests {
     fn glob_pattern_matching() {
         assert!(matches_pattern("BSD-2-Clause", "BSD-*"));
         assert!(matches_pattern("AGPL-3.0-only", "AGPL-*"));
+        assert!(matches_pattern("agpl-3.0-only", "AGPL-*")); // case insensitive prefix
         assert!(!matches_pattern("MIT", "BSD-*"));
         assert!(matches_pattern("MIT", "MIT"));
         assert!(matches_pattern("mit", "MIT")); // case insensitive
+    }
+
+    #[test]
+    fn conflict_fails_policy() {
+        let sbom = make_sbom_with_component(&["GPL-3.0-only", "Proprietary"], None);
+        let config = LicensePolicyConfig {
+            fail_on_conflict: true,
+            ..Default::default()
+        };
+        let result = evaluate_license_policy(&sbom, &config);
+        assert!(!result.passed);
+        assert_eq!(result.denied_count, 1);
+        assert!(result.violations.iter().any(|v| {
+            v.license.starts_with("CONFLICT:") && v.decision == PolicyDecision::Denied
+        }));
+    }
+
+    #[test]
+    fn fail_on_conflict_false_skips() {
+        let sbom = make_sbom_with_component(&["GPL-3.0-only", "Proprietary"], None);
+        let config = LicensePolicyConfig {
+            fail_on_conflict: false,
+            ..Default::default()
+        };
+        let result = evaluate_license_policy(&sbom, &config);
+        assert!(result.passed);
+        assert_eq!(result.denied_count, 0);
+    }
+
+    #[test]
+    fn concluded_only_license_evaluated() {
+        let sbom = make_sbom_with_component(&[], Some("AGPL-3.0-only"));
+        let config = LicensePolicyConfig::strict_permissive();
+        let result = evaluate_license_policy(&sbom, &config);
+        assert!(!result.passed);
+        assert_eq!(result.denied_count, 1);
+        assert_eq!(result.undeclared_count, 0);
+    }
+
+    #[test]
+    fn or_expression_denied_only_if_all_alternatives_denied() {
+        let config = LicensePolicyConfig {
+            deny: vec!["GPL-*".to_string()],
+            ..Default::default()
+        };
+
+        let choice = make_sbom_with_component(&["MIT OR GPL-3.0-only"], None);
+        let result = evaluate_license_policy(&choice, &config);
+        assert!(result.passed);
+        assert_eq!(result.denied_count, 0);
+
+        let no_choice = make_sbom_with_component(&["GPL-2.0-only OR GPL-3.0-only"], None);
+        let result = evaluate_license_policy(&no_choice, &config);
+        assert!(!result.passed);
+        assert_eq!(result.denied_count, 1);
+    }
+
+    #[test]
+    fn and_expression_denied_if_any_operand_denied() {
+        let config = LicensePolicyConfig {
+            deny: vec!["GPL-*".to_string()],
+            ..Default::default()
+        };
+        let sbom = make_sbom_with_component(&["MIT AND GPL-3.0-only"], None);
+        let result = evaluate_license_policy(&sbom, &config);
+        assert!(!result.passed);
+        assert_eq!(result.denied_count, 1);
+    }
+
+    #[test]
+    fn or_with_allow_list_chooses_allowed_branch() {
+        let config = LicensePolicyConfig {
+            allow: vec!["MIT".to_string()],
+            review: vec!["GPL-*".to_string()],
+            ..Default::default()
+        };
+        let sbom = make_sbom_with_component(&["MIT OR GPL-3.0-only"], None);
+        let result = evaluate_license_policy(&sbom, &config);
+        assert!(result.passed);
+        assert_eq!(result.allowed_count, 1);
+        assert_eq!(result.review_count, 0);
+    }
+
+    #[test]
+    fn with_exception_matches_base_id() {
+        let sbom = make_sbom_with_component(&["Apache-2.0 WITH LLVM-exception"], None);
+
+        let allow_config = LicensePolicyConfig {
+            allow: vec!["Apache-2.0".to_string()],
+            ..Default::default()
+        };
+        let result = evaluate_license_policy(&sbom, &allow_config);
+        assert_eq!(result.allowed_count, 1);
+
+        let deny_config = LicensePolicyConfig {
+            deny: vec!["Apache-2.0".to_string()],
+            ..Default::default()
+        };
+        let result = evaluate_license_policy(&sbom, &deny_config);
+        assert_eq!(result.denied_count, 1);
+    }
+
+    #[test]
+    fn non_spdx_falls_back_to_string_match() {
+        let config = LicensePolicyConfig {
+            deny: vec!["Commercial*".to_string()],
+            ..Default::default()
+        };
+        let sbom = make_sbom_with_component(&["Commercial EULA v2"], None);
+        let result = evaluate_license_policy(&sbom, &config);
+        assert!(!result.passed);
+        assert_eq!(result.denied_count, 1);
     }
 
     #[test]

--- a/src/license/propagation.rs
+++ b/src/license/propagation.rs
@@ -43,14 +43,7 @@ pub fn check_license_propagation(sbom: &NormalizedSbom) -> Vec<LicenseConflict> 
     let families: HashMap<&CanonicalId, LicenseFamily> = sbom
         .components
         .iter()
-        .map(|(id, comp)| {
-            let family = comp
-                .licenses
-                .declared
-                .first()
-                .map_or(LicenseFamily::Other, |l| l.family());
-            (id, family)
-        })
+        .map(|(id, comp)| (id, comp.licenses.effective_family()))
         .collect();
 
     let mut conflicts = Vec::new();
@@ -213,6 +206,53 @@ mod tests {
         let conflicts = check_license_propagation(&sbom);
         assert_eq!(conflicts.len(), 1);
         assert!(conflicts[0].reason.contains("copyleft"));
+    }
+
+    #[test]
+    fn second_declared_copyleft_detected() {
+        let mut sbom = NormalizedSbom::default();
+        let app = make_component("app", "MIT");
+        let mut lib = make_component("dual-lib", "MIT");
+        lib.licenses
+            .add_declared(LicenseExpression::new("GPL-3.0-only".to_string()));
+        let app_id = app.canonical_id.clone();
+        let lib_id = lib.canonical_id.clone();
+        sbom.components.insert(app_id.clone(), app);
+        sbom.components.insert(lib_id.clone(), lib);
+        sbom.edges.push(DependencyEdge {
+            from: app_id,
+            to: lib_id,
+            relationship: DependencyType::DependsOn,
+            scope: None,
+        });
+
+        let conflicts = check_license_propagation(&sbom);
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].dependency, "dual-lib");
+        assert_eq!(conflicts[0].dependency_family, LicenseFamily::Copyleft);
+    }
+
+    #[test]
+    fn concluded_copyleft_detected() {
+        let mut sbom = NormalizedSbom::default();
+        let app = make_component("app", "MIT");
+        let mut lib = make_component("concluded-lib", "MIT");
+        lib.licenses.concluded = Some(LicenseExpression::new("GPL-3.0-only".to_string()));
+        let app_id = app.canonical_id.clone();
+        let lib_id = lib.canonical_id.clone();
+        sbom.components.insert(app_id.clone(), app);
+        sbom.components.insert(lib_id.clone(), lib);
+        sbom.edges.push(DependencyEdge {
+            from: app_id,
+            to: lib_id,
+            relationship: DependencyType::DependsOn,
+            scope: None,
+        });
+
+        let conflicts = check_license_propagation(&sbom);
+        assert_eq!(conflicts.len(), 1);
+        assert_eq!(conflicts[0].dependency, "concluded-lib");
+        assert_eq!(conflicts[0].dependency_family, LicenseFamily::Copyleft);
     }
 
     #[test]

--- a/src/model/license.rs
+++ b/src/model/license.rs
@@ -181,6 +181,18 @@ impl LicenseExpression {
     }
 }
 
+/// Rank a license family by restrictiveness (higher is more restrictive).
+fn family_restrictiveness(family: &LicenseFamily) -> u8 {
+    match family {
+        LicenseFamily::Proprietary => 5,
+        LicenseFamily::Copyleft => 4,
+        LicenseFamily::WeakCopyleft => 3,
+        LicenseFamily::Permissive => 2,
+        LicenseFamily::PublicDomain => 1,
+        LicenseFamily::Other => 0,
+    }
+}
+
 /// Classify an SPDX license ID into a license family.
 fn classify_spdx_license(id: spdx::LicenseId) -> LicenseFamily {
     let name = id.name;
@@ -283,15 +295,33 @@ impl LicenseInfo {
         licenses
     }
 
-    /// Check if there are potential license conflicts across declared expressions.
+    /// Get the effective license family across all expressions.
     ///
-    /// A conflict exists when one declared expression requires copyleft compliance
+    /// Per-expression OR-choice is already resolved inside
+    /// [`LicenseExpression::family`]; multiple expressions (declared and
+    /// concluded) are treated conjunctively (conservative), so the most
+    /// restrictive family wins:
+    /// Proprietary > Copyleft > `WeakCopyleft` > Permissive > `PublicDomain` > Other.
+    /// Returns [`LicenseFamily::Other`] when no licenses are present.
+    #[must_use]
+    pub fn effective_family(&self) -> LicenseFamily {
+        self.all_licenses()
+            .into_iter()
+            .map(LicenseExpression::family)
+            .max_by_key(family_restrictiveness)
+            .unwrap_or(LicenseFamily::Other)
+    }
+
+    /// Check if there are potential license conflicts across license expressions
+    /// (declared and concluded).
+    ///
+    /// A conflict exists when one expression requires copyleft compliance
     /// and another declares proprietary terms. Note that a single expression like
     /// "MIT OR GPL-2.0" is NOT a conflict — it offers a choice.
     pub fn has_conflicts(&self) -> bool {
         let families: Vec<LicenseFamily> = self
-            .declared
-            .iter()
+            .all_licenses()
+            .into_iter()
             .map(LicenseExpression::family)
             .collect();
 
@@ -325,5 +355,56 @@ impl LicenseEvidence {
             file_path: None,
             line_number: None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn info(declared: &[&str], concluded: Option<&str>) -> LicenseInfo {
+        let mut info = LicenseInfo::new();
+        for lic in declared {
+            info.add_declared(LicenseExpression::new((*lic).to_string()));
+        }
+        info.concluded = concluded.map(|c| LicenseExpression::new(c.to_string()));
+        info
+    }
+
+    #[test]
+    fn effective_family_precedence() {
+        assert_eq!(info(&[], None).effective_family(), LicenseFamily::Other);
+        assert_eq!(
+            info(&["MIT"], None).effective_family(),
+            LicenseFamily::Permissive
+        );
+        assert_eq!(
+            info(&["MIT", "GPL-3.0-only"], None).effective_family(),
+            LicenseFamily::Copyleft
+        );
+        assert_eq!(
+            info(&["MIT", "LGPL-3.0-only"], None).effective_family(),
+            LicenseFamily::WeakCopyleft
+        );
+        assert_eq!(
+            info(&["GPL-3.0-only", "Proprietary"], None).effective_family(),
+            LicenseFamily::Proprietary
+        );
+        assert_eq!(
+            info(&["MIT"], Some("GPL-3.0-only")).effective_family(),
+            LicenseFamily::Copyleft
+        );
+    }
+
+    #[test]
+    fn has_conflicts_includes_concluded() {
+        let conflicted = info(&["Proprietary"], Some("GPL-3.0-only"));
+        assert!(conflicted.has_conflicts());
+
+        let declared_only = info(&["GPL-3.0-only", "Proprietary"], None);
+        assert!(declared_only.has_conflicts());
+
+        let no_conflict = info(&["MIT"], Some("GPL-3.0-only"));
+        assert!(!no_conflict.has_conflicts());
     }
 }


### PR DESCRIPTION
## Summary

Fixes four defects in the license policy engine:

1. **`fail_on_conflict` was a no-op.** Conflict violations were pushed with `PolicyDecision::Denied` but `denied_count` was never incremented (src/license/policy.rs:226-247 before this change), so `result.passed` stayed `true` and the CLI exit code — which keys on `denied_count` at src/cli/license_check.rs:87 — never fired. The conflict check is now folded into the per-component loop: a conflicted component is marked denied and pushes a `CONFLICT: <licenses>` violation, with a per-component bool so a component with both a denied license and a conflict counts once.
2. **Concluded-only components bypassed the deny list.** Evaluation iterated only `comp.licenses.declared` (policy.rs:188 before this change). It now iterates `LicenseInfo::all_licenses()` (declared + concluded), and `has_conflicts()` also maps over `all_licenses()` so the concluded license participates in conflict detection.
3. **Patterns matched the whole SPDX expression as one ID.** `matches_pattern` compared the raw expression string, so deny `GPL-*` missed `"MIT OR GPL-3.0-only"` entirely, while a prefix pattern could deny an expression whose OR-alternatives included a compliant choice. `evaluate_expression` now parses with `spdx::Expression::parse_mode(.., ParseMode::LAX)` (same as src/model/license.rs:46) and uses `Expression::evaluate` per operand: an expression is **denied iff it cannot be satisfied while avoiding denied operands** (OR is the licensee's choice: `"MIT OR GPL-3.0-only"` with deny `GPL-*` passes; `"MIT AND GPL-3.0-only"` fails; `WITH` exceptions match the base license ID). Non-parseable expressions keep the previous whole-string fallback; glob prefix matching is now case-insensitive like exact matching. Semantics documented in the module docs.
4. **Propagation classified by `declared.first()` only** (src/license/propagation.rs:47-51 before this change), missing copyleft in a second declared license or in the concluded license. It now uses the new `LicenseInfo::effective_family()`, which folds `all_licenses()` over `LicenseExpression::family` with most-restrictive-wins precedence (Proprietary > Copyleft > WeakCopyleft > Permissive > PublicDomain > Other; per-expression OR-choice is already resolved inside `family()`).

### Behavioral note for consumers

This is **intentionally stricter**: CI consumers may newly fail on license conflicts (`fail_on_conflict` now actually fails) and on concluded-only denied licenses. Conversely, OR-expressions previously denied by whole-string prefix matching (e.g. `"GPL-2.0-only OR MIT"` under deny `GPL-*`) may now correctly pass.

## Test plan

- New unit tests in `src/license/policy.rs`: `conflict_fails_policy`, `fail_on_conflict_false_skips`, `concluded_only_license_evaluated`, `or_expression_denied_only_if_all_alternatives_denied`, `and_expression_denied_if_any_operand_denied`, `or_with_allow_list_chooses_allowed_branch`, `with_exception_matches_base_id`, `non_spdx_falls_back_to_string_match`, plus a case-insensitive prefix assertion in `glob_pattern_matching`
- New unit tests in `src/license/propagation.rs`: `second_declared_copyleft_detected`, `concluded_copyleft_detected`
- New unit tests in `src/model/license.rs`: `effective_family_precedence`, `has_conflicts_includes_concluded`
- `cargo fmt --check` clean; `cargo clippy --all-targets` introduces 0 new warnings in changed files
- Full `cargo test`: 815 lib tests + all integration suites pass, 0 failures, no existing tests needed updating

🤖 Generated with [Claude Code](https://claude.com/claude-code)