### PR TITLE
fix(watch): enrich re-parsed SBOMs to prevent false resolved-vuln alerts

### DIFF
--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -799,6 +799,9 @@ pub struct EnrichmentConfig {
     /// Paths to external VEX documents (OpenVEX format)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub vex_paths: Vec<std::path::PathBuf>,
+    /// OSV API base URL override (defaults to the public OSV API)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_base: Option<String>,
 }
 
 impl Default for EnrichmentConfig {
@@ -813,6 +816,7 @@ impl Default for EnrichmentConfig {
             timeout_secs: 30,
             enable_eol: false,
             vex_paths: Vec::new(),
+            api_base: None,
         }
     }
 }
@@ -860,6 +864,13 @@ impl EnrichmentConfig {
     #[must_use]
     pub fn with_vex_paths(mut self, paths: Vec<std::path::PathBuf>) -> Self {
         self.vex_paths = paths;
+        self
+    }
+
+    /// Override the OSV API base URL.
+    #[must_use]
+    pub fn with_api_base(mut self, api_base: impl Into<String>) -> Self {
+        self.api_base = Some(api_base.into());
         self
     }
 }

--- a/src/enrichment/osv/mod.rs
+++ b/src/enrichment/osv/mod.rs
@@ -203,7 +203,7 @@ impl VulnerabilityEnricher for OsvEnricher {
             if !vulns.is_empty() {
                 stats.components_with_vulns += 1;
                 stats.total_vulns_found += vulns.len();
-                components[idx].vulnerabilities.extend(vulns);
+                merge_vulnerabilities(&mut components[idx], vulns);
             }
         }
 
@@ -236,7 +236,7 @@ impl VulnerabilityEnricher for OsvEnricher {
                         if !vulns.is_empty() {
                             stats.components_with_vulns += 1;
                             stats.total_vulns_found += vulns.len();
-                            components[idx].vulnerabilities.extend(vulns);
+                            merge_vulnerabilities(&mut components[idx], vulns);
                         }
                     }
                 }
