### PR TITLE
fix(diff): incremental cache splices only from the last diffed pair; propagate errors

### DIFF
--- a/src/cli/multi.rs
+++ b/src/cli/multi.rs
@@ -67,7 +67,7 @@ pub fn run_diff_multi(config: MultiDiffConfig) -> Result<i32> {
         &baseline_name,
         &config.baseline.to_string_lossy(),
         &target_refs,
-    );
+    )?;
 
     tracing::info!(
         "Multi-diff complete: {} comparisons, max deviation: {:.1}%",
@@ -139,7 +139,7 @@ pub fn run_timeline(config: TimelineConfig) -> Result<i32> {
     if config.graph_diff.enabled {
         engine = engine.with_graph_diff(crate::diff::GraphDiffConfig::default());
     }
-    let result = engine.timeline(&sbom_refs);
+    let result = engine.timeline(&sbom_refs)?;
 
     tracing::info!(
         "Timeline analysis complete: {} incremental diffs",
@@ -195,7 +195,7 @@ pub fn run_matrix(config: MatrixConfig) -> Result<i32> {
     if config.graph_diff.enabled {
         engine = engine.with_graph_diff(crate::diff::GraphDiffConfig::default());
     }
-    let result = engine.matrix(&sbom_refs, Some(config.cluster_threshold));
+    let result = engine.matrix(&sbom_refs, Some(config.cluster_threshold))?;
 
     tracing::info!(
         "Matrix comparison complete: {} pairs computed",

--- a/src/diff/incremental.rs
+++ b/src/diff/incremental.rs
@@ -19,6 +19,7 @@
 //! - Cold start: Same as regular diff
 
 use crate::diff::{DiffEngine, DiffResult};
+use crate::error::SbomDiffError;
 use crate::model::NormalizedSbom;
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -306,18 +307,18 @@ impl DiffCache {
     ///
     /// Returns `Some` if an exact match is found and still valid.
     pub fn get(&self, key: &DiffCacheKey) -> Option<Arc<DiffResult>> {
-        let mut stats = self.stats.write().expect("stats lock poisoned");
-        stats.lookups += 1;
-
         let result = {
-            let cache = self.cache.read().expect("cache lock poisoned");
-            cache.get(key).and_then(|entry| {
-                entry
-                    .is_valid(self.config.ttl)
-                    .then(|| Arc::clone(&entry.result))
+            let mut cache = self.cache.write().expect("cache lock poisoned");
+            cache.get_mut(key).and_then(|entry| {
+                entry.is_valid(self.config.ttl).then(|| {
+                    entry.hit_count += 1;
+                    Arc::clone(&entry.result)
+                })
             })
         };
 
+        let mut stats = self.stats.write().expect("stats lock poisoned");
+        stats.lookups += 1;
         if let Some(ref result) = result {
             stats.hits += 1;
             stats.time_saved_ms += Self::estimate_computation_time(result);
@@ -400,6 +401,16 @@ impl Default for DiffCache {
 // Incremental Diff Engine
 // ============================================================================
 
+/// Metadata about the last diffed pair, used for incremental updates.
+struct LastDiffMeta {
+    /// Cache key of the last diffed pair
+    key: DiffCacheKey,
+    /// Section hashes from the last pair's old SBOM
+    old_hashes: SectionHashes,
+    /// Section hashes from the last pair's new SBOM
+    new_hashes: SectionHashes,
+}
+
 /// A diff engine wrapper that supports incremental computation and caching.
 ///
 /// Wraps the standard `DiffEngine` and adds:
@@ -412,8 +423,7 @@ pub struct IncrementalDiffEngine {
     /// Result cache
     cache: DiffCache,
     /// Track previous computation for incremental updates
-    last_old_hashes: RwLock<Option<SectionHashes>>,
-    last_new_hashes: RwLock<Option<SectionHashes>>,
+    last_diff: RwLock<Option<LastDiffMeta>>,
 }
 
 impl IncrementalDiffEngine {
@@ -423,8 +433,7 @@ impl IncrementalDiffEngine {
         Self {
             engine,
             cache: DiffCache::new(),
-            last_old_hashes: RwLock::new(None),
-            last_new_hashes: RwLock::new(None),
+            last_diff: RwLock::new(None),
         }
     }
 
@@ -434,88 +443,91 @@ impl IncrementalDiffEngine {
         Self {
             engine,
             cache: DiffCache::with_config(config),
-            last_old_hashes: RwLock::new(None),
-            last_new_hashes: RwLock::new(None),
+            last_diff: RwLock::new(None),
         }
     }
 
     /// Perform a diff, using cache when possible.
     ///
     /// Returns the diff result and metadata about cache usage.
-    pub fn diff(&self, old: &NormalizedSbom, new: &NormalizedSbom) -> IncrementalDiffResult {
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the underlying diff computation fails.
+    pub fn diff(
+        &self,
+        old: &NormalizedSbom,
+        new: &NormalizedSbom,
+    ) -> Result<IncrementalDiffResult, SbomDiffError> {
         let start = Instant::now();
         let cache_key = DiffCacheKey::from_sboms(old, new);
 
         // Check for exact cache hit
         if let Some(cached) = self.cache.get(&cache_key) {
-            return IncrementalDiffResult {
+            return Ok(IncrementalDiffResult {
                 result: (*cached).clone(),
                 cache_hit: CacheHitType::Full,
                 sections_recomputed: ChangedSections::default(),
                 computation_time: start.elapsed(),
-            };
+            });
         }
 
         // Compute section hashes
         let old_hashes = SectionHashes::from_sbom(old);
         let new_hashes = SectionHashes::from_sbom(new);
 
-        // Check for incremental opportunity
-        let changed = {
-            let last_old = self
-                .last_old_hashes
-                .read()
-                .expect("last_old_hashes lock poisoned");
-            let last_new = self
-                .last_new_hashes
-                .read()
-                .expect("last_new_hashes lock poisoned");
+        // Check for incremental opportunity against the last diffed pair
+        let (changed, prev_key) = {
+            let last = self.last_diff.read().expect("last_diff lock poisoned");
+            match &*last {
+                Some(meta) => {
+                    let old_changed = old_hashes != meta.old_hashes;
+                    let new_changed = new_hashes != meta.new_hashes;
 
-            if let (Some(prev_old), Some(prev_new)) = (&*last_old, &*last_new) {
-                // Check what changed since last computation
-                let old_changed = old_hashes != *prev_old;
-                let new_changed = new_hashes != *prev_new;
-
-                if !old_changed && !new_changed {
-                    // Nothing changed, but we don't have the result cached
-                    // This shouldn't normally happen, but fall through to full compute
-                    None
-                } else {
-                    Some(
-                        prev_old
-                            .changed_sections(&old_hashes)
-                            .or(&prev_new.changed_sections(&new_hashes)),
-                    )
+                    if !old_changed && !new_changed {
+                        // Nothing changed, but we don't have the result cached
+                        // This shouldn't normally happen, but fall through to full compute
+                        (None, None)
+                    } else {
+                        (
+                            Some(
+                                meta.old_hashes
+                                    .changed_sections(&old_hashes)
+                                    .or(&meta.new_hashes.changed_sections(&new_hashes)),
+                            ),
+                            Some(meta.key.clone()),
+                        )
+                    }
                 }
-            } else {
-                None
+                None => (None, None),
             }
         };
 
         // Section-selective or full computation
         let (result, cache_hit, sections_recomputed) = if let Some(ref changed) = changed
+            && let Some(ref prev_key) = prev_key
             && !changed.all()
             && changed.any()
         {
-            // We know which sections changed and it's a partial change —
-            // try to reuse cached sections from a previous result
-            if let Some(prev_result) = self.find_previous_result() {
+            // Change detection is relative to the last diffed pair, so only
+            // that exact pair's cached result is a valid splice base
+            if let Some(prev_result) = self.find_previous_result(prev_key) {
                 match self.engine.diff_sections(old, new, changed, &prev_result) {
                     Ok(result) => (result, CacheHitType::Partial, changed.clone()),
                     Err(_) => {
-                        // Fall back to full computation on any error
-                        let result = self.engine.diff(old, new).unwrap_or_default();
+                        // Fall back to full computation on diff_sections errors
+                        let result = self.engine.diff(old, new)?;
                         (result, CacheHitType::Miss, ChangedSections::all_changed())
                     }
                 }
             } else {
-                // No previous result to build on — full computation
-                let result = self.engine.diff(old, new).unwrap_or_default();
+                // Last pair's entry was evicted or expired — full computation
+                let result = self.engine.diff(old, new)?;
                 (result, CacheHitType::Miss, ChangedSections::all_changed())
             }
         } else {
             // Either no change detection possible, or all sections changed — full computation
-            let result = self.engine.diff(old, new).unwrap_or_default();
+            let result = self.engine.diff(old, new)?;
             let sections = changed.unwrap_or_else(ChangedSections::all_changed);
             (result, CacheHitType::Miss, sections)
         };
@@ -529,40 +541,37 @@ impl IncrementalDiffEngine {
 
         // Cache the result
         self.cache.put(
-            cache_key,
+            cache_key.clone(),
             result.clone(),
             old_hashes.clone(),
             new_hashes.clone(),
         );
 
-        // Update last hashes
-        *self
-            .last_old_hashes
-            .write()
-            .expect("last_old_hashes lock poisoned") = Some(old_hashes);
-        *self
-            .last_new_hashes
-            .write()
-            .expect("last_new_hashes lock poisoned") = Some(new_hashes);
+        // Update last diff metadata
+        *self.last_diff.write().expect("last_diff lock poisoned") = Some(LastDiffMeta {
+            key: cache_key,
+            old_hashes,
+            new_hashes,
+        });
 
-        IncrementalDiffResult {
+        Ok(IncrementalDiffResult {
             result,
             cache_hit,
             sections_recomputed,
             computation_time: start.elapsed(),
-        }
+        })
     }
 
-    /// Find a previous cached result to use as a base for incremental recomputation.
+    /// Find the last diffed pair's cached result to use as a base for
+    /// incremental recomputation.
     ///
-    /// Returns the most recently accessed (highest hit count) cached result,
-    /// which is the best candidate for reuse since it likely covers similar SBOMs.
-    fn find_previous_result(&self) -> Option<Arc<DiffResult>> {
+    /// Section change detection is computed against the last diffed pair, so
+    /// only that exact pair's cached entry is a valid splice base.
+    fn find_previous_result(&self, key: &DiffCacheKey) -> Option<Arc<DiffResult>> {
         let cache = self.cache.cache.read().ok()?;
         cache
-            .values()
-            .filter(|e| e.is_valid(Duration::from_secs(3600)))
-            .max_by_key(|e| e.hit_count)
+            .get(key)
+            .filter(|e| e.is_valid(self.cache.config.ttl))
             .map(|e| Arc::clone(&e.result))
     }
 
@@ -779,11 +788,11 @@ mod tests {
         let new = make_sbom("new", &["a", "b", "d"]);
 
         // First diff should be a miss
-        let result1 = incremental.diff(&old, &new);
+        let result1 = incremental.diff(&old, &new).expect("diff should succeed");
         assert_eq!(result1.cache_hit, CacheHitType::Miss);
 
         // Same diff should be a hit
-        let result2 = incremental.diff(&old, &new);
+        let result2 = incremental.diff(&old, &new).expect("diff should succeed");
         assert_eq!(result2.cache_hit, CacheHitType::Full);
 
         // Stats should reflect this
@@ -913,14 +922,14 @@ mod tests {
         let old = make_sbom("old", &["a", "b", "c"]);
         let new1 = make_sbom("new1", &["a", "b", "d"]);
 
-        // First diff populates last_old_hashes and last_new_hashes
-        let result1 = incremental.diff(&old, &new1);
+        // First diff populates the last-diff metadata
+        let result1 = incremental.diff(&old, &new1).expect("diff should succeed");
         assert_eq!(result1.cache_hit, CacheHitType::Miss);
 
         // Second diff with different SBOMs (different content hashes = no exact cache hit)
-        // but last_old_hashes/last_new_hashes are now set, so change detection runs
+        // but the last-diff metadata is now set, so change detection runs
         let new2 = make_sbom("new2", &["a", "b", "e"]);
-        let result2 = incremental.diff(&old, &new2);
+        let result2 = incremental.diff(&old, &new2).expect("diff should succeed");
 
         // This should either be a Partial hit (if section-selective kicked in)
         // or a Miss (if all sections changed). Either way, it should produce a valid result.
@@ -935,8 +944,12 @@ mod tests {
     fn test_find_previous_result_empty_cache() {
         let engine = DiffEngine::new();
         let incremental = IncrementalDiffEngine::new(engine);
+        let key = DiffCacheKey {
+            old_hash: 1,
+            new_hash: 2,
+        };
         // With an empty cache, find_previous_result should return None
-        assert!(incremental.find_previous_result().is_none());
+        assert!(incremental.find_previous_result(&key).is_none());
     }
 
     #[test]
@@ -948,9 +961,101 @@ mod tests {
         let new = make_sbom("new", &["a", "c"]);
 
         // Populate the cache
-        let _ = incremental.diff(&old, &new);
+        let _ = incremental.diff(&old, &new).expect("diff should succeed");
 
-        // Now find_previous_result should return Some
-        assert!(incremental.find_previous_result().is_some());
+        // The diffed pair's key should be retrievable; an unrelated key should not
+        let key = DiffCacheKey::from_sboms(&old, &new);
+        assert!(incremental.find_previous_result(&key).is_some());
+        let other_key = DiffCacheKey {
+            old_hash: key.old_hash.wrapping_add(1),
+            new_hash: key.new_hash,
+        };
+        assert!(incremental.find_previous_result(&other_key).is_none());
+    }
+
+    fn assert_sections_match(actual: &DiffResult, expected: &DiffResult) {
+        assert_eq!(
+            actual.components.added.len(),
+            expected.components.added.len()
+        );
+        assert_eq!(
+            actual.components.removed.len(),
+            expected.components.removed.len()
+        );
+        assert_eq!(
+            actual.components.modified.len(),
+            expected.components.modified.len()
+        );
+        assert_eq!(
+            actual.licenses.new_licenses.len(),
+            expected.licenses.new_licenses.len()
+        );
+        assert_eq!(
+            actual.licenses.removed_licenses.len(),
+            expected.licenses.removed_licenses.len()
+        );
+        assert_eq!(
+            actual.vulnerabilities.introduced.len(),
+            expected.vulnerabilities.introduced.len()
+        );
+        assert_eq!(
+            actual.vulnerabilities.resolved.len(),
+            expected.vulnerabilities.resolved.len()
+        );
+        assert_eq!(
+            actual.dependencies.added.len(),
+            expected.dependencies.added.len()
+        );
+        assert_eq!(
+            actual.dependencies.removed.len(),
+            expected.dependencies.removed.len()
+        );
+    }
+
+    #[test]
+    fn test_no_cross_pair_section_splice() {
+        // Note: DiffEngine::diff has no constructible Err path today, so the
+        // Result-propagation change is covered at the type level only.
+        let incremental = IncrementalDiffEngine::new(DiffEngine::new());
+
+        let a_old = make_sbom("a-old", &["a", "b", "c"]);
+        let a_new = make_sbom("a-new", &["a", "b", "d"]);
+        let b_old = make_sbom("b-old", &["x", "y"]);
+        let b_new = make_sbom("b-new", &["x", "z", "w"]);
+
+        // Pair A first, then pair B through the same engine
+        let _ = incremental
+            .diff(&a_old, &a_new)
+            .expect("diff should succeed");
+        let b_result = incremental
+            .diff(&b_old, &b_new)
+            .expect("diff should succeed");
+
+        // Every section of B's result must match a from-scratch full diff —
+        // no sections spliced in from pair A's cached result
+        let fresh = DiffEngine::new()
+            .diff(&b_old, &b_new)
+            .expect("diff should succeed");
+        assert_sections_match(&b_result.result, &fresh);
+    }
+
+    #[test]
+    fn test_partial_splice_uses_last_pair_base() {
+        let incremental = IncrementalDiffEngine::new(DiffEngine::new());
+
+        let s0 = make_sbom("s0", &["a", "b", "c"]);
+        let s1 = make_sbom("s1", &["a", "b", "d"]);
+        let s2 = make_sbom("s2", &["a", "b", "e"]);
+
+        // s0->s1 first so that s0->s2 only differs in the components section
+        let _ = incremental.diff(&s0, &s1).expect("diff should succeed");
+        let result = incremental.diff(&s0, &s2).expect("diff should succeed");
+        assert_eq!(result.cache_hit, CacheHitType::Partial);
+
+        // The spliced result must match a from-scratch full diff of s0->s2
+        let fresh = DiffEngine::new()
+            .diff(&s0, &s2)
+            .expect("diff should succeed");
+        assert_sections_match(&result.result, &fresh);
     }
 }

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -26,7 +26,7 @@
 //! // For repeated diffs, use the incremental engine:
 //! use sbom_tools::diff::IncrementalDiffEngine;
 //! let incremental = IncrementalDiffEngine::new(engine);
-//! let result = incremental.diff(&old, &new);
+//! let result = incremental.diff(&old, &new)?;
 //! if result.was_cached() {
 //!     println!("Cache hit!");
 //! }

--- a/src/diff/multi_engine.rs
+++ b/src/diff/multi_engine.rs
@@ -13,6 +13,7 @@ use super::multi::{
     VersionChangeType, VersionSpread, VulnerabilityMatrix, VulnerabilitySnapshot,
 };
 use super::{DiffEngine, DiffResult};
+use crate::error::SbomDiffError;
 use crate::matching::FuzzyMatchConfig;
 use crate::model::{NormalizedSbom, VulnerabilityCounts};
 use std::collections::{HashMap, HashSet};
@@ -84,23 +85,32 @@ impl MultiDiffEngine {
     }
 
     /// Perform a single diff using the cached incremental engine.
-    fn cached_diff(&mut self, old: &NormalizedSbom, new: &NormalizedSbom) -> DiffResult {
+    fn cached_diff(
+        &mut self,
+        old: &NormalizedSbom,
+        new: &NormalizedSbom,
+    ) -> Result<DiffResult, SbomDiffError> {
         self.ensure_engine();
-        self.incremental
+        Ok(self
+            .incremental
             .as_ref()
             .expect("engine initialized by ensure_engine")
-            .diff(old, new)
-            .into_result()
+            .diff(old, new)?
+            .into_result())
     }
 
     /// Perform 1:N diff-multi comparison (baseline vs multiple targets)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any pairwise diff computation fails.
     pub fn diff_multi(
         &mut self,
         baseline: &NormalizedSbom,
         baseline_name: &str,
         baseline_path: &str,
         targets: &[(&NormalizedSbom, &str, &str)], // (sbom, name, path)
-    ) -> MultiDiffResult {
+    ) -> Result<MultiDiffResult, SbomDiffError> {
         let baseline_info = SbomInfo::from_sbom(
             baseline,
             baseline_name.to_string(),
@@ -121,7 +131,7 @@ impl MultiDiffEngine {
         }
 
         for (target_sbom, target_name, target_path) in targets {
-            let diff = self.cached_diff(baseline, target_sbom);
+            let diff = self.cached_diff(baseline, target_sbom)?;
             let target_info = SbomInfo::from_sbom(
                 target_sbom,
                 target_name.to_string(),
@@ -161,11 +171,11 @@ impl MultiDiffEngine {
                 self.find_divergent_components(baseline, target_sbom, target_name, &all_versions);
         }
 
-        MultiDiffResult {
+        Ok(MultiDiffResult {
             baseline: baseline_info,
             comparisons,
             summary,
-        }
+        })
     }
 
     fn compute_multi_diff_summary(
@@ -387,10 +397,14 @@ impl MultiDiffEngine {
     }
 
     /// Perform timeline analysis across ordered SBOM versions
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any pairwise diff computation fails.
     pub fn timeline(
         &mut self,
         sboms: &[(&NormalizedSbom, &str, &str)], // (sbom, name, path)
-    ) -> TimelineResult {
+    ) -> Result<TimelineResult, SbomDiffError> {
         let sbom_infos: Vec<SbomInfo> = sboms
             .iter()
             .map(|(sbom, name, path)| SbomInfo::from_sbom(sbom, name.to_string(), path.to_string()))
@@ -399,7 +413,7 @@ impl MultiDiffEngine {
         // Compute incremental diffs (adjacent pairs)
         let mut incremental_diffs: Vec<DiffResult> = vec![];
         for i in 0..sboms.len().saturating_sub(1) {
-            let diff = self.cached_diff(sboms[i].0, sboms[i + 1].0);
+            let diff = self.cached_diff(sboms[i].0, sboms[i + 1].0)?;
             incremental_diffs.push(diff);
         }
 
@@ -407,7 +421,7 @@ impl MultiDiffEngine {
         let mut cumulative_from_first: Vec<DiffResult> = vec![];
         if !sboms.is_empty() {
             for i in 1..sboms.len() {
-                let diff = self.cached_diff(sboms[0].0, sboms[i].0);
+                let diff = self.cached_diff(sboms[0].0, sboms[i].0)?;
                 cumulative_from_first.push(diff);
             }
         }
@@ -416,12 +430,12 @@ impl MultiDiffEngine {
         let evolution_summary =
             self.build_evolution_summary(sboms, &sbom_infos, &incremental_diffs);
 
-        TimelineResult {
+        Ok(TimelineResult {
             sboms: sbom_infos,
             incremental_diffs,
             cumulative_from_first,
             evolution_summary,
-        }
+        })
     }
 
     fn build_evolution_summary(
@@ -608,11 +622,15 @@ impl MultiDiffEngine {
     }
 
     /// Perform N×N matrix comparison
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any pairwise diff computation fails.
     pub fn matrix(
         &mut self,
         sboms: &[(&NormalizedSbom, &str, &str)], // (sbom, name, path)
         similarity_threshold: Option<f64>,
-    ) -> MatrixResult {
+    ) -> Result<MatrixResult, SbomDiffError> {
         let sbom_infos: Vec<SbomInfo> = sboms
             .iter()
             .map(|(sbom, name, path)| SbomInfo::from_sbom(sbom, name.to_string(), path.to_string()))
@@ -628,7 +646,7 @@ impl MultiDiffEngine {
         let mut idx = 0;
         for i in 0..n {
             for j in (i + 1)..n {
-                let diff = self.cached_diff(sboms[i].0, sboms[j].0);
+                let diff = self.cached_diff(sboms[i].0, sboms[j].0)?;
                 let similarity = diff.semantic_score / 100.0;
                 similarity_scores[idx] = similarity;
                 diffs[idx] = Some(diff);
@@ -640,12 +658,12 @@ impl MultiDiffEngine {
         let clustering = similarity_threshold
             .map(|threshold| self.cluster_sboms(&sbom_infos, &similarity_scores, threshold));
 
-        MatrixResult {
+        Ok(MatrixResult {
             sboms: sbom_infos,
             diffs,
             similarity_scores,
             clustering,
-        }
+        })
     }
 
     fn cluster_sboms(


### PR DESCRIPTION
## Summary

**Root cause.** `IncrementalDiffEngine::find_previous_result` (src/diff/incremental.rs:560-567 at b81314f) picked the cached entry with `max_by_key(hit_count)` — but `hit_count` was set to 0 at insert (src/diff/incremental.rs:204) and never incremented, so an **arbitrary** cached entry (possibly a different SBOM pair) became the splice base for `diff_sections`. Section change detection (src/diff/incremental.rs:464-493) is computed against `last_old_hashes`/`last_new_hashes` — the **last diffed pair** — so the only valid splice base is that exact pair's cached entry; splicing from any other pair leaves stale unchanged-sections in the output. The lookup also hardcoded `Duration::from_secs(3600)` instead of the configured `cache.config.ttl`, and `unwrap_or_default()` at lines 507/513/518 turned diff errors into empty "no changes" results.

**Fix.**
- Replaced `last_old_hashes`/`last_new_hashes` with a single `last_diff: RwLock<Option<LastDiffMeta>>` carrying the last pair's cache **key** plus its section hashes; `find_previous_result` now looks the cache up **by that key**, validated against the configured TTL (`src/diff/incremental.rs`). Evicted/expired → existing full-compute branch.
- `IncrementalDiffEngine::diff` returns `Result<IncrementalDiffResult, SbomDiffError>`; the three `unwrap_or_default()` became `?`. The fall-back-to-full-diff behavior on `diff_sections` errors is kept, but `engine.diff` errors now propagate.
- `DiffCache::get` increments `hit_count` on valid hits (write lock + `get_mut`), so the field is truthful.
- Ripple: `MultiDiffEngine::{diff_multi, timeline, matrix}` now return `Result<_, SbomDiffError>`; `?` added at the `cached_diff` call sites and in `cli/multi.rs` (anyhow converts the thiserror type). Doc example in `src/diff/mod.rs` updated.

**Behavioral notes (intentional):**
- **Public API break**: `IncrementalDiffEngine::diff` and `MultiDiffEngine::{diff_multi, timeline, matrix}` now return `Result`.
- **Partial-cache reuse becomes rarer by design** — only the exact last diffed pair's cached entry qualifies as a splice base (correctness over speed).
- The full-result (exact-match) cache is untouched.

## Test plan

- New `test_no_cross_pair_section_splice`: diffs pair A then pair B through the same engine and asserts every section of B's result (components added/removed/modified, licenses, vulnerabilities, dependencies) equals a from-scratch `DiffEngine::new().diff(b_old, b_new)`.
- New `test_partial_splice_uses_last_pair_base`: s0→s1 then s0→s2; asserts `cache_hit` is `Partial` **and** contents equal a fresh full diff. (`DiffEngine::diff` has no constructible `Err` path today, so the error-propagation change is covered at the type level only — noted in a test comment.)
- Updated existing in-file tests for the `Result` signature and `find_previous_result`'s new key parameter.
- `cargo fmt --check` clean; `cargo clippy --all-targets` introduces no new warnings (local Homebrew rustc 1.96 shows 39 pre-existing warnings identical at HEAD; pinned 1.88 CI is clean).
- Targeted: 15/15 `diff::incremental` tests pass. Full `cargo test`: 1220 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)