### PR TITLE
fix(enrichment): hydrate OSV querybatch results with full vulnerability details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,206 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "ascii-canvas"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
+dependencies = [
+ "term",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "async-attributes"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3203e79f4dd9bdda415ed03cf14dae5a2bf775c683a00f94e9cd1faf0f596e5"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-object-pool"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "333c456b97c3f2d50604e8b2624253b7f787208cb72eb75e64b0ad11b221652c"
+dependencies = [
+ "async-std",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-attributes",
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,9 +342,26 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "basic-cookies"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67bd8fd42c16bdb08688243dc5f0cc117a3ca9efeeaba3a345a18a6159ad96f7"
+dependencies = [
+ "lalrpop",
+ "lalrpop-util",
+ "regex",
+]
 
 [[package]]
 name = "bit-set"
@@ -213,6 +430,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -415,6 +645,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -713,6 +952,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -720,8 +969,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -775,6 +1035,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "ena"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabffdaee24bd1bf95c5ef7cec31260444317e72ea56c4c91750e8b7ee58d5f1"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,6 +1066,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -900,6 +1196,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,6 +1239,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -977,6 +1298,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1020,10 +1353,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
 
 [[package]]
 name = "http"
@@ -1037,12 +1387,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1053,8 +1414,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1063,6 +1424,40 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "httpmock"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08ec9586ee0910472dec1a1f0f8acf52f0fdde93aea74d70d4a3107b4be0fd5b"
+dependencies = [
+ "assert-json-diff",
+ "async-object-pool",
+ "async-std",
+ "async-trait",
+ "base64 0.21.7",
+ "basic-cookies",
+ "crossbeam-utils",
+ "form_urlencoded",
+ "futures-util",
+ "hyper 0.14.32",
+ "lazy_static",
+ "levenshtein",
+ "log",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_regex",
+ "similar",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "hybrid-array"
@@ -1075,6 +1470,29 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1083,8 +1501,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1100,8 +1518,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -1116,18 +1534,18 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1338,6 +1756,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1414,10 +1841,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lalrpop"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cb077ad656299f160924eb2912aa147d7339ea7d69e1b5517326fdcec3c1ca"
+dependencies = [
+ "ascii-canvas",
+ "bit-set 0.5.3",
+ "ena",
+ "itertools 0.11.0",
+ "lalrpop-util",
+ "petgraph",
+ "pico-args",
+ "regex",
+ "regex-syntax",
+ "string_cache",
+ "term",
+ "tiny-keccak",
+ "unicode-xid",
+ "walkdir",
+]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507460a910eb7b32ee961886ff48539633b788a36b65692b95f225b844c82553"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "lazy_static"
@@ -1430,6 +1897,12 @@ name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "levenshtein"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
@@ -1488,6 +1961,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru"
@@ -1561,6 +2037,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
@@ -1706,6 +2188,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +2280,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
 name = "phf"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1844,6 +2342,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pico-args"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,6 +2358,17 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "plotters"
@@ -1881,6 +2396,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1912,6 +2441,12 @@ checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
 ]
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
@@ -1980,7 +2515,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2018,7 +2553,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2207,6 +2742,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -2271,15 +2817,15 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -2473,6 +3019,7 @@ dependencies = [
  "crossterm",
  "ctrlc",
  "dirs",
+ "httpmock",
  "indexmap",
  "pathfinding",
  "proptest",
@@ -2632,6 +3179,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_yaml_ng"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2713,6 +3270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "siphasher"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2729,6 +3292,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -2760,6 +3333,18 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared",
+ "precomputed-hash",
+]
 
 [[package]]
 name = "strsim"
@@ -2850,6 +3435,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2877,7 +3473,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
 dependencies = [
  "anyhow",
- "base64",
+ "base64 0.22.1",
  "bitflags 2.11.0",
  "fancy-regex",
  "filedescriptor",
@@ -2983,6 +3579,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,8 +3632,21 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "signal-hook-registry",
+ "socket2 0.6.2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3065,8 +3683,8 @@ dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -3259,6 +3877,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ ffi = []
 
 [dev-dependencies]
 criterion = "0.8"
+httpmock = "0.7"
 proptest = "1.11"
 tempfile = "3.27"
 

--- a/src/enrichment/osv/mapper.rs
+++ b/src/enrichment/osv/mapper.rs
@@ -12,7 +12,8 @@ pub fn map_osv_to_vulnerability_ref(osv: &OsvVulnerability) -> VulnerabilityRef 
     VulnerabilityRef {
         id: osv.id.clone(),
         source: VulnerabilitySource::Osv,
-        severity: extract_severity(&osv.severity),
+        severity: extract_severity(&osv.severity)
+            .or_else(|| extract_database_severity(osv.database_specific.as_ref())),
         cvss: extract_cvss_scores(&osv.severity),
         affected_versions: extract_affected_versions(&osv.affected),
         remediation: extract_remediation(&osv.affected),
@@ -75,8 +76,12 @@ fn parse_cvss_score(score_str: &str) -> Option<f32> {
         return Some(score);
     }
 
-    // Try to extract score from CVSS vector string
-    // Format: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H (score at end or calculated)
+    // OSV severity entries normally carry the raw vector string
+    // (e.g. "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+    if score_str.starts_with("CVSS:3") {
+        return cvss_v3_base_score(score_str);
+    }
+
     // Some vectors have /score:X.X at the end
     if score_str.contains('/') {
         // Look for explicit score field
@@ -90,6 +95,103 @@ fn parse_cvss_score(score_str: &str) -> Option<f32> {
     }
 
     None
+}
+
+/// Compute the CVSS 3.x base score from a vector string.
+///
+/// Implements the base-score equations from the FIRST CVSS v3.1
+/// specification (section 7.1), including the Roundup function from
+/// Appendix A. CVSS v3.0 vectors use the same equations.
+fn cvss_v3_base_score(vector: &str) -> Option<f32> {
+    let mut metrics = std::collections::HashMap::new();
+    for part in vector.split('/').skip(1) {
+        let (name, value) = part.split_once(':')?;
+        metrics.insert(name, value);
+    }
+    let metric = |name: &str| metrics.get(name).copied();
+
+    let scope_changed = match metric("S")? {
+        "C" => true,
+        "U" => false,
+        _ => return None,
+    };
+    let attack_vector = match metric("AV")? {
+        "N" => 0.85,
+        "A" => 0.62,
+        "L" => 0.55,
+        "P" => 0.2,
+        _ => return None,
+    };
+    let attack_complexity = match metric("AC")? {
+        "L" => 0.77,
+        "H" => 0.44,
+        _ => return None,
+    };
+    let privileges_required = match (metric("PR")?, scope_changed) {
+        ("N", _) => 0.85,
+        ("L", false) => 0.62,
+        ("L", true) => 0.68,
+        ("H", false) => 0.27,
+        ("H", true) => 0.5,
+        _ => return None,
+    };
+    let user_interaction = match metric("UI")? {
+        "N" => 0.85,
+        "R" => 0.62,
+        _ => return None,
+    };
+    let impact_weight = |value: &str| -> Option<f64> {
+        match value {
+            "H" => Some(0.56),
+            "L" => Some(0.22),
+            "N" => Some(0.0),
+            _ => None,
+        }
+    };
+    let conf = impact_weight(metric("C")?)?;
+    let integ = impact_weight(metric("I")?)?;
+    let avail = impact_weight(metric("A")?)?;
+
+    let iss = 1.0 - (1.0 - conf) * (1.0 - integ) * (1.0 - avail);
+    let impact = if scope_changed {
+        7.52 * (iss - 0.029) - 3.25 * (iss - 0.02).powi(15)
+    } else {
+        6.42 * iss
+    };
+    if impact <= 0.0 {
+        return Some(0.0);
+    }
+
+    let exploitability =
+        8.22 * attack_vector * attack_complexity * privileges_required * user_interaction;
+    let base = if scope_changed {
+        1.08 * (impact + exploitability)
+    } else {
+        impact + exploitability
+    };
+
+    Some(round_up(base.min(10.0)) as f32)
+}
+
+/// CVSS v3.1 Roundup: smallest value with one decimal place that is equal
+/// to or higher than the input (Appendix A of the specification).
+fn round_up(value: f64) -> f64 {
+    let scaled = (value * 100_000.0).round() as i64;
+    if scaled % 10_000 == 0 {
+        scaled as f64 / 100_000.0
+    } else {
+        (scaled / 10_000 + 1) as f64 / 10.0
+    }
+}
+
+/// Extract a severity label from `database_specific` (e.g. GHSA's "HIGH",
+/// Ubuntu's "Medium") when no CVSS-derived severity is available.
+fn extract_database_severity(database_specific: Option<&serde_json::Value>) -> Option<Severity> {
+    let label = database_specific?.get("severity")?.as_str()?;
+    label
+        .parse::<Severity>()
+        .ok()
+        .filter(|severity| *severity != Severity::Unknown)
 }
 
 /// Extract affected versions from OSV affected array.
@@ -194,5 +296,90 @@ mod tests {
         assert_eq!(Severity::from_cvss(7.5), Severity::High);
         assert_eq!(Severity::from_cvss(5.0), Severity::Medium);
         assert_eq!(Severity::from_cvss(2.0), Severity::Low);
+    }
+
+    fn assert_score(vector: &str, expected: f32) {
+        let score = parse_cvss_score(vector).unwrap();
+        assert!(
+            (score - expected).abs() < 1e-4,
+            "{vector}: expected {expected}, got {score}"
+        );
+    }
+
+    #[test]
+    fn test_parse_cvss_v31_vector_scope_unchanged() {
+        assert_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 9.8);
+        assert_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N", 5.3);
+    }
+
+    #[test]
+    fn test_parse_cvss_v31_vector_scope_changed() {
+        assert_score("CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:L/I:L/A:N", 6.4);
+        assert_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H", 10.0);
+    }
+
+    #[test]
+    fn test_parse_cvss_v30_vector() {
+        assert_score("CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H", 9.8);
+    }
+
+    #[test]
+    fn test_parse_cvss_v3_vector_zero_impact() {
+        assert_score("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:N", 0.0);
+    }
+
+    #[test]
+    fn test_parse_cvss_v3_vector_invalid() {
+        assert_eq!(
+            parse_cvss_score("CVSS:3.1/AV:X/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"),
+            None
+        );
+        assert_eq!(parse_cvss_score("CVSS:3.1/AV:N/AC:L"), None);
+        assert_eq!(
+            parse_cvss_score("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"),
+            None
+        );
+    }
+
+    #[test]
+    fn test_map_vector_severity_and_cvss() {
+        let json = r#"{
+            "id": "GHSA-test-1234",
+            "severity": [
+                {"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}
+            ]
+        }"#;
+        let osv: OsvVulnerability = serde_json::from_str(json).unwrap();
+        let vuln = map_osv_to_vulnerability_ref(&osv);
+        assert_eq!(vuln.severity, Some(Severity::Critical));
+        assert_eq!(vuln.cvss.len(), 1);
+        assert!((vuln.cvss[0].base_score - 9.8).abs() < 1e-4);
+        assert_eq!(
+            vuln.cvss[0].vector.as_deref(),
+            Some("CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H")
+        );
+    }
+
+    #[test]
+    fn test_database_specific_severity_fallback() {
+        let json = r#"{
+            "id": "GHSA-test-5678",
+            "database_specific": {"severity": "MODERATE"}
+        }"#;
+        let osv: OsvVulnerability = serde_json::from_str(json).unwrap();
+        let vuln = map_osv_to_vulnerability_ref(&osv);
+        assert_eq!(vuln.severity, Some(Severity::Medium));
+        assert!(vuln.cvss.is_empty());
+    }
+
+    #[test]
+    fn test_database_specific_severity_unknown_label() {
+        let json = r#"{
+            "id": "GHSA-test-9999",
+            "database_specific": {"severity": "bogus"}
+        }"#;
+        let osv: OsvVulnerability = serde_json::from_str(json).unwrap();
+        let vuln = map_osv_to_vulnerability_ref(&osv);
+        assert_eq!(vuln.severity, None);
     }
 }