@@ -256,6 +256,21 @@ impl VulnerabilityEnricher for OsvEnricher {
 
     fn is_available(&self) -> bool {
         self.client.health_check().unwrap_or(false)
+    }
+}
+
+/// Append vulnerabilities to a component, skipping ids it already carries so
+/// repeated enrichment runs are idempotent.
+fn merge_vulnerabilities(component: &mut Component, vulns: Vec<VulnerabilityRef>) {
+    let mut seen: std::collections::HashSet<String> = component
+        .vulnerabilities
+        .iter()
+        .map(|v| v.id.clone())
+        .collect();
+    for vuln in vulns {
+        if seen.insert(vuln.id.clone()) {
+            component.vulnerabilities.push(vuln);
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1585,6 +1585,7 @@ fn main() -> Result<()> {
                 timeout_secs: args.api_timeout,
                 enable_eol: args.enrich_eol,
                 vex_paths: Vec::new(), // VEX paths handled separately
+                ..Default::default()
             };
 
             let config = sbom_tools::config::VexConfig {

--- a/src/pipeline/parse.rs
+++ b/src/pipeline/parse.rs
@@ -103,7 +103,7 @@ pub fn parse_sbom_with_context(path: &Path, quiet: bool) -> Result<ParsedSbom> {
 pub fn build_enrichment_config(
     config: &crate::config::EnrichmentConfig,
 ) -> crate::enrichment::OsvEnricherConfig {
-    crate::enrichment::OsvEnricherConfig {
+    let mut osv_config = crate::enrichment::OsvEnricherConfig {
         cache_dir: config
             .cache_dir
             .clone()
@@ -112,7 +112,11 @@ pub fn build_enrichment_config(
         bypass_cache: config.bypass_cache,
         timeout: std::time::Duration::from_secs(config.timeout_secs),
         ..Default::default()
+    };
+    if let Some(ref api_base) = config.api_base {
+        osv_config.api_base = api_base.clone();
     }
+    osv_config
 }
 
 /// Enrich an SBOM with vulnerability data from OSV

--- a/src/watch/loop_impl.rs
+++ b/src/watch/loop_impl.rs
@@ -178,6 +178,36 @@ pub fn run_watch_loop(config: &WatchConfig) -> anyhow::Result<()> {
     }
 }
 
+/// Enrich an SBOM in place with OSV/EOL/VEX data per the watch config.
+///
+/// `bypass_cache` forces fresh OSV/EOL data (used by periodic enrichment
+/// cycles); otherwise the configured cache behavior applies.
+#[cfg(feature = "enrichment")]
+fn enrich_watched_sbom(sbom: &mut NormalizedSbom, config: &WatchConfig, bypass_cache: bool) {
+    let mut osv_config = crate::pipeline::build_enrichment_config(&config.enrichment);
+    osv_config.bypass_cache = osv_config.bypass_cache || bypass_cache;
+    crate::pipeline::enrich_sbom(sbom, &osv_config, true);
+
+    if config.enrichment.enable_eol {
+        let eol_config = crate::enrichment::EolClientConfig {
+            cache_dir: config
+                .enrichment
+                .cache_dir
+                .clone()
+                .unwrap_or_else(crate::pipeline::dirs::eol_cache_dir),
+            cache_ttl: std::time::Duration::from_secs(config.enrichment.cache_ttl_hours * 3600),
+            bypass_cache,
+            timeout: std::time::Duration::from_secs(config.enrichment.timeout_secs),
+            ..Default::default()
+        };
+        crate::pipeline::enrich_eol(sbom, &eol_config, true);
+    }
+
+    if !config.enrichment.vex_paths.is_empty() {
+        crate::pipeline::enrich_vex(sbom, &config.enrichment.vex_paths, true);
+    }
+}
+
 /// Parse and record the initial state of a discovered SBOM (no diff).
 ///
 /// When enrichment is enabled, also enriches the SBOM with vulnerability/EOL/VEX
@@ -194,29 +224,7 @@ fn process_initial(path: &Path, config: &WatchConfig, state: &mut WatchState) {
             // Enrich on initial scan when enrichment is configured
             #[cfg(feature = "enrichment")]
             if config.enrichment.enabled {
-                let osv_config = crate::pipeline::build_enrichment_config(&config.enrichment);
-                crate::pipeline::enrich_sbom(&mut sbom, &osv_config, true);
-
-                if config.enrichment.enable_eol {
-                    let eol_config = crate::enrichment::EolClientConfig {
-                        cache_dir: config
-                            .enrichment
-                            .cache_dir
-                            .clone()
-                            .unwrap_or_else(crate::pipeline::dirs::eol_cache_dir),
-                        cache_ttl: std::time::Duration::from_secs(
-                            config.enrichment.cache_ttl_hours * 3600,
-                        ),
-                        timeout: std::time::Duration::from_secs(config.enrichment.timeout_secs),
-                        ..Default::default()
-                    };
-                    crate::pipeline::enrich_eol(&mut sbom, &eol_config, true);
-                }
-
-                if !config.enrichment.vex_paths.is_empty() {
-                    crate::pipeline::enrich_vex(&mut sbom, &config.enrichment.vex_paths, true);
-                }
-
+                enrich_watched_sbom(&mut sbom, config, false);
                 entry.last_enriched = Some(Instant::now());
             }
 
@@ -237,9 +245,14 @@ fn process_initial(path: &Path, config: &WatchConfig, state: &mut WatchState) {
 }
 
 /// Handle a new or modified SBOM file: parse, diff against previous, alert.
+///
+/// When enrichment is enabled, the re-parsed SBOM is enriched before diffing;
+/// otherwise every file touch would report all previously enriched
+/// vulnerabilities as resolved.
+#[allow(unused_variables)]
 fn process_sbom_change(
     path: &Path,
-    _config: &WatchConfig,
+    config: &WatchConfig,
     state: &mut WatchState,
     sinks: &mut [Box<dyn AlertSink>],
     engine: &DiffEngine,
@@ -251,7 +264,14 @@ fn process_sbom_change(
 
     match crate::pipeline::parse_sbom_with_context(path, true) {
         Ok(parsed) => {
-            let new_sbom = parsed.into_sbom();
+            let mut new_sbom = parsed.into_sbom();
+
+            #[cfg(feature = "enrichment")]
+            if config.enrichment.enabled {
+                enrich_watched_sbom(&mut new_sbom, config, false);
+                entry.last_enriched = Some(Instant::now());
+            }
+
             entry.component_count = new_sbom.component_count();
             entry.vuln_count = count_vulns(&new_sbom);
             entry.eol_count = count_eol(&new_sbom);
@@ -404,23 +424,6 @@ fn run_enrichment_cycle(
 
     #[cfg(feature = "enrichment")]
     {
-        let osv_config = crate::pipeline::build_enrichment_config(&config.enrichment);
-        let eol_config = if config.enrichment.enable_eol {
-            Some(crate::enrichment::EolClientConfig {
-                cache_dir: config
-                    .enrichment
-                    .cache_dir
-                    .clone()
-                    .unwrap_or_else(crate::pipeline::dirs::eol_cache_dir),
-                cache_ttl: std::time::Duration::from_secs(config.enrichment.cache_ttl_hours * 3600),
-                bypass_cache: true, // force fresh data during enrichment cycles
-                timeout: std::time::Duration::from_secs(config.enrichment.timeout_secs),
-                ..Default::default()
-            })
-        } else {
-            None
-        };
-
         let paths: Vec<_> = state
             .sboms
             .iter()
@@ -445,20 +448,8 @@ fn run_enrichment_cycle(
                 .flat_map(|c| c.vulnerabilities.iter().map(|v| v.id.clone()))
                 .collect();
 
-            // OSV enrichment (with cache bypass for fresh data)
-            let mut bypass_config = osv_config.clone();
-            bypass_config.bypass_cache = true;
-            crate::pipeline::enrich_sbom(sbom, &bypass_config, true);
-
-            // EOL enrichment
-            if let Some(ref eol_cfg) = eol_config {
-                crate::pipeline::enrich_eol(sbom, eol_cfg, true);
-            }
-
-            // VEX enrichment
-            if !config.enrichment.vex_paths.is_empty() {
-                crate::pipeline::enrich_vex(sbom, &config.enrichment.vex_paths, true);
-            }
+            // Bypass caches so enrichment cycles see fresh data
+            enrich_watched_sbom(sbom, config, true);
 
             entry.last_enriched = Some(Instant::now());
             entry.vuln_count = count_vulns(sbom);

--- a/tests/enrichment_http_tests.rs
+++ b/tests/enrichment_http_tests.rs
@@ -197,6 +197,36 @@ fn cached_component_results_skip_network() {
 }
 
 #[test]
+fn repeated_enrichment_does_not_duplicate_vulnerabilities() {
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+
+    server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(200)
+            .json_body(querybatch_stub_body(&[&[VULN_ID]]));
+    });
+    server.mock(|when, then| {
+        when.method(GET).path(format!("/v1/vulns/{VULN_ID}"));
+        then.status(200).json_body(full_vuln_body(VULN_ID));
+    });
+
+    let enricher =
+        OsvEnricher::new(enricher_config(&server, cache_dir.path().to_path_buf())).unwrap();
+    let mut components = vec![make_component("lodash", "4.17.20")];
+
+    enricher.enrich(&mut components).unwrap();
+    assert_eq!(components[0].vulnerabilities.len(), 1);
+
+    enricher.enrich(&mut components).unwrap();
+    assert_eq!(
+        components[0].vulnerabilities.len(),
+        1,
+        "re-enrichment must not duplicate vulnerabilities"
+    );
+}
+
+#[test]
 fn failed_hydration_keeps_stub_and_is_not_cached() {
     let server = MockServer::start();
     let cache_dir = tempfile::tempdir().unwrap();

--- a/tests/watch_tests.rs
+++ b/tests/watch_tests.rs
@@ -203,6 +203,154 @@ fn test_watch_loop_initial_scan_parses_fixtures() {
 }
 
 // ============================================================================
+// Enrichment-aware watch loop (mock OSV API)
+// ============================================================================
+
+#[cfg(feature = "enrichment")]
+mod enrichment_loop {
+    use super::*;
+    use httpmock::prelude::*;
+
+    const VULN_ID: &str = "GHSA-watch-test-0001";
+
+    fn sbom_body(version: &str) -> String {
+        serde_json::json!({
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "version": 1,
+            "components": [{
+                "type": "library",
+                "name": "lodash",
+                "version": version,
+                "purl": format!("pkg:npm/lodash@{version}")
+            }]
+        })
+        .to_string()
+    }
+
+    fn full_vuln_body() -> serde_json::Value {
+        serde_json::json!({
+            "id": VULN_ID,
+            "summary": "Prototype pollution in lodash",
+            "modified": "2026-01-10T00:00:00Z",
+            "severity": [
+                {"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}
+            ]
+        })
+    }
+
+    #[test]
+    fn test_watch_loop_enriched_reparse_no_false_resolved_alerts() {
+        let server = MockServer::start();
+        let health_mock = server.mock(|when, then| {
+            when.method(GET).path("/v1/vulns/OSV-2020-1");
+            then.status(404);
+        });
+        let batch_mock = server.mock(|when, then| {
+            when.method(POST).path("/v1/querybatch");
+            then.status(200).json_body(serde_json::json!({
+                "results": [{"vulns": [{"id": VULN_ID, "modified": "2026-01-10T00:00:00Z"}]}]
+            }));
+        });
+        let vuln_mock = server.mock(|when, then| {
+            when.method(GET).path(format!("/v1/vulns/{VULN_ID}"));
+            then.status(200).json_body(full_vuln_body());
+        });
+
+        let watch_dir = tempfile::tempdir().expect("create watch dir");
+        let cache_dir = tempfile::tempdir().expect("create cache dir");
+        let out_dir = tempfile::tempdir().expect("create out dir");
+        let sbom_path = watch_dir.path().join("app.cdx.json");
+        std::fs::write(&sbom_path, sbom_body("4.17.20")).expect("write sbom");
+        let output_file = out_dir.path().join("events.ndjson");
+
+        let config = WatchConfig {
+            watch_dirs: vec![watch_dir.path().to_path_buf()],
+            poll_interval: Duration::from_millis(50),
+            enrich_interval: Duration::from_millis(150),
+            debounce: Duration::ZERO,
+            output: sbom_tools::config::OutputConfig {
+                format: sbom_tools::reports::ReportFormat::Json,
+                file: Some(output_file.clone()),
+                ..Default::default()
+            },
+            enrichment: sbom_tools::config::EnrichmentConfig {
+                enabled: true,
+                cache_dir: Some(cache_dir.path().to_path_buf()),
+                timeout_secs: 5,
+                api_base: Some(server.base_url()),
+                ..Default::default()
+            },
+            webhook_url: None,
+            exit_on_change: true,
+            max_snapshots: 10,
+            quiet: true,
+            dry_run: false,
+            cra_standards_enabled: false,
+            cra_standards_interval: Duration::from_secs(86_400),
+            cra_standards_timeout: Duration::from_secs(10),
+        };
+
+        let config_clone = config.clone();
+        let handle = std::thread::spawn(move || sbom_tools::watch::run_watch_loop(&config_clone));
+
+        // Let the initial scan plus at least one periodic enrichment cycle run,
+        // then touch the file with a component version bump
+        std::thread::sleep(Duration::from_millis(500));
+        std::fs::write(&sbom_path, sbom_body("4.17.21")).expect("modify sbom");
+
+        let result = handle.join().expect("thread join");
+        assert!(result.is_ok(), "watch loop should exit cleanly: {result:?}");
+
+        // Initial scan, first periodic cycle, and the re-parse must all enrich
+        assert!(
+            batch_mock.hits() >= 3,
+            "expected >=3 querybatch calls, got {}",
+            batch_mock.hits()
+        );
+        assert!(vuln_mock.hits() >= 1);
+        assert!(health_mock.hits() >= 3);
+
+        let output = std::fs::read_to_string(&output_file).expect("read ndjson output");
+        let events: Vec<serde_json::Value> = output
+            .lines()
+            .map(|l| serde_json::from_str(l).expect("valid NDJSON line"))
+            .collect();
+
+        let changes: Vec<&serde_json::Value> =
+            events.iter().filter(|e| e["type"] == "change").collect();
+        assert!(!changes.is_empty(), "expected a change event: {events:?}");
+        for change in &changes {
+            assert_eq!(
+                change["resolved_vulns"].as_array().map(Vec::len),
+                Some(0),
+                "vuln still present must not be alerted as resolved: {change}"
+            );
+            assert_eq!(
+                change["new_vulns"].as_array().map(Vec::len),
+                Some(0),
+                "known vuln must not be re-alerted as new: {change}"
+            );
+        }
+
+        assert!(
+            !events.iter().any(|e| e["type"] == "new_vulns"),
+            "enrichment cycles must not re-announce known vulns: {events:?}"
+        );
+
+        let statuses: Vec<&serde_json::Value> =
+            events.iter().filter(|e| e["type"] == "status").collect();
+        assert!(!statuses.is_empty(), "expected status events: {events:?}");
+        for status in &statuses {
+            assert_eq!(
+                status["vulns"], 1,
+                "vuln count must stay at 1 across enrichment cycles: {status}"
+            );
+        }
+    }
+}
+
+// ============================================================================
 // NDJSON output verification
 // ============================================================================
 


### PR DESCRIPTION
Supersedes #220 (auto-closed when its stacked base `fix/osv-hydration` merged as #219 and the branch was deleted). Rebased onto main; only the watch-fix commit remains.

> [!NOTE]
> Stacked on #219 (`fix/osv-hydration`, OSV querybatch hydration). Merge that PR first; this one targets its branch.

## Summary

**Root cause 1 — false resolved/new alerts on every file touch.** `process_sbom_change` parsed modified files without enrichment (the `_config` parameter was unused, `src/watch/loop_impl.rs:240-312` pre-fix) and diffed the bare parse against the enriched previous snapshot. Resolved vulnerabilities are computed as in-old-not-new (`src/diff/changes/vulnerabilities.rs:145-150`), so every file touch alerted all OSV-enriched vulnerabilities as resolved, and the next enrichment cycle re-alerted them as new.

**Root cause 2 — vuln-count inflation.** `run_enrichment_cycle` re-enriches already-enriched SBOMs, and `OsvEnricher::enrich` extended `component.vulnerabilities` without dedup (`src/enrichment/osv/mod.rs`, both the cached-results and batch-fetch apply sites), so counts grew on every cycle.

**Fix**
- `process_sbom_change` now enriches the re-parsed SBOM when `config.enrichment.enabled`, through a shared `enrich_watched_sbom` helper extracted from the previously duplicated OSV/EOL/VEX blocks in `process_initial` and `run_enrichment_cycle` (`src/watch/loop_impl.rs:181-209`). Periodic cycles keep bypassing caches; initial scans and re-parses use the cache.
- OSV enrichment applies results via `merge_vulnerabilities`, which skips vulnerability ids the component already carries, making repeated enrichment idempotent (`src/enrichment/osv/mod.rs:262-276`).
- `EnrichmentConfig` gains an optional `api_base` override wired through `pipeline::build_enrichment_config` so the watch loop's enrichment path can target a mock (or private mirror) OSV endpoint — required to drive the end-to-end test, and the only knob the watch path lacked compared to `OsvEnricherConfig`.

## Test plan

- New `tests/watch_tests.rs::enrichment_loop::test_watch_loop_enriched_reparse_no_false_resolved_alerts`: drives `run_watch_loop` in a thread against a tempdir SBOM with httpmock OSV endpoints (querybatch + per-vuln hydration + health check) and an NDJSON `AlertSink`. The first cycle enriches; the file is then touched with a component version bump. Asserts: no `resolved_vulns`/`new_vulns` in any change event, no `new_vulns` enrichment events, and `vulns` stays at 1 in every status event across >=3 enrichment passes (verified via mock hit counts). Ran 6x locally with no flakes.
- New `tests/enrichment_http_tests.rs::repeated_enrichment_does_not_duplicate_vulnerabilities`: enriching the same component twice (second pass served from cache) yields exactly one vulnerability.
- `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo clippy --all-features -- -D warnings` (toolchain 1.88): clean.
- Full `cargo test`: all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)