### PR TITLE
fix(bindings): add AiReadiness profile to Go/Swift wrappers + constant drift check

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -9,6 +9,15 @@ on:
 permissions: read-all
 
 jobs:
+  constant-parity:
+    name: Binding Constant Parity
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - name: Check wrapper constants match sbom_tools.h
+        run: ./scripts/check-binding-constants.sh
+
   dagger-rust-sdk:
     name: Dagger CI (workspace check + staticlib + FFI tests + Go bindings)
     runs-on: ubuntu-latest

--- a/bindings/go/sbomtools.go
+++ b/bindings/go/sbomtools.go
@@ -39,6 +39,7 @@ const (
 	LicenseComplianceProfile ScoringProfile = ScoringProfile(C.SBOM_TOOLS_PROFILE_LICENSE_COMPLIANCE)
 	CRAProfile               ScoringProfile = ScoringProfile(C.SBOM_TOOLS_PROFILE_CRA)
 	ComprehensiveProfile     ScoringProfile = ScoringProfile(C.SBOM_TOOLS_PROFILE_COMPREHENSIVE)
+	AIReadinessProfile       ScoringProfile = ScoringProfile(C.SBOM_TOOLS_PROFILE_AI_READINESS)
 )
 
 type Error struct {

--- a/bindings/swift/Sources/SbomTools/SbomTools.swift
+++ b/bindings/swift/Sources/SbomTools/SbomTools.swift
@@ -67,6 +67,7 @@ public enum SbomToolsScoring: UInt32 {
     case licenseCompliance = 3
     case cra = 4
     case comprehensive = 5
+    case aiReadiness = 6
 }
 
 public struct SbomToolsError: Error, CustomStringConvertible {

--- a/scripts/check-binding-constants.sh
+++ b/scripts/check-binding-constants.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+header="$repo_root/bindings/swift/Sources/CSbomTools/include/sbom_tools.h"
+go_wrapper="$repo_root/bindings/go/sbomtools.go"
+swift_wrapper="$repo_root/bindings/swift/Sources/SbomTools/SbomTools.swift"
+
+failures=0
+
+fail() {
+  echo "DRIFT: $1" >&2
+  failures=$((failures + 1))
+}
+
+# SBOM_TOOLS_PROFILE_AI_READINESS -> aiReadiness
+to_swift_case() {
+  local raw="$1" out="" part lower first=1
+  for part in $(echo "$raw" | tr '_' ' '); do
+    lower="$(echo "$part" | tr '[:upper:]' '[:lower:]')"
+    if [ "$first" -eq 1 ]; then
+      out="$lower"
+      first=0
+    else
+      out="${out}$(echo "${lower:0:1}" | tr '[:lower:]' '[:upper:]')${lower:1}"
+    fi
+  done
+  echo "$out"
+}
+
+constants="$(grep -Eo 'SBOM_TOOLS_(PROFILE|ERROR)_[A-Z0-9_]+ = [0-9]+' "$header")"
+
+if [ -z "$constants" ]; then
+  echo "No SBOM_TOOLS_PROFILE_*/SBOM_TOOLS_ERROR_* constants found in $header" >&2
+  exit 2
+fi
+
+echo "[header] found $(echo "$constants" | wc -l | tr -d ' ') constants in ${header#"$repo_root"/}"
+
+# Go mirrors every header constant via cgo (C.<NAME>). cgo pins the value at
+# compile time, so a missing reference is the only way the wrapper can drift.
+while read -r name _ value; do
+  if ! grep -Eq "C\.${name}([^A-Za-z0-9_]|\$)" "$go_wrapper"; then
+    fail "Go wrapper missing C.$name (= $value); add a ScoringProfile/ErrorCode constant to ${go_wrapper#"$repo_root"/}"
+  fi
+done <<<"$constants"
+
+# Swift mirrors profiles in the SbomToolsScoring enum; error codes are consumed
+# directly from the vendored header via CSbomTools, so only profiles can drift.
+profiles="$(echo "$constants" | grep '^SBOM_TOOLS_PROFILE_')"
+scoring_enum="$(sed -n '/enum SbomToolsScoring/,/^}/p' "$swift_wrapper")"
+
+while read -r name _ value; do
+  case_name="$(to_swift_case "${name#SBOM_TOOLS_PROFILE_}")"
+  if ! echo "$scoring_enum" | grep -Eq "case[[:space:]]+${case_name}[[:space:]]*=[[:space:]]*${value}(\$|[^0-9])"; then
+    fail "Swift SbomToolsScoring missing 'case $case_name = $value' (from $name) in ${swift_wrapper#"$repo_root"/}"
+  fi
+done <<<"$profiles"
+
+header_profile_count="$(echo "$profiles" | wc -l | tr -d ' ')"
+swift_case_count="$(echo "$scoring_enum" | grep -Ec 'case[[:space:]]+[a-zA-Z]+[[:space:]]*=' || true)"
+if [ "$swift_case_count" != "$header_profile_count" ]; then
+  fail "Swift SbomToolsScoring has $swift_case_count cases but the header declares $header_profile_count profiles; remove stale cases"
+fi
+
+if [ "$failures" -gt 0 ]; then
+  echo "" >&2
+  echo "Binding constants are out of sync with sbom_tools.h ($failures issue(s))." >&2
+  echo "Update the wrappers to match the header, or update the header first if the FFI changed." >&2
+  exit 1
+fi
+
+echo "[go] OK: all header constants are referenced in ${go_wrapper#"$repo_root"/}"
+echo "[swift] OK: SbomToolsScoring matches the $header_profile_count header profiles"


### PR DESCRIPTION
## Summary

Commit 1e6063c added `SBOM_TOOLS_PROFILE_AI_READINESS = 6` to the hand-maintained C header (`bindings/swift/Sources/CSbomTools/include/sbom_tools.h:42`) and `src/ffi.rs:48`, but neither wrapper was updated: the Go `ScoringProfile` constants (`bindings/go/sbomtools.go:36-42`) stopped at `ComprehensiveProfile` and the Swift `SbomToolsScoring` enum (`bindings/swift/Sources/SbomTools/SbomTools.swift:63-70`) stopped at `comprehensive = 5`, so neither binding could request AI-readiness scoring. `tests/ffi_schema_snapshots.rs:88` only pins the header itself — wrapper drift was structurally undetected.

Fix:
- Add `AIReadinessProfile` to the Go wrapper (cgo-backed, so the value is pinned to the header at compile time) and `case aiReadiness = 6` to the Swift scoring enum.
- Add `scripts/check-binding-constants.sh`: extracts `SBOM_TOOLS_PROFILE_*` / `SBOM_TOOLS_ERROR_*` names+values from the header, asserts every constant is referenced as `C.<NAME>` in the Go wrapper, and asserts the Swift `SbomToolsScoring` enum has a `case <name> = <value>` for every profile plus a case-count check to catch stale cases. Swift consumes error codes directly from the vendored header via `CSbomTools` (no mirrored enum), so only profiles can drift on the Swift side.
- Wire the script into `.github/workflows/bindings.yml` as a new `constant-parity` job (checkout + plain run step, SHA-pinned action, matching existing step conventions).

This is the cheap guard; cbindgen adoption is a separate track.

## Test plan

- `./scripts/check-binding-constants.sh` passes on the fixed tree (14 header constants, 7 profiles).
- Negative test: with the wrapper edits stashed (pre-fix state), the script fails with 3 clear DRIFT messages (missing Go constant, missing Swift case, case-count mismatch) and exit 1.
- Built the FFI staticlib via `scripts/build-bindings-mvp.sh`, then ran both binding suites locally:
  - `go test ./...` in `bindings/go` — ok (go1.26.0)
  - `swift test` in `bindings/swift` — 7/7 tests pass (Swift 6.3.2, via Xcode toolchain; the bare CommandLineTools toolchain on this machine has a broken PackageDescription link, unrelated to this change)
- `gofmt -l` clean, `bash -n` clean, workflow YAML validated. No Rust code touched, so no cargo fmt/clippy/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)