--- a/src/enrichment/osv/mod.rs
+++ b/src/enrichment/osv/mod.rs
@@ -15,8 +15,8 @@ use crate::enrichment::cache::{CacheKey, FileCache};
 use crate::enrichment::stats::{EnrichmentError, EnrichmentStats};
 use crate::enrichment::traits::VulnerabilityEnricher;
 use crate::error::Result;
-use crate::model::{Component, Ecosystem};
-use response::OsvQuery;
+use crate::model::{Component, Ecosystem, VulnerabilityRef};
+use response::{OsvQuery, OsvVulnerability};
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
@@ -33,6 +33,8 @@ pub struct OsvEnricherConfig {
     pub timeout: Duration,
     /// OSV API base URL
     pub api_base: String,
+    /// Maximum retries for failed requests
+    pub max_retries: u8,
 }
 
 impl Default for OsvEnricherConfig {
@@ -43,6 +45,7 @@ impl Default for OsvEnricherConfig {
             bypass_cache: false,
             timeout: Duration::from_secs(30),
             api_base: "https://api.osv.dev".to_string(),
+            max_retries: 3,
         }
     }
 }
@@ -60,6 +63,7 @@ impl OsvEnricher {
         let client_config = OsvClientConfig {
             api_base: config.api_base,
             timeout: config.timeout,
+            max_retries: config.max_retries,
             ..Default::default()
         };
 
@@ -104,6 +108,64 @@ impl OsvEnricher {
 
         None
     }
+
+    /// Cache key for an individual vulnerability record.
+    fn vuln_cache_key(vuln_id: &str) -> CacheKey {
+        CacheKey::new(None, format!("osv-vuln:{vuln_id}"), None, None)
+    }
+
+    /// Hydrate querybatch stubs into full vulnerability records.
+    ///
+    /// The `/v1/querybatch` endpoint returns only `{id, modified}` per
+    /// vulnerability, so each record is fetched from `/v1/vulns/{id}` (or the
+    /// per-vulnerability cache) before mapping. Returns the mapped
+    /// vulnerabilities and whether every record was fully hydrated; records
+    /// that could not be fetched fall back to the id-only stub.
+    fn hydrate_vulns(
+        &self,
+        stubs: &[OsvVulnerability],
+        stats: &mut EnrichmentStats,
+    ) -> (Vec<VulnerabilityRef>, bool) {
+        let mut vulns = Vec::with_capacity(stubs.len());
+        let mut complete = true;
+
+        for stub in stubs {
+            let key = Self::vuln_cache_key(&stub.id);
+
+            if !self.bypass_cache
+                && let Some(cached) = self.cache.get(&key)
+                && let Some(vuln) = cached.into_iter().next()
+            {
+                stats.cache_hits += 1;
+                vulns.push(vuln);
+                continue;
+            }
+
+            stats.api_calls += 1;
+            match self.client.get_vulnerability(&stub.id) {
+                Ok(Some(full)) => {
+                    let vuln = mapper::map_osv_to_vulnerability_ref(&full);
+                    if let Err(e) = self.cache.set(&key, std::slice::from_ref(&vuln)) {
+                        stats
+                            .errors
+                            .push(EnrichmentError::CacheError(e.to_string()));
+                    }
+                    vulns.push(vuln);
+                }
+                Ok(None) => {
+                    complete = false;
+                    vulns.push(mapper::map_osv_to_vulnerability_ref(stub));
+                }
+                Err(e) => {
+                    complete = false;
+                    stats.errors.push(EnrichmentError::ApiError(e.to_string()));
+                    vulns.push(mapper::map_osv_to_vulnerability_ref(stub));
+                }
+            }
+        }
+
+        (vulns, complete)
+    }
 }
 
 impl VulnerabilityEnricher for OsvEnricher {
@@ -122,7 +184,7 @@ impl VulnerabilityEnricher for OsvEnricher {
         stats.components_skipped = components.len() - queries.len();
 
         // Separate cached vs needs-fetch
-        let mut cached_results: Vec<(usize, Vec<crate::model::VulnerabilityRef>)> = Vec::new();
+        let mut cached_results: Vec<(usize, Vec<VulnerabilityRef>)> = Vec::new();
         let mut to_fetch: Vec<(usize, CacheKey, OsvQuery)> = Vec::new();
 
         for (idx, key, query) in queries {
@@ -161,14 +223,11 @@ impl VulnerabilityEnricher for OsvEnricher {
                             .into_iter()
                             .flat_map(|r| r.results.into_iter()),
                     ) {
-                        let vulns: Vec<_> = result
-                            .vulns
-                            .iter()
-                            .map(mapper::map_osv_to_vulnerability_ref)
-                            .collect();
+                        let (vulns, complete) = self.hydrate_vulns(&result.vulns, &mut stats);
 
-                        // Cache the result (even if empty)
-                        if let Err(e) = self.cache.set(&key, &vulns) {
+                        // Cache the result (even if empty), but only when
+                        // fully hydrated so failures are retried next run
+                        if complete && let Err(e) = self.cache.set(&key, &vulns) {
                             stats
                                 .errors
                                 .push(EnrichmentError::CacheError(e.to_string()));

--- a/tests/enrichment_http_tests.rs
+++ b/tests/enrichment_http_tests.rs
@@ -1,0 +1,353 @@
+//! HTTP-level integration tests for OSV enrichment.
+//!
+//! Uses httpmock to simulate the OSV API and verify that querybatch results
+//! (which carry only `{id, modified}` stubs) are hydrated into full
+//! vulnerability records, that the client retries transient failures, and
+//! that cache expiry combined with network failures behaves as documented.
+
+#![cfg(feature = "enrichment")]
+
+use httpmock::prelude::*;
+use sbom_tools::enrichment::osv::response::OsvQuery;
+use sbom_tools::enrichment::osv::{OsvClient, OsvClientConfig};
+use sbom_tools::enrichment::{
+    CacheKey, FileCache, OsvEnricher, OsvEnricherConfig, VulnerabilityEnricher,
+};
+use sbom_tools::model::{Component, Severity, VulnerabilityRef, VulnerabilitySource};
+use std::path::PathBuf;
+use std::time::Duration;
+
+const VULN_ID: &str = "GHSA-jf85-cpcp-j695";
+
+fn querybatch_stub_body(vuln_ids_per_result: &[&[&str]]) -> serde_json::Value {
+    let results: Vec<serde_json::Value> = vuln_ids_per_result
+        .iter()
+        .map(|ids| {
+            let vulns: Vec<serde_json::Value> = ids
+                .iter()
+                .map(|id| serde_json::json!({"id": id, "modified": "2026-01-10T00:00:00Z"}))
+                .collect();
+            serde_json::json!({"vulns": vulns})
+        })
+        .collect();
+    serde_json::json!({ "results": results })
+}
+
+fn full_vuln_body(id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": id,
+        "summary": "Prototype pollution in lodash",
+        "details": "Versions of lodash before 4.17.21 are vulnerable to prototype pollution.",
+        "aliases": ["CVE-2026-0001"],
+        "published": "2026-01-05T00:00:00Z",
+        "modified": "2026-01-10T00:00:00Z",
+        "severity": [
+            {"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}
+        ],
+        "affected": [{
+            "package": {"name": "lodash", "ecosystem": "npm", "purl": "pkg:npm/lodash"},
+            "ranges": [{"type": "SEMVER", "events": [{"introduced": "0"}, {"fixed": "4.17.21"}]}]
+        }],
+        "database_specific": {"severity": "CRITICAL", "cwe_ids": ["CWE-1321"]}
+    })
+}
+
+fn make_component(name: &str, version: &str) -> Component {
+    Component::new(name.to_string(), format!("{name}@{version}"))
+        .with_purl(format!("pkg:npm/{name}@{version}"))
+        .with_version(version.to_string())
+}
+
+fn enricher_config(server: &MockServer, cache_dir: PathBuf) -> OsvEnricherConfig {
+    OsvEnricherConfig {
+        cache_dir,
+        cache_ttl: Duration::from_secs(3600),
+        bypass_cache: false,
+        timeout: Duration::from_secs(5),
+        api_base: server.base_url(),
+        max_retries: 0,
+    }
+}
+
+fn client_config(server: &MockServer, max_retries: u8, timeout: Duration) -> OsvClientConfig {
+    OsvClientConfig {
+        api_base: server.base_url(),
+        timeout,
+        max_retries,
+        batch_size: 1000,
+    }
+}
+
+// ============================================================================
+// Hydration: querybatch stubs must be expanded via /v1/vulns/{id}
+// ============================================================================
+
+#[test]
+fn enriched_vulnerabilities_carry_severity_and_cvss() {
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(200)
+            .json_body(querybatch_stub_body(&[&[VULN_ID]]));
+    });
+    let vuln_mock = server.mock(|when, then| {
+        when.method(GET).path(format!("/v1/vulns/{VULN_ID}"));
+        then.status(200).json_body(full_vuln_body(VULN_ID));
+    });
+
+    let enricher =
+        OsvEnricher::new(enricher_config(&server, cache_dir.path().to_path_buf())).unwrap();
+    let mut components = vec![make_component("lodash", "4.17.20")];
+    let stats = enricher.enrich(&mut components).unwrap();
+
+    batch_mock.assert();
+    vuln_mock.assert();
+    assert_eq!(stats.components_with_vulns, 1);
+    assert_eq!(stats.total_vulns_found, 1);
+    assert!(!stats.has_errors());
+
+    let vuln = &components[0].vulnerabilities[0];
+    assert_eq!(vuln.id, VULN_ID);
+    assert_eq!(vuln.severity, Some(Severity::Critical));
+    assert_eq!(vuln.cvss.len(), 1);
+    assert!((vuln.cvss[0].base_score - 9.8).abs() < 1e-4);
+    assert!(
+        vuln.description
+            .as_deref()
+            .unwrap()
+            .contains("prototype pollution")
+    );
+    assert_eq!(
+        vuln.remediation.as_ref().unwrap().fixed_version.as_deref(),
+        Some("4.17.21")
+    );
+    assert_eq!(vuln.cwes, vec!["CWE-1321".to_string()]);
+}
+
+#[test]
+fn shared_vulnerability_details_fetched_once() {
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(200)
+            .json_body(querybatch_stub_body(&[&[VULN_ID], &[VULN_ID]]));
+    });
+    let vuln_mock = server.mock(|when, then| {
+        when.method(GET).path(format!("/v1/vulns/{VULN_ID}"));
+        then.status(200).json_body(full_vuln_body(VULN_ID));
+    });
+
+    let enricher =
+        OsvEnricher::new(enricher_config(&server, cache_dir.path().to_path_buf())).unwrap();
+    let mut components = vec![
+        make_component("lodash", "4.17.20"),
+        make_component("lodash-es", "4.17.20"),
+    ];
+    let stats = enricher.enrich(&mut components).unwrap();
+
+    batch_mock.assert();
+    // The second component's record is served from the per-vuln cache.
+    vuln_mock.assert_hits(1);
+    assert_eq!(stats.components_with_vulns, 2);
+    for component in &components {
+        assert_eq!(
+            component.vulnerabilities[0].severity,
+            Some(Severity::Critical)
+        );
+        assert!((component.vulnerabilities[0].cvss[0].base_score - 9.8).abs() < 1e-4);
+    }
+}
+
+#[test]
+fn cached_component_results_skip_network() {
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(200)
+            .json_body(querybatch_stub_body(&[&[VULN_ID]]));
+    });
+    let vuln_mock = server.mock(|when, then| {
+        when.method(GET).path(format!("/v1/vulns/{VULN_ID}"));
+        then.status(200).json_body(full_vuln_body(VULN_ID));
+    });
+
+    let config = enricher_config(&server, cache_dir.path().to_path_buf());
+    let enricher = OsvEnricher::new(config.clone()).unwrap();
+    let mut components = vec![make_component("lodash", "4.17.20")];
+    enricher.enrich(&mut components).unwrap();
+
+    let enricher = OsvEnricher::new(config).unwrap();
+    let mut components = vec![make_component("lodash", "4.17.20")];
+    let stats = enricher.enrich(&mut components).unwrap();
+
+    batch_mock.assert_hits(1);
+    vuln_mock.assert_hits(1);
+    assert_eq!(stats.cache_hits, 1);
+    assert_eq!(stats.api_calls, 0);
+    assert_eq!(
+        components[0].vulnerabilities[0].severity,
+        Some(Severity::Critical)
+    );
+}
+
+#[test]
+fn failed_hydration_keeps_stub_and_is_not_cached() {
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(200)
+            .json_body(querybatch_stub_body(&[&[VULN_ID]]));
+    });
+    let mut failing_vuln = server.mock(|when, then| {
+        when.method(GET).path(format!("/v1/vulns/{VULN_ID}"));
+        then.status(500).body("internal error");
+    });
+
+    let config = enricher_config(&server, cache_dir.path().to_path_buf());
+    let enricher = OsvEnricher::new(config).unwrap();
+    let mut components = vec![make_component("lodash", "4.17.20")];
+    let stats = enricher.enrich(&mut components).unwrap();
+
+    // The id-only stub is kept so the finding is not silently dropped.
+    assert!(stats.has_errors());
+    assert_eq!(components[0].vulnerabilities.len(), 1);
+    assert_eq!(components[0].vulnerabilities[0].id, VULN_ID);
+    assert_eq!(components[0].vulnerabilities[0].severity, None);
+
+    failing_vuln.delete();
+    server.mock(|when, then| {
+        when.method(GET).path(format!("/v1/vulns/{VULN_ID}"));
+        then.status(200).json_body(full_vuln_body(VULN_ID));
+    });
+
+    // Nothing was cached for the component, so the next run re-queries and
+    // picks up the full record.
+    let mut components = vec![make_component("lodash", "4.17.20")];
+    let stats = enricher.enrich(&mut components).unwrap();
+    assert!(!stats.has_errors());
+    assert_eq!(
+        components[0].vulnerabilities[0].severity,
+        Some(Severity::Critical)
+    );
+    batch_mock.assert_hits(2);
+}
+
+// ============================================================================
+// Retry behavior on querybatch
+// ============================================================================
+
+#[test]
+fn querybatch_retries_on_429_then_fails() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(429).body("rate limited");
+    });
+
+    let client = OsvClient::new(client_config(&server, 2, Duration::from_secs(5))).unwrap();
+    let queries = vec![OsvQuery::from_purl("pkg:npm/lodash@4.17.20".to_string())];
+    let result = client.query_batch(&queries);
+
+    assert!(result.is_err());
+    // Initial attempt + 2 retries
+    mock.assert_hits(3);
+    let err = result.unwrap_err();
+    let source = std::error::Error::source(&err).unwrap();
+    assert!(source.to_string().contains("429"));
+}
+
+#[test]
+fn querybatch_recovers_after_server_error_clears() {
+    let server = MockServer::start();
+    let mut failing = server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(500).body("internal error");
+    });
+
+    let client = OsvClient::new(client_config(&server, 1, Duration::from_secs(5))).unwrap();
+    let queries = vec![OsvQuery::from_purl("pkg:npm/lodash@4.17.20".to_string())];
+
+    assert!(client.query_batch(&queries).is_err());
+    failing.assert_hits(2);
+    failing.delete();
+
+    server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(200).json_body(querybatch_stub_body(&[&[]]));
+    });
+    let responses = client.query_batch(&queries).unwrap();
+    assert_eq!(responses.len(), 1);
+    assert!(responses[0].results[0].vulns.is_empty());
+}
+
+#[test]
+fn querybatch_times_out_and_retries() {
+    let server = MockServer::start();
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(200)
+            .json_body(querybatch_stub_body(&[&[]]))
+            .delay(Duration::from_millis(500));
+    });
+
+    let client = OsvClient::new(client_config(&server, 1, Duration::from_millis(50))).unwrap();
+    let queries = vec![OsvQuery::from_purl("pkg:npm/lodash@4.17.20".to_string())];
+    let result = client.query_batch(&queries);
+
+    assert!(result.is_err());
+    // Wait for the delayed mock responses to finish before counting hits.
+    std::thread::sleep(Duration::from_millis(1200));
+    mock.assert_hits(2);
+}
+
+// ============================================================================
+// Cache TTL expiry + network failure
+// ============================================================================
+
+#[test]
+fn expired_cache_with_network_failure_yields_no_vulns_and_error() {
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+
+    let mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(503).body("unavailable");
+    });
+
+    // Pre-populate the component-level cache entry, then let it expire.
+    let ttl = Duration::from_millis(50);
+    let cache = FileCache::new(cache_dir.path().to_path_buf(), ttl).unwrap();
+    let key = CacheKey::new(
+        Some("pkg:npm/lodash@4.17.20".to_string()),
+        "lodash".to_string(),
+        Some("npm".to_string()),
+        Some("4.17.20".to_string()),
+    );
+    let mut stale = VulnerabilityRef::new(VULN_ID.to_string(), VulnerabilitySource::Osv);
+    stale.severity = Some(Severity::Critical);
+    cache.set(&key, std::slice::from_ref(&stale)).unwrap();
+    std::thread::sleep(Duration::from_millis(150));
+
+    let mut config = enricher_config(&server, cache_dir.path().to_path_buf());
+    config.cache_ttl = ttl;
+    let enricher = OsvEnricher::new(config).unwrap();
+    let mut components = vec![make_component("lodash", "4.17.20")];
+    let stats = enricher.enrich(&mut components).unwrap();
+
+    // Current behavior: the expired entry is evicted (never served stale),
+    // the network failure is recorded as an error, and the component stays
+    // unenriched until a later run succeeds.
+    mock.assert();
+    assert_eq!(stats.cache_hits, 0);
+    assert!(stats.has_errors());
+    assert!(components[0].vulnerabilities.is_empty());
+    assert!(cache.get(&key).is_none());
+}


