### PR TITLE
fix(matching): deterministic MinHash seeds and solver ordering; add diff property tests

### DIFF
--- a/src/diff/changes/components.rs
+++ b/src/diff/changes/components.rs
@@ -357,6 +357,11 @@ impl ChangeComputer for ComponentChangeComputer {
             }
         }
 
+        // Removed/modified are collected from hash-map iteration; sort by ID
+        // for deterministic output ordering
+        result.removed.sort_by(|a, b| a.id.cmp(&b.id));
+        result.modified.sort_by(|a, b| a.id.cmp(&b.id));
+
         result
     }
 

--- a/src/diff/changes/licenses.rs
+++ b/src/diff/changes/licenses.rs
@@ -77,6 +77,15 @@ impl ChangeComputer for LicenseChangeComputer {
             }
         }
 
+        // License sets are collected from hash-map iteration; sort for
+        // deterministic output ordering
+        result
+            .new_licenses
+            .sort_by(|a, b| a.license.cmp(&b.license));
+        result
+            .removed_licenses
+            .sort_by(|a, b| a.license.cmp(&b.license));
+
         result
     }
 

--- a/src/diff/engine.rs
+++ b/src/diff/engine.rs
@@ -175,7 +175,10 @@ impl DiffEngine {
 
         // Compute match metrics for observability
         {
-            let scores: Vec<f64> = component_matches.pairs.values().copied().collect();
+            // Sorted so float accumulation order (and thus the serialized
+            // average) is identical across runs
+            let mut scores: Vec<f64> = component_matches.pairs.values().copied().collect();
+            scores.sort_unstable_by(f64::total_cmp);
             let exact = scores.iter().filter(|&&s| s >= 0.99).count();
             let fuzzy = scores.len() - exact;
             let matched_count = scores.len();

--- a/src/diff/engine_matching.rs
+++ b/src/diff/engine_matching.rs
@@ -423,15 +423,20 @@ fn optimal_assignment(
         return Vec::new();
     }
 
-    // Build unique sets of old and new IDs from candidates
+    // Build unique sets of old and new IDs from candidates, in stable order
+    // so solver tie-breaking is reproducible across runs
     let old_ids: Vec<CanonicalId> = {
         let set: HashSet<_> = candidates.iter().map(|(o, _, _)| o.clone()).collect();
-        set.into_iter().collect()
+        let mut ids: Vec<_> = set.into_iter().collect();
+        ids.sort_by(|a, b| a.value().cmp(b.value()));
+        ids
     };
 
     let new_ids: Vec<CanonicalId> = {
         let set: HashSet<_> = candidates.iter().map(|(_, n, _)| n.clone()).collect();
-        set.into_iter().collect()
+        let mut ids: Vec<_> = set.into_iter().collect();
+        ids.sort_by(|a, b| a.value().cmp(b.value()));
+        ids
     };
 
     let n = old_ids.len().max(new_ids.len());
@@ -531,7 +536,13 @@ fn greedy_assignment(
     use std::cmp::Ordering;
 
     let mut sorted: Vec<_> = candidates.to_vec();
-    sorted.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(Ordering::Equal));
+    // Break score ties by ID so the greedy result is stable across runs
+    sorted.sort_by(|a, b| {
+        b.2.partial_cmp(&a.2)
+            .unwrap_or(Ordering::Equal)
+            .then_with(|| a.0.value().cmp(b.0.value()))
+            .then_with(|| a.1.value().cmp(b.1.value()))
+    });
 
     let mut result = Vec::new();
     let mut used_old: HashSet<CanonicalId> = HashSet::new();

--- a/src/diff/traits.rs
+++ b/src/diff/traits.rs
@@ -125,6 +125,9 @@ impl VulnerabilityChangeSet {
     }
 
     /// Sort vulnerabilities by severity (critical first).
+    ///
+    /// Ties are broken by vulnerability and component ID since the details
+    /// are collected from hash-map iteration in otherwise random order.
     pub fn sort_by_severity(&mut self) {
         let severity_order = |s: &str| match s {
             "Critical" => 0,
@@ -133,11 +136,21 @@ impl VulnerabilityChangeSet {
             "Low" => 3,
             _ => 4,
         };
+        let detail_order = |a: &VulnerabilityDetail, b: &VulnerabilityDetail| {
+            severity_order(&a.severity)
+                .cmp(&severity_order(&b.severity))
+                .then_with(|| a.id.cmp(&b.id))
+                .then_with(|| a.component_id.cmp(&b.component_id))
+        };
 
-        self.introduced
-            .sort_by(|a, b| severity_order(&a.severity).cmp(&severity_order(&b.severity)));
-        self.resolved
-            .sort_by(|a, b| severity_order(&a.severity).cmp(&severity_order(&b.severity)));
+        self.introduced.sort_by(detail_order);
+        self.resolved.sort_by(detail_order);
+        self.persistent.sort_by(detail_order);
+        self.vex_changes.sort_by(|a, b| {
+            a.vuln_id
+                .cmp(&b.vuln_id)
+                .then_with(|| a.component_name.cmp(&b.component_name))
+        });
     }
 }
 

--- a/src/matching/index.rs
+++ b/src/matching/index.rs
@@ -323,26 +323,33 @@ impl ComponentIndex {
         }
 
         // Priority 3: Similar prefixes (1-char difference in prefix)
+        // Iterated in sorted prefix order so truncation is deterministic
         if candidates.len() < max_candidates && source_entry.prefix.len() >= 2 {
             let prefix_2 = &source_entry.prefix[..2.min(source_entry.prefix.len())];
-            for (prefix, ids) in &self.by_prefix {
-                if prefix.starts_with(prefix_2) && prefix != &source_entry.prefix {
-                    for id in ids {
-                        if id.as_ref() != source_id
-                            && !seen.contains(id)
-                            && let Some(entry) = self.entries.get(id.as_ref())
-                        {
-                            let len_diff = (source_entry.name_length as i32
-                                - entry.name_length as i32)
-                                .unsigned_abs() as usize;
-                            if len_diff <= max_length_diff {
-                                candidates.push(Arc::clone(id));
-                                seen.insert(Arc::clone(id));
-                            }
+            let mut similar_prefixes: Vec<_> = self
+                .by_prefix
+                .iter()
+                .filter(|(prefix, _)| {
+                    prefix.starts_with(prefix_2) && *prefix != &source_entry.prefix
+                })
+                .collect();
+            similar_prefixes.sort_by(|a, b| a.0.cmp(b.0));
+
+            for (_prefix, ids) in similar_prefixes {
+                for id in ids {
+                    if id.as_ref() != source_id
+                        && !seen.contains(id)
+                        && let Some(entry) = self.entries.get(id.as_ref())
+                    {
+                        let len_diff = (source_entry.name_length as i32 - entry.name_length as i32)
+                            .unsigned_abs() as usize;
+                        if len_diff <= max_length_diff {
+                            candidates.push(Arc::clone(id));
+                            seen.insert(Arc::clone(id));
                         }
-                        if candidates.len() >= max_candidates {
-                            break;
-                        }
+                    }
+                    if candidates.len() >= max_candidates {
+                        break;
                     }
                 }
                 if candidates.len() >= max_candidates {
@@ -374,12 +381,13 @@ impl ComponentIndex {
                 2
             };
 
-            // Sort by trigram overlap count (descending)
+            // Sort by trigram overlap count (descending), breaking ties by ID
+            // so truncation is deterministic
             let mut scored: Vec<_> = trigram_scores
                 .into_iter()
                 .filter(|(_, count)| *count >= min_shared)
                 .collect();
-            scored.sort_by(|a, b| b.1.cmp(&a.1));
+            scored.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.value().cmp(b.0.value())));
 
             for (id, _score) in scored {
                 if candidates.len() >= max_candidates {

--- a/src/matching/lsh.rs
+++ b/src/matching/lsh.rs
@@ -22,6 +22,25 @@ use crate::model::{CanonicalId, Component, NormalizedSbom};
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};
 
+/// Fixed seed for `MinHash` coefficient generation.
+///
+/// Coefficients must be identical across runs so that LSH candidate sets —
+/// and therefore diff results for large SBOMs — are reproducible. Never seed
+/// from input data or process-local randomness.
+const MINHASH_COEFF_SEED: u64 = 0x9E37_79B9_7F4A_7C15;
+
+/// splitmix64 PRNG step (public-domain generator by Sebastiano Vigna).
+///
+/// Produces well-distributed 64-bit values from a sequential seed, which is
+/// all `MinHash` needs for its `h(x) = a*x + b` coefficient pairs.
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
 /// Configuration for LSH index.
 #[derive(Debug, Clone)]
 pub struct LshConfig {
@@ -151,17 +170,14 @@ impl LshIndex {
     /// Create a new LSH index with the given configuration.
     #[must_use]
     pub fn new(config: LshConfig) -> Self {
-        use std::collections::hash_map::RandomState;
-        use std::hash::BuildHasher;
-
-        // Generate random hash coefficients
+        // Generate hash coefficients deterministically from a fixed seed
         let mut hash_coeffs = Vec::with_capacity(config.num_hashes);
-        let random_state = RandomState::new();
+        let mut seed = MINHASH_COEFF_SEED;
 
-        for i in 0..config.num_hashes {
-            let a = random_state.hash_one(i as u64 * 31337) | 1; // Ensure odd (coprime with 2^64)
+        for _ in 0..config.num_hashes {
+            let a = splitmix64(&mut seed) | 1; // Ensure odd (coprime with 2^64)
 
-            let b = random_state.hash_one(i as u64 * 7919 + 12345);
+            let b = splitmix64(&mut seed);
 
             hash_coeffs.push((a, b));
         }
@@ -220,9 +236,13 @@ impl LshIndex {
     }
 
     /// Find candidates using a pre-computed signature.
+    ///
+    /// Candidates are returned in deterministic band/bucket order so that
+    /// downstream truncation selects the same subset across runs.
     #[must_use]
     pub fn find_candidates_by_signature(&self, signature: &MinHashSignature) -> Vec<CanonicalId> {
-        let mut candidates = HashSet::new();
+        let mut candidates = Vec::new();
+        let mut seen = HashSet::new();
         let rows_per_band = self.config.rows_per_band();
 
         for (band_idx, bucket_map) in self.buckets.iter().enumerate() {
@@ -230,12 +250,14 @@ impl LshIndex {
 
             if let Some(ids) = bucket_map.get(&band_hash) {
                 for id in ids {
-                    candidates.insert(id.clone());
+                    if seen.insert(id.clone()) {
+                        candidates.push(id.clone());
+                    }
                 }
             }
         }
 
-        candidates.into_iter().collect()
+        candidates
     }
 
     /// Find candidates for a component from another index.
@@ -538,6 +560,32 @@ mod tests {
             "lodash vs lodash-es ({:.2}) should be more similar than lodash vs completely-different ({:.2})",
             sim_12,
             sim_13
+        );
+    }
+
+    #[test]
+    fn test_lsh_deterministic_across_instances() {
+        let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
+        for name in ["lodash", "lodash-es", "underscore", "react", "angular"] {
+            sbom.add_component(make_component(name));
+        }
+
+        let index_a = LshIndex::build(&sbom, LshConfig::default_balanced());
+        let index_b = LshIndex::build(&sbom, LshConfig::default_balanced());
+
+        for id in sbom.components.keys() {
+            assert_eq!(
+                index_a.get_signature(id).unwrap().values,
+                index_b.get_signature(id).unwrap().values,
+                "signatures must be identical across index instances"
+            );
+        }
+
+        let query = make_component("lodash");
+        assert_eq!(
+            index_a.find_candidates(&query),
+            index_b.find_candidates(&query),
+            "candidate lists must be identical (same content and order)"
         );
     }
 

--- a/tests/proptest_diff.rs
+++ b/tests/proptest_diff.rs
@@ -1,0 +1,163 @@
+//! Property-based tests for diff engine invariants.
+//!
+//! Verifies that the semantic diff engine satisfies key properties:
+//! reflexivity (diff(a, a) reports no changes), added/removed symmetry
+//! between diff directions, and deterministic serialized output across
+//! repeated runs — including SBOMs above the 500-component LSH threshold.
+
+use proptest::prelude::*;
+use sbom_tools::diff::DiffEngine;
+use sbom_tools::model::{Component, DocumentMetadata, NormalizedSbom};
+use std::collections::HashSet;
+
+/// Generate an arbitrary component with random fields.
+///
+/// Mirrors `arb_component` in `proptest_matching.rs`: names are at least
+/// 3 characters with no hyphens to avoid known alias-table asymmetries.
+fn arb_component() -> impl Strategy<Value = Component> {
+    (
+        "[a-z][a-z0-9]{2}[a-z0-9]{0,17}", // name (min 3 chars, no hyphens to avoid alias asymmetry)
+        prop::option::of("[0-9]{1,2}\\.[0-9]{1,2}\\.[0-9]{1,2}"), // version
+        prop::option::of(prop::sample::select(vec![
+            "npm", "pypi", "maven", "cargo", "golang",
+        ])),
+    )
+        .prop_map(|(name, version, ecosystem)| {
+            let format_id = format!("test:{name}");
+            let mut comp = Component::new(name, format_id);
+            if let Some(v) = version {
+                comp = comp.with_version(v);
+            }
+            if let Some(eco) = ecosystem {
+                comp.ecosystem = Some(sbom_tools::model::Ecosystem::from_purl_type(eco));
+            }
+            comp
+        })
+}
+
+/// Build a normalized SBOM from a list of components.
+///
+/// Per-component content hashes are computed (as parsers do) so the diff
+/// engine can detect modifications.
+fn build_sbom(components: Vec<Component>) -> NormalizedSbom {
+    let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
+    for mut comp in components {
+        comp.calculate_content_hash();
+        sbom.add_component(comp);
+    }
+    sbom
+}
+
+/// Mutation applied per base component when deriving the "new" SBOM.
+#[derive(Debug, Clone, Copy)]
+enum Mutation {
+    /// Component is carried over unchanged
+    Keep,
+    /// Component is replaced by a same-name variant with a new format ID and
+    /// version, forcing it through the fuzzy-matching path
+    Bump,
+    /// Component is removed
+    Drop,
+}
+
+fn arb_mutation() -> impl Strategy<Value = Mutation> {
+    prop_oneof![
+        4 => Just(Mutation::Keep),
+        1 => Just(Mutation::Bump),
+        1 => Just(Mutation::Drop),
+    ]
+}
+
+fn apply_mutations(
+    base: &[Component],
+    mutations: &[Mutation],
+    added: Vec<Component>,
+) -> Vec<Component> {
+    let mut out = Vec::with_capacity(base.len() + added.len());
+    for (comp, mutation) in base.iter().zip(mutations) {
+        match mutation {
+            Mutation::Keep => out.push(comp.clone()),
+            Mutation::Bump => {
+                let mut bumped = Component::new(comp.name.clone(), format!("v2:{}", comp.name))
+                    .with_version("99.0.0".to_string());
+                bumped.ecosystem = comp.ecosystem.clone();
+                out.push(bumped);
+            }
+            Mutation::Drop => {}
+        }
+    }
+    out.extend(added);
+    out
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    #[test]
+    fn diff_with_self_yields_no_changes(
+        components in prop::collection::vec(arb_component(), 0..40),
+    ) {
+        let sbom = build_sbom(components);
+        let engine = DiffEngine::new();
+        let result = engine.diff(&sbom, &sbom).expect("diff should succeed");
+
+        prop_assert!(result.components.added.is_empty());
+        prop_assert!(result.components.removed.is_empty());
+        prop_assert!(result.components.modified.is_empty());
+    }
+
+    #[test]
+    fn forward_added_equals_reverse_removed(
+        a_comps in prop::collection::vec(arb_component(), 0..40),
+        b_comps in prop::collection::vec(arb_component(), 0..40),
+    ) {
+        let a = build_sbom(a_comps);
+        let b = build_sbom(b_comps);
+        let engine = DiffEngine::new();
+
+        let forward = engine.diff(&a, &b).expect("diff should succeed");
+        let reverse = engine.diff(&b, &a).expect("diff should succeed");
+
+        let forward_added: HashSet<String> = forward
+            .components
+            .added
+            .iter()
+            .map(|c| c.id.clone())
+            .collect();
+        let reverse_removed: HashSet<String> = reverse
+            .components
+            .removed
+            .iter()
+            .map(|c| c.id.clone())
+            .collect();
+
+        prop_assert_eq!(forward_added, reverse_removed);
+    }
+}
+
+proptest! {
+    // Low case count: each case diffs >500-component SBOMs twice
+    #![proptest_config(ProptestConfig::with_cases(10))]
+
+    #[test]
+    fn large_diff_output_is_deterministic(
+        pairs in prop::collection::vec((arb_component(), arb_mutation()), 520..560),
+        added in prop::collection::vec(arb_component(), 0..30),
+    ) {
+        let (base, mutations): (Vec<_>, Vec<_>) = pairs.into_iter().unzip();
+        let old = build_sbom(base.clone());
+        let new = build_sbom(apply_mutations(&base, &mutations, added));
+
+        // Above the 500-component LSH threshold, so MinHash-based candidate
+        // generation participates in matching
+        prop_assert!(old.component_count() >= 500);
+
+        let run = || {
+            let engine = DiffEngine::new();
+            let result = engine.diff(&old, &new).expect("diff should succeed");
+            serde_json::to_string(&result).expect("diff result should serialize")
+        };
+
+        prop_assert_eq!(run(), run());
+    }
+}

--- a/tests/proptest_quality.rs
+++ b/tests/proptest_quality.rs
@@ -1,0 +1,110 @@
+//! Property-based tests for quality scoring and SBOM merge invariants.
+//!
+//! Verifies that `QualityScorer` produces bounded scores with grades
+//! consistent with the score across all scoring profiles, and that merging
+//! an SBOM with itself (raw-JSON layer) preserves the component count.
+
+use proptest::prelude::*;
+use sbom_tools::model::{Component, DocumentMetadata, NormalizedSbom};
+use sbom_tools::quality::{QualityGrade, QualityScorer, ScoringProfile};
+use sbom_tools::serialization::{MergeConfig, merge_sbom_json};
+
+/// Generate an arbitrary component with random fields.
+///
+/// Mirrors `arb_component` in `proptest_matching.rs`: names are at least
+/// 3 characters with no hyphens to avoid known alias-table asymmetries.
+fn arb_component() -> impl Strategy<Value = Component> {
+    (
+        "[a-z][a-z0-9]{2}[a-z0-9]{0,17}", // name (min 3 chars, no hyphens to avoid alias asymmetry)
+        prop::option::of("[0-9]{1,2}\\.[0-9]{1,2}\\.[0-9]{1,2}"), // version
+        prop::option::of(prop::sample::select(vec![
+            "npm", "pypi", "maven", "cargo", "golang",
+        ])),
+    )
+        .prop_map(|(name, version, ecosystem)| {
+            let format_id = format!("test:{name}");
+            let mut comp = Component::new(name, format_id);
+            if let Some(v) = version {
+                comp = comp.with_version(v);
+            }
+            if let Some(eco) = ecosystem {
+                comp.ecosystem = Some(sbom_tools::model::Ecosystem::from_purl_type(eco));
+            }
+            comp
+        })
+}
+
+fn build_sbom(components: Vec<Component>) -> NormalizedSbom {
+    let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
+    for mut comp in components {
+        comp.calculate_content_hash();
+        sbom.add_component(comp);
+    }
+    sbom
+}
+
+const ALL_PROFILES: [ScoringProfile; 9] = [
+    ScoringProfile::Minimal,
+    ScoringProfile::Standard,
+    ScoringProfile::Security,
+    ScoringProfile::LicenseCompliance,
+    ScoringProfile::Cra,
+    ScoringProfile::BsiTr03183_2,
+    ScoringProfile::Comprehensive,
+    ScoringProfile::Cbom,
+    ScoringProfile::AiReadiness,
+];
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    #[test]
+    fn quality_score_bounded_with_consistent_grade(
+        components in prop::collection::vec(arb_component(), 0..60),
+    ) {
+        let sbom = build_sbom(components);
+
+        for profile in ALL_PROFILES {
+            let report = QualityScorer::new(profile).score(&sbom);
+
+            prop_assert!(
+                report.overall_score.is_finite()
+                    && (0.0..=100.0).contains(&report.overall_score),
+                "score out of range for {:?}: {}",
+                profile,
+                report.overall_score
+            );
+            prop_assert_eq!(
+                report.grade,
+                QualityGrade::from_score(report.overall_score),
+                "grade {:?} inconsistent with score {} for {:?}",
+                report.grade,
+                report.overall_score,
+                profile
+            );
+        }
+    }
+
+    #[test]
+    fn merge_with_self_preserves_component_count(
+        components in prop::collection::vec(arb_component(), 0..40),
+    ) {
+        let doc = serde_json::json!({
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "components": components
+                .iter()
+                .map(|c| serde_json::json!({"name": c.name, "version": c.version}))
+                .collect::<Vec<_>>(),
+        });
+        let doc_str = doc.to_string();
+
+        let merged = merge_sbom_json(&doc_str, &doc_str, &MergeConfig::default())
+            .expect("merge should succeed");
+        let merged_doc: serde_json::Value =
+            serde_json::from_str(&merged).expect("merged output should be valid JSON");
+        let merged_count = merged_doc["components"].as_array().map_or(0, Vec::len);
+
+        prop_assert_eq!(merged_count, components.len());
+    }
+}


### PR DESCRIPTION
## Summary

Diffs of SBOMs above the 500-component LSH threshold were non-reproducible across runs, undermining CI `--fail-on-*` gating.

Root causes named in the issue:

- `LshIndex::new` seeded MinHash coefficients from `RandomState` (src/matching/lsh.rs:154-167 pre-change), so LSH candidate sets differed per process. Coefficients are now generated from a fixed seed constant via an inline splitmix64 PRNG (dependency-free, not derived from SBOM content), keeping the `| 1` odd-multiplier property the hash family expects (src/matching/lsh.rs:26-40, 167-180).
- `optimal_assignment` collected `old_ids`/`new_ids` from `HashSet` iteration (src/diff/engine_matching.rs:432-446), randomizing Hungarian-solver tie-breaking per run. Both ID lists are now sorted by canonical-ID value before the assignment problem is built, and `greedy_assignment` breaks score ties by ID (src/diff/engine_matching.rs:553-560).

The new round-trip determinism property test (diff twice, byte-compare serialized JSON) exposed further sources of run-to-run nondeterminism, fixed alongside:

- `LshIndex::find_candidates_by_signature` returned `HashSet` iteration order; the `.take(max_candidates/2)` truncation in `BatchCandidateGenerator::find_candidates` (src/matching/index.rs:690) therefore selected a different candidate subset per call. Candidates are now returned in deterministic band/bucket order (src/matching/lsh.rs:236-258).
- `ComponentIndex::find_candidates` iterated the `by_prefix` HashMap for similar-prefix candidates (priority 3) and broke trigram-overlap ties (priority 4) in random order, selecting differing subsets when `max_candidates` binds (src/matching/index.rs:326-371, 390).
- `ComponentChangeComputer::compute` emitted `removed`/`modified` in match-map iteration order (the match map is a fresh `HashMap` per diff call); outputs are now sorted by ID (src/diff/changes/components.rs:360-363). `added` already followed deterministic `IndexMap` order and is unchanged.
- `LicenseChangeComputer::compute` emitted license changes in HashMap order; now sorted by license expression (src/diff/changes/licenses.rs:80-87).
- `VulnerabilityChangeSet::sort_by_severity` left equal-severity entries — and `persistent`/`vex_changes` entirely — in HashMap order; ties now break by vulnerability and component ID (src/diff/traits.rs:127-154).
- `avg_match_score` summed `f64` scores in `pairs` HashMap order, producing bit-level differences in the serialized average; scores are sorted with `total_cmp` before accumulation (src/diff/engine.rs:177-182).

Known residual (not relevant to the reported symptom): `CrossEcosystemDb::find_equivalents` iterates a per-family `HashMap` of ecosystem names, which could reorder cross-ecosystem candidates under truncation; it only applies to built-in well-known package families.

## Test plan

- New `tests/proptest_diff.rs` (replicating `arb_component` from `tests/proptest_matching.rs`, since integration-test binaries cannot import from each other):
  - `diff_with_self_yields_no_changes` — diff(a,a) has zero added/removed/modified
  - `forward_added_equals_reverse_removed` — diff(a,b).added == diff(b,a).removed by canonical ID
  - `large_diff_output_is_deterministic` — 10 cases of 520-560-component SBOMs (LSH engaged) with keep/bump/drop mutations; two diffs must serialize byte-identically. Verified this test FAILS against the pre-fix source (`git stash` of src/ → 1 failed) and passes with the fix.
- New `tests/proptest_quality.rs`:
  - `quality_score_bounded_with_consistent_grade` — `QualityScorer::score` finite, in 0..=100, and `grade == QualityGrade::from_score(overall_score)` across all 9 profiles (incl. Cbom, BsiTr03183_2, AiReadiness)
  - `merge_with_self_preserves_component_count` — there is no merge API over `NormalizedSbom`; merging exists only at the raw-JSON layer, so idempotence is tested against `serialization::merge_sbom_json` as anticipated by the spec
- New unit test `test_lsh_deterministic_across_instances` — identical signatures and candidate ordering across independently built indexes
- `cargo test --test proptest_diff --test proptest_quality --test proptest_matching`, `cargo test --lib matching::`, `cargo test --lib diff::` — all green
- Full `cargo test` — all green (804 lib tests + all integration suites, 0 failures)
- `cargo fmt --check` clean; `cargo clippy --all-targets` introduces no new warnings in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)