### PR TITLE
fix(reports,tui): CSV formula-injection guard, terminal sanitization, TUI panic hook

### DIFF
--- a/src/reports/csv.rs
+++ b/src/reports/csv.rs
@@ -97,7 +97,7 @@ impl ReportGenerator for CsvReporter {
                 .join("; ");
             let vuln_count = comp.vulnerabilities.len();
             let ecosystem = comp.ecosystem.as_ref().map(|e| format!("{e:?}"));
-            let ecosystem = ecosystem.as_deref().unwrap_or("-");
+            let ecosystem = escape_csv_opt(ecosystem.as_deref());
 
             let eol_status = comp.eol.as_ref().map_or("-", |e| e.status.label());
             let eol_date = comp
@@ -118,7 +118,7 @@ impl ReportGenerator for CsvReporter {
                 .and_then(|cp| {
                     cp.algorithm_properties
                         .as_ref()
-                        .and_then(|a| a.algorithm_family.clone())
+                        .and_then(|a| a.algorithm_family.as_deref().map(escape_csv))
                 })
                 .unwrap_or_default();
             let quantum_level = comp
@@ -135,10 +135,10 @@ impl ReportGenerator for CsvReporter {
                 content,
                 "\"{}\",\"{}\",\"{}\",\"{:?}\",\"{}\",\"{}\",{},\"{}\",\"{}\",\"{}\",\"{}\",\"{}\"",
                 escape_csv(&comp.name),
-                comp.version.as_deref().unwrap_or("-"),
+                escape_csv_opt(comp.version.as_deref()),
                 ecosystem,
                 comp.component_type,
-                comp.identifiers.purl.as_deref().unwrap_or("-"),
+                escape_csv_opt(comp.identifiers.purl.as_deref()),
                 escape_csv(&licenses),
                 vuln_count,
                 eol_status,
@@ -168,9 +168,9 @@ fn write_component_line(
         "{},\"{}\",\"{}\",\"{}\",\"{}\"",
         change_type,
         escape_csv(&comp.name),
-        comp.old_version.as_deref().unwrap_or("-"),
-        comp.new_version.as_deref().unwrap_or("-"),
-        comp.ecosystem.as_deref().unwrap_or("-")
+        escape_csv_opt(comp.old_version.as_deref()),
+        escape_csv_opt(comp.new_version.as_deref()),
+        escape_csv_opt(comp.ecosystem.as_deref())
     );
 }
 
@@ -210,8 +210,22 @@ fn write_vuln_line(content: &mut String, status: &str, vuln: &VulnerabilityDetai
 
 /// Escape a string for CSV embedding: double-quote escaping per RFC 4180,
 /// plus newline flattening since fields are already wrapped in double quotes.
+///
+/// Values starting with a formula trigger (`=`, `+`, `-`, `@`, tab, CR) are
+/// prefixed with a single quote so spreadsheet applications treat them as
+/// text rather than executable formulas (OWASP CSV injection guidance).
 fn escape_csv(s: &str) -> String {
-    s.replace('"', "\"\"").replace('\n', " ")
+    let escaped = s.replace('"', "\"\"").replace('\n', " ");
+    if s.starts_with(['=', '+', '-', '@', '\t', '\r']) {
+        format!("'{escaped}")
+    } else {
+        escaped
+    }
+}
+
+/// Escape an optional string for CSV embedding, returning "-" for `None`.
+fn escape_csv_opt(s: Option<&str>) -> String {
+    s.map_or_else(|| "-".to_string(), escape_csv)
 }
 
 fn format_sla_csv(vuln: &VulnerabilityDetail) -> String {
@@ -221,5 +235,50 @@ fn format_sla_csv(vuln: &VulnerabilityDetail) -> String {
         SlaStatus::NoDueDate => vuln
             .days_since_published
             .map_or_else(|| "-".to_string(), |d| format!("{d}d old")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_csv_guards_formula_triggers() {
+        assert_eq!(escape_csv("=1+2"), "'=1+2");
+        assert_eq!(escape_csv("+SUM(A1:A2)"), "'+SUM(A1:A2)");
+        assert_eq!(escape_csv("-2+3"), "'-2+3");
+        assert_eq!(escape_csv("@cmd"), "'@cmd");
+        assert_eq!(escape_csv("\tpayload"), "'\tpayload");
+        assert_eq!(escape_csv("\rpayload"), "'\rpayload");
+        // Scoped npm names share the '@' trigger; the quote prefix keeps them
+        // readable while staying inert in spreadsheets
+        assert_eq!(escape_csv("@types/node"), "'@types/node");
+    }
+
+    #[test]
+    fn escape_csv_guards_formula_after_quote_doubling() {
+        assert_eq!(escape_csv("=cmd|'/c calc'!A0"), "'=cmd|'/c calc'!A0");
+        assert_eq!(escape_csv("=\"evil\""), "'=\"\"evil\"\"");
+    }
+
+    #[test]
+    fn escape_csv_leaves_benign_values_alone() {
+        assert_eq!(escape_csv("lodash"), "lodash");
+        assert_eq!(escape_csv("1.2.3"), "1.2.3");
+        assert_eq!(
+            escape_csv("pkg:npm/lodash@4.17.21"),
+            "pkg:npm/lodash@4.17.21"
+        );
+        assert_eq!(escape_csv("MIT OR Apache-2.0"), "MIT OR Apache-2.0");
+        assert_eq!(escape_csv("name \"quoted\""), "name \"\"quoted\"\"");
+        assert_eq!(escape_csv("line1\nline2"), "line1 line2");
+        assert_eq!(escape_csv(""), "");
+    }
+
+    #[test]
+    fn escape_csv_opt_uses_placeholder_for_none() {
+        assert_eq!(escape_csv_opt(None), "-");
+        assert_eq!(escape_csv_opt(Some("=evil")), "'=evil");
+        assert_eq!(escape_csv_opt(Some("1.0.0")), "1.0.0");
     }
 }

--- a/src/reports/escape.rs
+++ b/src/reports/escape.rs
@@ -13,6 +13,27 @@
 //!
 //! All user-controllable data MUST be escaped before embedding in reports.
 
+use std::borrow::Cow;
+
+/// Sanitize a string for safe terminal (TTY) output.
+///
+/// Strips control characters — C0 controls except `\n` and `\t`, DEL, and C1
+/// controls — including ESC (0x1B), which neutralizes ANSI escape sequences
+/// embedded in untrusted SBOM data (cursor movement, screen clearing, title
+/// changes, etc.). Returns the input unchanged when nothing needs stripping.
+#[must_use]
+pub(crate) fn sanitize_terminal(s: &str) -> Cow<'_, str> {
+    fn is_disallowed(c: char) -> bool {
+        c.is_control() && c != '\n' && c != '\t'
+    }
+
+    if s.contains(is_disallowed) {
+        Cow::Owned(s.chars().filter(|&c| !is_disallowed(c)).collect())
+    } else {
+        Cow::Borrowed(s)
+    }
+}
+
 /// Escape a string for safe inclusion in HTML content.
 ///
 /// Escapes the following characters:
@@ -297,6 +318,43 @@ mod tests {
         assert_eq!(escape_html("日本語"), "日本語");
         assert_eq!(escape_markdown_table("émoji 🎉"), "émoji 🎉");
         assert_eq!(escape_html("Ω ≈ ∞"), "Ω ≈ ∞");
+    }
+
+    #[test]
+    fn test_sanitize_terminal_ansi_neutralized() {
+        // ESC is stripped, so the CSI sequence loses its meaning
+        assert_eq!(
+            sanitize_terminal("\x1b[31mevil\x1b[0m"),
+            Cow::<str>::Owned("[31mevil[0m".to_string())
+        );
+        // OSC title change
+        assert_eq!(sanitize_terminal("\x1b]0;pwned\x07name"), "]0;pwnedname");
+    }
+
+    #[test]
+    fn test_sanitize_terminal_control_chars_stripped() {
+        assert_eq!(sanitize_terminal("a\x07b\x08c"), "abc");
+        assert_eq!(sanitize_terminal("over\rwrite"), "overwrite");
+        assert_eq!(sanitize_terminal("\x00null\x7f"), "null");
+        // C1 controls
+        assert_eq!(sanitize_terminal("a\u{9b}31mb"), "a31mb");
+    }
+
+    #[test]
+    fn test_sanitize_terminal_preserves_safe_input() {
+        assert!(matches!(
+            sanitize_terminal("lodash@4.17.21"),
+            Cow::Borrowed("lodash@4.17.21")
+        ));
+        assert!(matches!(
+            sanitize_terminal("日本語 émoji 🎉"),
+            Cow::Borrowed(_)
+        ));
+        assert!(matches!(
+            sanitize_terminal("line1\nline2\ttabbed"),
+            Cow::Borrowed(_)
+        ));
+        assert!(matches!(sanitize_terminal(""), Cow::Borrowed("")));
     }
 
     #[test]

--- a/src/reports/summary.rs
+++ b/src/reports/summary.rs
@@ -2,6 +2,7 @@
 //!
 //! Provides a compact, human-readable summary for terminal usage.
 
+use super::escape::sanitize_terminal;
 use super::{ReportConfig, ReportError, ReportFormat, ReportGenerator};
 use crate::diff::DiffResult;
 use crate::model::NormalizedSbom;
@@ -69,8 +70,8 @@ impl ReportGenerator for SummaryReporter {
         lines.push(self.color("─".repeat(40).as_str(), "dim"));
 
         // File info
-        let old_name = old_sbom.document.name.as_deref().unwrap_or("old");
-        let new_name = new_sbom.document.name.as_deref().unwrap_or("new");
+        let old_name = sanitize_terminal(old_sbom.document.name.as_deref().unwrap_or("old"));
+        let new_name = sanitize_terminal(new_sbom.document.name.as_deref().unwrap_or("new"));
         lines.push(format!(
             "{}  {} → {}",
             self.color("Files:", "cyan"),
@@ -260,7 +261,11 @@ impl ReportGenerator for SummaryReporter {
 
         // Basic info
         if let Some(name) = &sbom.document.name {
-            lines.push(format!("{}  {}", self.color("Name:", "cyan"), name));
+            lines.push(format!(
+                "{}  {}",
+                self.color("Name:", "cyan"),
+                sanitize_terminal(name)
+            ));
         }
         lines.push(format!(
             "{}  {}",
@@ -285,10 +290,11 @@ impl ReportGenerator for SummaryReporter {
             .map(std::string::ToString::to_string)
             .collect();
         if !ecosystems.is_empty() {
+            let joined = ecosystems.join(", ");
             lines.push(format!(
                 "{}  {}",
                 self.color("Ecosystems:", "cyan"),
-                ecosystems.join(", ")
+                sanitize_terminal(&joined)
             ));
         }
 
@@ -446,11 +452,11 @@ impl ReportGenerator for TableReporter {
 
         // Added components
         for comp in &result.components.added {
-            let version = comp.new_version.as_deref().unwrap_or("-");
+            let version = sanitize_terminal(comp.new_version.as_deref().unwrap_or("-"));
             lines.push(format!(
                 "{:<12} {:<40} {:<15} {:<15}",
                 self.color("+ Added", "green"),
-                truncate(&comp.name, 40),
+                truncate(&sanitize_terminal(&comp.name), 40),
                 "-",
                 version
             ));
@@ -458,11 +464,11 @@ impl ReportGenerator for TableReporter {
 
         // Removed components
         for comp in &result.components.removed {
-            let version = comp.old_version.as_deref().unwrap_or("-");
+            let version = sanitize_terminal(comp.old_version.as_deref().unwrap_or("-"));
             lines.push(format!(
                 "{:<12} {:<40} {:<15} {:<15}",
                 self.color("- Removed", "red"),
-                truncate(&comp.name, 40),
+                truncate(&sanitize_terminal(&comp.name), 40),
                 version,
                 "-"
             ));
@@ -470,12 +476,12 @@ impl ReportGenerator for TableReporter {
 
         // Modified components
         for comp in &result.components.modified {
-            let old_ver = comp.old_version.as_deref().unwrap_or("-");
-            let new_ver = comp.new_version.as_deref().unwrap_or("-");
+            let old_ver = sanitize_terminal(comp.old_version.as_deref().unwrap_or("-"));
+            let new_ver = sanitize_terminal(comp.new_version.as_deref().unwrap_or("-"));
             lines.push(format!(
                 "{:<12} {:<40} {:<15} {:<15}",
                 self.color("~ Modified", "yellow"),
-                truncate(&comp.name, 40),
+                truncate(&sanitize_terminal(&comp.name), 40),
                 old_ver,
                 new_ver
             ));
@@ -494,17 +500,18 @@ impl ReportGenerator for TableReporter {
             lines.push("─".repeat(85));
 
             for vuln in &result.vulnerabilities.introduced {
+                let severity = sanitize_terminal(&vuln.severity);
                 let severity_colored = match vuln.severity.to_lowercase().as_str() {
-                    "critical" | "high" => self.color(&vuln.severity, "red"),
-                    "medium" => self.color(&vuln.severity, "yellow"),
-                    _ => vuln.severity.clone(),
+                    "critical" | "high" => self.color(&severity, "red"),
+                    "medium" => self.color(&severity, "yellow"),
+                    _ => severity.into_owned(),
                 };
                 lines.push(format!(
                     "{:<12} {:<20} {:<10} {:<40}",
                     self.color("! NEW", "red"),
-                    truncate(&vuln.id, 20),
+                    truncate(&sanitize_terminal(&vuln.id), 20),
                     severity_colored,
-                    truncate(&vuln.component_name, 40)
+                    truncate(&sanitize_terminal(&vuln.component_name), 40)
                 ));
             }
         }
@@ -561,9 +568,9 @@ impl ReportGenerator for TableReporter {
 
             lines.push(format!(
                 "{:<40} {:<15} {:<20} {:<10}",
-                truncate(&comp.name, 40),
-                truncate(version, 15),
-                truncate(license, 20),
+                truncate(&sanitize_terminal(&comp.name), 40),
+                truncate(&sanitize_terminal(version), 15),
+                truncate(&sanitize_terminal(license), 20),
                 vuln_display
             ));
         }

--- a/src/tui/shared/mod.rs
+++ b/src/tui/shared/mod.rs
@@ -12,6 +12,38 @@ pub mod quality;
 pub mod source;
 pub mod vulnerabilities;
 
+use crossterm::{
+    event::DisableMouseCapture,
+    execute,
+    terminal::{LeaveAlternateScreen, disable_raw_mode},
+};
+
+/// Restore the terminal to its normal state (cooked mode, main screen,
+/// mouse capture off).
+///
+/// Errors are ignored so this is safe to call from a panic hook and
+/// idempotent with the normal TUI exit path.
+pub(crate) fn restore_terminal() {
+    let _ = disable_raw_mode();
+    let _ = execute!(std::io::stdout(), LeaveAlternateScreen, DisableMouseCapture);
+}
+
+/// Install a panic hook that restores the terminal before delegating to the
+/// previously installed hook, so a panic inside the TUI doesn't leave the
+/// shell in raw mode with the backtrace swallowed by the alternate screen.
+///
+/// Installs at most once per process; subsequent calls are no-ops.
+pub(crate) fn install_panic_hook() {
+    static INSTALL: std::sync::Once = std::sync::Once::new();
+    INSTALL.call_once(|| {
+        let previous = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            restore_terminal();
+            previous(info);
+        }));
+    });
+}
+
 /// Find the largest byte index <= `index` that is on a UTF-8 char boundary.
 ///
 /// Equivalent to `str::floor_char_boundary` (stabilized in Rust 1.94,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -29,6 +29,7 @@ pub fn run_tui(app: &mut App) -> io::Result<()> {
     set_theme(Theme::from_name(prefs.theme.as_str()));
 
     // Setup terminal
+    super::shared::install_panic_hook();
     enable_raw_mode()?;
     let mut stdout = stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;

--- a/src/tui/view/ui.rs
+++ b/src/tui/view/ui.rs
@@ -27,6 +27,7 @@ pub fn run_view_tui(app: &mut ViewApp) -> io::Result<()> {
     set_theme(Theme::from_name(prefs.theme.as_str()));
 
     // Setup terminal
+    crate::tui::shared::install_panic_hook();
     enable_raw_mode()?;
     let mut stdout = stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;


### PR DESCRIPTION
## Summary

Three security-hygiene fixes for untrusted SBOM data (SECURITY.md scopes untrusted SBOM inputs):

1. **CSV formula injection** — `escape_csv` (src/reports/csv.rs:213 before this change) only doubled quotes, so a component name/version/license like `=cmd|'/c calc'!A0` would execute as a formula when the exported CSV is opened in Excel/LibreOffice. Cells starting with `=`, `+`, `-`, `@`, tab (0x09), or CR (0x0D) are now prefixed with a single quote per OWASP CSV-injection guidance (src/reports/csv.rs:217-224). Call-site audit showed numeric cells (vuln counts, quantum level) are formatted separately and never pass through `escape_csv`, so no negative numbers can be mangled. String-typed cells that previously bypassed escaping entirely — versions, PURLs, ecosystems, algorithm family (src/reports/csv.rs:100,121,138,141,171-173) — are now routed through a new `escape_csv_opt` helper that keeps the static `"-"` placeholder untouched.

2. **Terminal output sanitization** — `SummaryReporter` and `TableReporter` (both in src/reports/summary.rs; there is no separate table.rs) interpolated component names, versions, vuln ids/severities, license strings, and document names into TTY output with no control-char stripping, letting a crafted SBOM emit ANSI escape sequences (cursor movement, screen clearing, terminal-title changes) or raw control chars. New `pub(crate) fn sanitize_terminal(&str) -> Cow<str>` in src/reports/escape.rs strips C0 controls (except `\n`/`\t`), DEL, and C1 controls — including ESC (0x1B), which neutralizes ANSI sequences — and returns `Cow::Borrowed` for clean input. Applied at every user-data interpolation point in both reporters (static template strings untouched).

3. **TUI panic hook** — `enable_raw_mode` + `EnterAlternateScreen` run in src/tui/ui.rs:33 and src/tui/view/ui.rs:31 with no `panic::set_hook` anywhere, so any panic left the shell in raw mode with the backtrace swallowed by the alternate screen. `tui::shared` now provides `install_panic_hook` (Once-guarded, chains the previous hook — standard ratatui pattern) and an error-ignoring, idempotent `restore_terminal` (disable raw mode, leave alternate screen, disable mouse capture); both `run_tui` and `run_view_tui` install it before entering raw mode. The normal exit path is unchanged and remains safe if the hook later fires.

## Test plan

- New unit tests in src/reports/csv.rs: each formula-trigger prefix char, quote-doubling interaction, benign values (names, versions, PURLs, license expressions) unchanged, `escape_csv_opt` placeholder behavior.
- New unit tests in src/reports/escape.rs: ANSI CSI and OSC sequences neutralized, bell/backspace/CR/NUL/DEL/C1 stripped, plain unicode + `\n`/`\t` untouched (`Cow::Borrowed`).
- `cargo fmt`, `cargo clippy --all-targets` (no new warnings vs HEAD baseline), full `cargo test` suite green (810 lib tests + all integration suites, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)