### PR DESCRIPTION
## Summary

**Root cause.** OSV's `/v1/querybatch` endpoint returns only `{id, modified}` stubs per vulnerability, but `OsvEnricher` mapped batch results directly as if they were full records (`src/enrichment/osv/mod.rs:164-168` pre-fix). Enriched vulnerabilities therefore **never** carried severity, CVSS scores, descriptions, or remediation data — and those empty records were cached for 24h, masking the bug on subsequent runs. `OsvClient::get_vulnerability` (`src/enrichment/osv/client.rs:156`) was dead code. Additionally, `parse_cvss_score` (`src/enrichment/osv/mapper.rs:72-93` pre-fix) could not derive a score from CVSS vector strings, which is the severity format OSV actually returns.

**Fix.**
- After querybatch, each returned id is hydrated via `GET /v1/vulns/{id}` and mapped through the existing mapper (`OsvEnricher::hydrate_vulns`, `src/enrichment/osv/mod.rs`). Hydrated records go through the existing `FileCache` keyed per vulnerability id, so a vulnerability shared by multiple components is fetched once per TTL.
- Component-level cache entries are written only when every record hydrated successfully, so transient per-vuln failures are retried on the next run instead of pinning id-only stubs for 24h. On hydration failure the id-only stub is kept (finding is not silently dropped) and an `ApiError` is recorded in stats.
- **CVSS choice:** I implemented the proper CVSS 3.x base-score computation from vector strings per the FIRST CVSS v3.1 spec §7.1 (incl. the Appendix A Roundup function) — it stays compact (~70 lines) and is exact, so no approximation was needed. OSV's `database_specific.severity` labels (GHSA `"HIGH"`, Ubuntu `"Medium"`, …) are a *label*, not a score, so they are used as a severity-bucket fallback when no CVSS entry is parseable (e.g. CVSS v4-only or label-only records). CVSS v4 vector computation (MacroVector tables) is intentionally out of scope; v4 entries with plain numeric scores still parse.
- `OsvEnricherConfig` gains `max_retries` (default 3, mirrors `OsvClientConfig`); construction via `..Default::default()` in `build_enrichment_config` is unaffected.
- Added `httpmock` (sync, fits `reqwest::blocking`) as a dev-dependency.

