### PR TITLE
fix(quality): iterative Tarjan SCC cycle detection prevents stack-overflow abort

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -38,6 +38,7 @@ jobs:
           - fuzz_spdx_json
           - fuzz_spdx_tagvalue
           - fuzz_detect_format
+          - fuzz_score_sbom
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -57,7 +57,7 @@ jobs:
           key: fuzz-${{ matrix.target }}
 
       - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz --locked
+        run: cargo +nightly install cargo-fuzz --locked
 
       - name: Run fuzzer
         run: |

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -893,6 +893,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1152,12 +1158,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1770,9 +1776,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.1"
+version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd58c6a1fc307e1092aa0bb23d204ca4d1f021764142cd0424dccc84d2d5d106"
+checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
@@ -2252,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "sbom-tools"
-version = "0.1.19"
+version = "0.1.21"
 dependencies = [
  "anyhow",
  "chrono",

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -49,3 +49,8 @@ doc = false
 name = "fuzz_detect_format"
 path = "fuzz_targets/fuzz_detect_format.rs"
 doc = false
+
+[[bin]]
+name = "fuzz_score_sbom"
+path = "fuzz_targets/fuzz_score_sbom.rs"
+doc = false

--- a/fuzz/fuzz_targets/fuzz_score_sbom.rs
+++ b/fuzz/fuzz_targets/fuzz_score_sbom.rs
@@ -1,0 +1,29 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use sbom_tools::quality::{QualityScorer, ScoringProfile};
+
+/// Fuzz the quality scoring engine.
+///
+/// Parses arbitrary UTF-8 input as an SBOM; when parsing succeeds, scores the
+/// document with every scoring profile. This exercises all metric computations
+/// (including dependency graph analysis) against adversarial component and
+/// dependency structures.
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data)
+        && let Ok(sbom) = sbom_tools::parsers::parse_sbom_str(s)
+    {
+        for profile in [
+            ScoringProfile::Minimal,
+            ScoringProfile::Standard,
+            ScoringProfile::Security,
+            ScoringProfile::LicenseCompliance,
+            ScoringProfile::Cra,
+            ScoringProfile::BsiTr03183_2,
+            ScoringProfile::Comprehensive,
+            ScoringProfile::Cbom,
+            ScoringProfile::AiReadiness,
+        ] {
+            let _ = QualityScorer::new(profile).score(&sbom);
+        }
+    }
+});