**Behavior notes.** Hydration adds one sequential GET per *new* vulnerability id (cached individually afterwards). `get_vulnerability` keeps its existing no-retry convention; the querybatch retry/backoff path is unchanged.

## Test plan

- `tests/enrichment_http_tests.rs` (new, httpmock-backed, 8 tests):
  - `enriched_vulnerabilities_carry_severity_and_cvss`: realistic ids-only querybatch + per-vuln fixture → enriched component carries `Severity::Critical` and CVSS 9.8. **Verified this fails before the fix** (the `/v1/vulns/{id}` endpoint is never hit; severity stays `None`).
  - per-vuln cache: shared vuln id across two components fetched once; component-level cache skips the network entirely on re-run.
  - `failed_hydration_keeps_stub_and_is_not_cached`: 500 on `/v1/vulns/{id}` keeps the id-only stub, records an error, and re-fetches successfully on the next run.
  - retry behavior: 429 retried `max_retries` times then surfaced; 5xx recovery after server clears; client-side timeout retried.
  - TTL-expired cache + network failure (documents current behavior): expired entry is evicted, never served stale; error recorded; component stays unenriched.
- New mapper unit tests: CVSS 3.0/3.1 vectors (9.8 / 5.3 / 6.4 scope-changed / 10.0 cap / 0.0 zero-impact), malformed and v4 vectors → `None`, `database_specific` severity fallback.
- `cargo fmt --check` clean; `cargo clippy` and `cargo clippy --all-features` clean (0 warnings) on the pinned 1.88 toolchain; `cargo deny check` (licenses, bans, advisories, sources) clean with the new dev-dependency; full `cargo test` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)