--- a/src/quality/metrics.rs
+++ b/src/quality/metrics.rs
@@ -683,7 +683,7 @@ impl VulnerabilityMetrics {
 // ============================================================================
 
 /// Maximum edge count before skipping expensive graph analysis
-const MAX_EDGES_FOR_GRAPH_ANALYSIS: usize = 50_000;
+const MAX_EDGES_FOR_GRAPH_ANALYSIS: usize = 1_000_000;
 
 // ============================================================================
 // Software complexity index
@@ -764,7 +764,7 @@ pub struct DependencyMetrics {
     pub orphan_components: usize,
     /// Root components (no incoming deps, but has outgoing)
     pub root_components: usize,
-    /// Number of dependency cycles detected
+    /// Number of dependency cycles detected (SCCs with more than one node, plus self-loops)
     pub cycle_count: usize,
     /// Number of disconnected subgraphs (islands)
     pub island_count: usize,
@@ -841,7 +841,7 @@ impl DependencyMetrics {
         // BFS from roots to compute depth
         let (max_depth, avg_depth) = compute_depth(&roots, &children);
 
-        // DFS cycle detection
+        // Iterative Tarjan SCC cycle detection
         let cycle_count = detect_cycles(&all_ids, &children);
 
         // Union-Find for island/subgraph detection
@@ -954,43 +954,90 @@ fn compute_depth(
     (Some(max_d), avg)
 }
 
-/// DFS-based cycle detection (white/gray/black coloring)
+/// Iterative Tarjan SCC-based cycle detection.
+///
+/// Counts each strongly connected component with more than one node as a
+/// single cycle, plus single-node components with a self-loop. Uses explicit
+/// stacks instead of recursion so arbitrarily deep graphs cannot overflow
+/// the call stack.
 fn detect_cycles(all_nodes: &[&str], children: &HashMap<&str, Vec<&str>>) -> usize {
-    const WHITE: u8 = 0;
-    const GRAY: u8 = 1;
-    const BLACK: u8 = 2;
-
-    let mut color: HashMap<&str, u8> = HashMap::with_capacity(all_nodes.len());
+    let mut index_of: HashMap<&str, usize> = HashMap::with_capacity(all_nodes.len());
     for &node in all_nodes {
-        color.insert(node, WHITE);
+        let next = index_of.len();
+        index_of.entry(node).or_insert(next);
+    }
+    for (&from, kids) in children {
+        let next = index_of.len();
+        index_of.entry(from).or_insert(next);
+        for &kid in kids {
+            let next = index_of.len();
+            index_of.entry(kid).or_insert(next);
+        }
     }
 
-    let mut cycles = 0;
+    let node_count = index_of.len();
+    let mut adjacency: Vec<Vec<usize>> = vec![Vec::new(); node_count];
+    let mut has_self_loop = vec![false; node_count];
+    for (from, kids) in children {
+        let from_idx = index_of[from];
+        for kid in kids {
+            let kid_idx = index_of[kid];
+            if from_idx == kid_idx {
+                has_self_loop[from_idx] = true;
+            }
+            adjacency[from_idx].push(kid_idx);
+        }
+    }
 
-    fn dfs<'a>(
-        node: &'a str,
-        children: &HashMap<&str, Vec<&'a str>>,
-        color: &mut HashMap<&'a str, u8>,
-        cycles: &mut usize,
-    ) {
-        color.insert(node, GRAY);
+    const UNVISITED: usize = usize::MAX;
+    let mut order = vec![UNVISITED; node_count];
+    let mut lowlink = vec![0usize; node_count];
+    let mut on_stack = vec![false; node_count];
+    let mut scc_stack: Vec<usize> = Vec::new();
+    let mut call_stack: Vec<(usize, usize)> = Vec::new();
+    let mut next_order = 0usize;
+    let mut cycles = 0usize;
 
-        if let Some(kids) = children.get(node) {
-            for &kid in kids {
-                match color.get(kid).copied().unwrap_or(WHITE) {
-                    GRAY => *cycles += 1, // back edge = cycle
-                    WHITE => dfs(kid, children, color, cycles),
-                    _ => {}
+    for start in 0..node_count {
+        if order[start] != UNVISITED {
+            continue;
+        }
+        call_stack.push((start, 0));
+        while let Some(frame) = call_stack.last_mut() {
+            let node = frame.0;
+            if frame.1 == 0 {
+                order[node] = next_order;
+                lowlink[node] = next_order;
+                next_order += 1;
+                scc_stack.push(node);
+                on_stack[node] = true;
+            }
+            if let Some(&target) = adjacency[node].get(frame.1) {
+                frame.1 += 1;
+                if order[target] == UNVISITED {
+                    call_stack.push((target, 0));
+                } else if on_stack[target] {
+                    lowlink[node] = lowlink[node].min(order[target]);
+                }
+            } else {
+                call_stack.pop();
+                if let Some(&(parent, _)) = call_stack.last() {
+                    lowlink[parent] = lowlink[parent].min(lowlink[node]);
+                }
+                if lowlink[node] == order[node] {
+                    let mut scc_size = 0usize;
+                    while let Some(member) = scc_stack.pop() {
+                        on_stack[member] = false;
+                        scc_size += 1;
+                        if member == node {
+                            break;
+                        }
+                    }
+                    if scc_size > 1 || has_self_loop[node] {
+                        cycles += 1;
+                    }
                 }
             }
-        }
-
-        color.insert(node, BLACK);
-    }
-
-    for &node in all_nodes {
-        if color.get(node).copied().unwrap_or(WHITE) == WHITE {
-            dfs(node, children, &mut color, &mut cycles);
         }
     }
 
@@ -2063,6 +2110,7 @@ mod tests {
         let children: HashMap<&str, Vec<&str>> =
             HashMap::from([("a", vec!["b"]), ("b", vec!["c"])]);
         let all_nodes = vec!["a", "b", "c"];
+        // Linear chain has no SCC with more than one node
         assert_eq!(detect_cycles(&all_nodes, &children), 0);
     }
 
@@ -2071,7 +2119,75 @@ mod tests {
         let children: HashMap<&str, Vec<&str>> =
             HashMap::from([("a", vec!["b"]), ("b", vec!["c"]), ("c", vec!["a"])]);
         let all_nodes = vec!["a", "b", "c"];
+        // a→b→c→a forms a single 3-node SCC = one cycle
         assert_eq!(detect_cycles(&all_nodes, &children), 1);
+    }
+
+    #[test]
+    fn test_cycle_detection_deep_linear_chain_no_overflow() {
+        let n = 40_000usize;
+        let names: Vec<String> = (0..n).map(|i| format!("node-{i}")).collect();
+        let all_nodes: Vec<&str> = names.iter().map(String::as_str).collect();
+        let mut children: HashMap<&str, Vec<&str>> = HashMap::new();
+        for w in all_nodes.windows(2) {
+            children.entry(w[0]).or_default().push(w[1]);
+        }
+        assert_eq!(detect_cycles(&all_nodes, &children), 0);
+    }
+
+    #[test]
+    fn test_cycle_detection_diamond_dag() {
+        let children: HashMap<&str, Vec<&str>> =
+            HashMap::from([("a", vec!["b", "c"]), ("b", vec!["d"]), ("c", vec!["d"])]);
+        let all_nodes = vec!["a", "b", "c", "d"];
+        assert_eq!(detect_cycles(&all_nodes, &children), 0);
+    }
+
+    #[test]
+    fn test_cycle_detection_multi_back_edge_scc_counts_once() {
+        let children: HashMap<&str, Vec<&str>> = HashMap::from([
+            ("a", vec!["b", "c"]),
+            ("b", vec!["a", "c"]),
+            ("c", vec!["a", "b"]),
+        ]);
+        let all_nodes = vec!["a", "b", "c"];
+        // One SCC with multiple back edges still counts as a single cycle
+        assert_eq!(detect_cycles(&all_nodes, &children), 1);
+    }
+
+    #[test]
+    fn test_cycle_detection_self_loop_counts_once() {
+        let children: HashMap<&str, Vec<&str>> =
+            HashMap::from([("a", vec!["a", "b"]), ("b", vec!["c"])]);
+        let all_nodes = vec!["a", "b", "c"];
+        assert_eq!(detect_cycles(&all_nodes, &children), 1);
+    }
+
+    #[test]
+    fn test_quality_scorer_deep_chain_end_to_end() {
+        use crate::model::{Component, DependencyEdge, DependencyType};
+        use crate::quality::{QualityScorer, ScoringProfile};
+
+        let n = 40_000usize;
+        let mut sbom = NormalizedSbom::default();
+        let mut ids = Vec::with_capacity(n);
+        for i in 0..n {
+            let component = Component::new(format!("node-{i}"), format!("ref-{i}"));
+            ids.push(component.canonical_id.clone());
+            sbom.add_component(component);
+        }
+        for w in ids.windows(2) {
+            sbom.add_edge(DependencyEdge::new(
+                w[0].clone(),
+                w[1].clone(),
+                DependencyType::DependsOn,
+            ));
+        }
+
+        let report = QualityScorer::new(ScoringProfile::Standard).score(&sbom);
+        assert!(!report.dependency_metrics.graph_analysis_skipped);
+        assert_eq!(report.dependency_metrics.cycle_count, 0);
+        assert_eq!(report.dependency_metrics.max_depth, Some(n - 1));
     }
 
     #[test]

--- a/src/quality/scorer.rs
+++ b/src/quality/scorer.rs
@@ -15,7 +15,7 @@ use super::metrics::{
 };
 
 /// Quality scoring engine version
-pub const SCORING_ENGINE_VERSION: &str = "2.0";
+pub const SCORING_ENGINE_VERSION: &str = "2.1";
 
 /// Returns true if any of the JSON pointers resolves to a non-empty value in `raw`.
 /// Used by the AI-readiness profile to inspect model-card fields preserved in
@@ -1345,7 +1345,7 @@ mod tests {
 
     #[test]
     fn test_scoring_engine_version() {
-        assert_eq!(SCORING_ENGINE_VERSION, "2.0");
+        assert_eq!(SCORING_ENGINE_VERSION, "2.1");
     }
 
     #[test]

--- a/tests/ffi_regression.rs
+++ b/tests/ffi_regression.rs
@@ -7,8 +7,8 @@ mod common;
 
 use common::ffi_helpers::{consume_result, into_c_string};
 use sbom_tools::ffi::{
-    SbomToolsErrorCode, sbom_tools_diff_sboms_json, sbom_tools_parse_sbom_path_json,
-    sbom_tools_parse_sbom_str_json,
+    SbomToolsErrorCode, SbomToolsScoringProfile, sbom_tools_diff_sboms_json,
+    sbom_tools_parse_sbom_path_json, sbom_tools_parse_sbom_str_json, sbom_tools_score_sbom_json,
 };
 use std::ffi::CString;
 use std::path::Path;
@@ -112,6 +112,56 @@ fn regression_cross_format_diff_cyclonedx_vs_spdx() {
     assert!(
         value["summary"].is_object(),
         "diff should have a summary object"
+    );
+}
+
+/// Regression: scoring a 40K-component linear dependency chain through FFI
+/// must not abort the host process (cycle detection is iterative, not recursive).
+#[test]
+fn regression_score_deep_dependency_chain_does_not_abort() {
+    let n = 40_000usize;
+    let components: Vec<serde_json::Value> = (0..n)
+        .map(|i| {
+            serde_json::json!({
+                "type": "library",
+                "bom-ref": format!("ref-{i}"),
+                "name": format!("node-{i}"),
+                "version": "1.0.0"
+            })
+        })
+        .collect();
+    let dependencies: Vec<serde_json::Value> = (0..n - 1)
+        .map(|i| {
+            serde_json::json!({
+                "ref": format!("ref-{i}"),
+                "dependsOn": [format!("ref-{}", i + 1)]
+            })
+        })
+        .collect();
+    let bom = serde_json::json!({
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.5",
+        "version": 1,
+        "components": components,
+        "dependencies": dependencies
+    });
+
+    let content_c = into_c_string(&bom.to_string());
+    let parsed = consume_result(sbom_tools_parse_sbom_str_json(content_c.as_ptr()))
+        .expect("deep-chain CycloneDX should parse");
+    let parsed_c = into_c_string(&parsed);
+
+    let score_json = consume_result(sbom_tools_score_sbom_json(
+        parsed_c.as_ptr(),
+        SbomToolsScoringProfile::Standard,
+    ))
+    .expect("scoring deep chain should succeed");
+
+    let value: serde_json::Value = serde_json::from_str(&score_json).expect("score is JSON");
+    assert_eq!(
+        value["dependency_metrics"]["cycle_count"].as_u64(),
+        Some(0),
+        "linear chain has no cycles"
     );
 }
 


### PR DESCRIPTION
## Summary

**Root cause:** `detect_cycles` in `src/quality/metrics.rs` used a recursive inner `fn dfs` (previously src/quality/metrics.rs:970-989), so a 40K-node linear dependency chain overflowed the call stack and SIGABRTed the process. The function is reachable from every `QualityScorer::score` call (CLI `quality`, diff pipeline, TUI) and from the FFI entry `sbom_tools_score_sbom_json` (src/ffi.rs:352), where `catch_unwind` cannot contain a stack-overflow abort — one hostile SBOM kills embedding Go/Swift hosts. Additionally, the DFS counted *back edges* rather than cycles (old metrics.rs:981), so a single SCC with k back edges was penalized k times (5 pts each, src/quality/metrics.rs:898) and any single back edge triggered the B-grade hard cap (src/quality/scorer.rs:906-913).

**Fix:**
- Replaced `detect_cycles` with an iterative Tarjan SCC algorithm (explicit call/SCC stacks, no recursion), same signature (src/quality/metrics.rs:963). New semantics: `cycle_count` = number of SCCs with >1 node, plus single-node SCCs with a self-loop — one SCC with several back edges now counts as ONE cycle.
- Raised `MAX_EDGES_FOR_GRAPH_ANALYSIS` from 50_000 to 1_000_000 (src/quality/metrics.rs:686); it remains purely a DoS ceiling since recursion depth is no longer a risk.
- Bumped `SCORING_ENGINE_VERSION` "2.0" → "2.1" (src/quality/scorer.rs:18): **scores change for cyclic graphs** (multi-back-edge SCCs are penalized once instead of per back edge).
- New fuzz target `fuzz/fuzz_targets/fuzz_score_sbom.rs` (parse arbitrary bytes → if parse succeeds, score with all 9 profiles), registered in `fuzz/Cargo.toml` and added to the `fuzz.yml` matrix.

## Test plan

- New unit tests in the `metrics.rs` test module: permanent 40K linear-chain probe (`test_cycle_detection_deep_linear_chain_no_overflow`), diamond DAG → 0, multi-back-edge SCC → 1, self-loop → 1, plus a 40K-chain end-to-end test through `QualityScorer::score` asserting `cycle_count == 0` and `max_depth == 39_999`.
- New FFI regression test `regression_score_deep_dependency_chain_does_not_abort` in `tests/ffi_regression.rs` driving a 40K-component CycloneDX chain through `sbom_tools_parse_sbom_str_json` → `sbom_tools_score_sbom_json`.
- Existing cycle assertions verified against the new SCC semantics (a 3-node ring is one SCC = 1 cycle; linear chain = 0 — values unchanged, comments clarified).
- Updated `test_scoring_engine_version` to "2.1".
- `cargo fmt`, `cargo clippy --all-targets` (no new warnings), full `cargo test --features ffi` (all 9 FFI regression + 800+ lib + all integration tests pass), `cd fuzz && cargo check` (new target compiles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)