### PR TITLE
feat(cli): stdin ('-') input, consistent size guards, truthful streaming docs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ readme = "README.md"
 repository = "https://github.com/sbom-tool/sbom-tools"
 keywords = ["sbom", "cyclonedx", "spdx", "diff", "security"]
 categories = ["command-line-utilities", "development-tools", "security"]
+# Keep multi-MB test fixtures out of the published crate (only used by ignored,
+# locally-run integration tests). Wildcards match the large generated SBOM.
+exclude = [
+    "tests/fixtures/cyclonedx/sbom-cyclone-dx-json-*.json",
+]
 
 [lib]
 name = "sbom_tools"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Semantic SBOM/CBOM diff, quality scoring, and analysis tool. Compare, validate, 
 
 - **Semantic Diffing** — Component-level change detection (added, removed, modified), dependency graph diffing, vulnerability tracking, and license change analysis
 - **Multi-Format Support** — CycloneDX (1.4–1.7) and SPDX (2.2–2.3, 3.0) in JSON, JSON-LD, XML, tag-value, and RDF/XML with automatic format detection
-- **Streaming Parser** — Memory-efficient parsing for very large SBOMs (>512MB) with progress reporting
+- **Stdin Input** — Every analysis command accepts `-` as the input path, reading the SBOM from standard input so generated/fetched SBOMs can be piped in without temp files (e.g. `syft -o cyclonedx-json . | sbom-tools quality -`)
+- **Streaming Report Output** — Large diff reports are streamed to JSON without buffering the whole document in memory; inputs are capped at 512 MB
 - **Fuzzy Matching** — Multi-tier matching engine using exact PURL match, alias lookup, ecosystem-specific normalization, and string similarity with adaptive thresholds and LSH indexing
 - **Vulnerability Enrichment** — Integration with OSV and KEV databases to track new and resolved vulnerabilities, with VEX (Vulnerability Exploitability eXchange) overlay support (feature-gated)
 - **EOL Detection** — End-of-life status for components via endoflife.date API with TUI visualization and compliance integration (feature-gated)
@@ -317,6 +318,13 @@ sbom-tools quality cbom.cdx.json --profile cbom
 
 # View CBOM with crypto-specific tabs
 sbom-tools view cbom.cdx.json --bom-type cbom
+
+# Pipe an SBOM in via stdin with '-' (no temp file needed)
+syft -o cyclonedx-json . | sbom-tools quality - --profile security
+cosign download sbom my-image:latest | sbom-tools validate - --standard ntia
+
+# Diff a freshly generated SBOM against a committed baseline ('-' = one side only)
+syft -o cyclonedx-json . | sbom-tools diff baseline.cdx.json -
 ```
 
 ### Diff
@@ -797,7 +805,7 @@ src/
 ├── cli/          Command handlers (diff, view, validate, quality, query, fleet, vex, watch, ...)
 ├── config/       YAML/JSON config with presets, validation, schema generation
 ├── model/        Canonical SBOM representation (NormalizedSbom, Component, CanonicalId)
-├── parsers/      Format detection + parsing (streaming for >512MB)
+├── parsers/      Format detection + parsing (stdin via '-', 512 MB input cap)
 ├── matching/     Multi-tier fuzzy matching (PURL, alias, ecosystem, adaptive, LSH)
 ├── diff/         Semantic diffing engine with graph support + incremental section-selective diff
 ├── enrichment/   OSV/KEV vulnerability data + EOL detection + VEX (feature-gated)

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -4,12 +4,12 @@
 
 use crate::config::DiffConfig;
 use crate::pipeline::{
-    OutputTarget, auto_detect_format, compute_diff, exit_codes, output_report,
+    OutputTarget, auto_detect_format, compute_diff, exit_codes, is_stdin_path, output_report,
     parse_sbom_with_context,
 };
 use crate::reports::ReportFormat;
 use crate::tui::{App, run_tui};
-use anyhow::Result;
+use anyhow::{Result, bail};
 
 /// Run the diff command, returning the desired exit code.
 ///
@@ -22,6 +22,11 @@ use anyhow::Result;
 #[allow(clippy::needless_pass_by_value)]
 pub fn run_diff(config: DiffConfig) -> Result<i32> {
     let quiet = config.behavior.quiet;
+
+    // Stdin can only be consumed once, so a diff can read at most one side from "-".
+    if is_stdin_path(&config.paths.old) && is_stdin_path(&config.paths.new) {
+        bail!("Cannot read both SBOMs from stdin ('-'); only one '-' is allowed per diff");
+    }
 
     // Parse SBOMs
     let mut old_parsed = parse_sbom_with_context(&config.paths.old, quiet)?;

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -374,6 +374,17 @@ pub fn run_query(config: QueryConfig, filter: QueryFilter) -> Result<i32> {
         );
     }
 
+    // Stdin can only be consumed once, so at most one input may be "-".
+    if config
+        .sbom_paths
+        .iter()
+        .filter(|p| crate::pipeline::is_stdin_path(p))
+        .count()
+        > 1
+    {
+        bail!("Cannot read more than one SBOM from stdin ('-')");
+    }
+
     let sboms = super::multi::parse_multiple_sboms(&config.sbom_paths)?;
 
     // Optionally enrich with vulnerability data

--- a/src/main.rs
+++ b/src/main.rs
@@ -2103,7 +2103,8 @@ fn split_query_args(args: &[String]) -> (Option<String>, Vec<PathBuf>) {
     }
 
     let first = &args[0];
-    let looks_like_file = first.contains(std::path::MAIN_SEPARATOR)
+    let looks_like_file = first == sbom_tools::pipeline::STDIN_PATH
+        || first.contains(std::path::MAIN_SEPARATOR)
         || first.contains('/')
         || has_sbom_extension(first)
         || Path::new(first).is_file();

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -86,19 +86,19 @@ pub fn detect_format(content: &str) -> Option<DetectedFormat> {
     }
 }
 
-/// Maximum SBOM file size (512 MB). Files larger than this should use the streaming parser.
-const MAX_SBOM_FILE_SIZE: u64 = 512 * 1024 * 1024;
+/// Maximum SBOM file size (512 MB), enforced to bound memory use when loading a
+/// whole document into a string. Inputs larger than this are rejected.
+pub(crate) const MAX_SBOM_FILE_SIZE: u64 = 512 * 1024 * 1024;
 
 /// Detect SBOM format from file content and parse accordingly
 ///
 /// Uses confidence-based detection to select the best parser.
 /// Returns an error if the file exceeds [`MAX_SBOM_FILE_SIZE`] to prevent OOM.
-/// For very large files, use the streaming parser instead.
 pub fn parse_sbom(path: &Path) -> Result<NormalizedSbom, ParseError> {
     let metadata = std::fs::metadata(path).map_err(|e| ParseError::IoError(e.to_string()))?;
     if metadata.len() > MAX_SBOM_FILE_SIZE {
         return Err(ParseError::IoError(format!(
-            "SBOM file is {} MB, exceeding the {} MB limit. Use the streaming parser for large files.",
+            "SBOM file is {} MB, exceeding the {} MB limit. Split the document or filter it (e.g. `sbom-tools tailor`) before processing.",
             metadata.len() / (1024 * 1024),
             MAX_SBOM_FILE_SIZE / (1024 * 1024),
         )));

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -12,7 +12,7 @@ mod report_stage;
 pub use diff_stage::{apply_post_diff_filters, compute_diff, graph_diff_config_from};
 pub use enrich::{AggregatedEnrichmentStats, enrich_sbom_full, enrich_sboms};
 pub use output::{OutputTarget, auto_detect_format, should_use_color, write_output};
-pub use parse::{ParsedSbom, parse_sbom_with_context};
+pub use parse::{ParsedSbom, STDIN_PATH, is_stdin_path, parse_sbom_with_context, read_input};
 pub use report_stage::output_report;
 
 #[cfg(feature = "enrichment")]

--- a/src/pipeline/parse.rs
+++ b/src/pipeline/parse.rs
@@ -3,8 +3,56 @@
 //! Provides functions for parsing SBOMs with context and optional enrichment.
 
 use crate::model::NormalizedSbom;
-use anyhow::Result;
+use crate::parsers::MAX_SBOM_FILE_SIZE;
+use anyhow::{Context, Result, bail};
+use std::io::Read;
 use std::path::Path;
+
+/// The path token that selects standard input instead of a file.
+pub const STDIN_PATH: &str = "-";
+
+/// Returns true when `path` refers to standard input (the `-` token).
+#[must_use]
+pub fn is_stdin_path(path: &Path) -> bool {
+    path.as_os_str() == STDIN_PATH
+}
+
+/// Read an SBOM input to a string, applying the [`MAX_SBOM_FILE_SIZE`] guard.
+///
+/// `path` of `"-"` reads the full document from standard input (for CI pipelines
+/// that pipe an SBOM in-flight, e.g. `syft -o cyclonedx-json | sbom-tools quality -`);
+/// any other path reads the file. Either way the result is capped at 512 MB so a
+/// runaway input cannot exhaust memory.
+pub fn read_input(path: &Path) -> Result<String> {
+    if is_stdin_path(path) {
+        let mut buf = String::new();
+        let limit = MAX_SBOM_FILE_SIZE + 1;
+        let read = std::io::stdin()
+            .lock()
+            .take(limit)
+            .read_to_string(&mut buf)
+            .context("Failed to read SBOM from stdin")?;
+        if read as u64 > MAX_SBOM_FILE_SIZE {
+            bail!(
+                "SBOM on stdin exceeds the {} MB limit. Split the document or filter it (e.g. `sbom-tools tailor`) before piping.",
+                MAX_SBOM_FILE_SIZE / (1024 * 1024),
+            );
+        }
+        return Ok(buf);
+    }
+
+    let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+    if size > MAX_SBOM_FILE_SIZE {
+        bail!(
+            "SBOM file {} is {} MB, exceeding the {} MB limit. Split the document or filter it (e.g. `sbom-tools tailor`) before processing.",
+            path.display(),
+            size / (1024 * 1024),
+            MAX_SBOM_FILE_SIZE / (1024 * 1024),
+        );
+    }
+    std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read SBOM file {}", path.display()))
+}
 
 /// A parsed SBOM with optional enrichment stats
 pub struct ParsedSbom {
@@ -72,13 +120,16 @@ pub fn parse_sbom_with_context(path: &Path, quiet: bool) -> Result<ParsedSbom> {
         tracing::info!("Parsing SBOM: {:?}", path);
     }
 
-    let path_display = path.display().to_string();
+    let path_display = if is_stdin_path(path) {
+        "<stdin>".to_string()
+    } else {
+        path.display().to_string()
+    };
 
-    let raw_content =
-        std::fs::read_to_string(path).map_err(|e| super::PipelineError::ParseFailed {
-            path: path_display.clone(),
-            source: e.into(),
-        })?;
+    let raw_content = read_input(path).map_err(|e| super::PipelineError::ParseFailed {
+        path: path_display.clone(),
+        source: e,
+    })?;
     let sbom = crate::parsers::parse_sbom_str(&raw_content).map_err(|e| {
         super::PipelineError::ParseFailed {
             path: path_display,
@@ -296,5 +347,30 @@ mod tests {
         let (recovered, raw) = parsed.into_parts();
         assert_eq!(recovered.component_count(), 0);
         assert_eq!(raw, "test");
+    }
+
+    #[test]
+    fn test_is_stdin_path() {
+        assert!(is_stdin_path(Path::new("-")));
+        assert!(!is_stdin_path(Path::new("sbom.json")));
+        assert!(!is_stdin_path(Path::new("./-")));
+        assert!(!is_stdin_path(Path::new("-.json")));
+    }
+
+    #[test]
+    fn test_read_input_reads_file() {
+        let dir = std::env::temp_dir();
+        let path = dir.join("sbom_tools_read_input_test.json");
+        std::fs::write(&path, "{\"hello\":\"world\"}").expect("write temp file");
+        let content = read_input(&path).expect("read should succeed");
+        assert_eq!(content, "{\"hello\":\"world\"}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_read_input_missing_file_errors() {
+        let err = read_input(Path::new("/nonexistent/sbom_tools_missing.json"))
+            .expect_err("missing file should error");
+        assert!(err.to_string().contains("Failed to read SBOM file"));
     }
 }

--- a/tests/stdin_input_tests.rs
+++ b/tests/stdin_input_tests.rs
@@ -1,0 +1,176 @@
+//! Integration tests for stdin (`-`) input support and the shared 512 MB size
+//! guard, plus a (default-ignored) parse+diff of the large CycloneDX fixture.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+const FIXTURES_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn fixture_path(name: &str) -> PathBuf {
+    Path::new(FIXTURES_DIR).join(name)
+}
+
+fn sbom_tools_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_sbom-tools"))
+}
+
+fn base_command() -> Command {
+    let mut cmd = Command::new(sbom_tools_bin());
+    cmd.arg("--no-color");
+    cmd.env("RUST_LOG", "error");
+    cmd.env("RUST_LOG_STYLE", "never");
+    cmd
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+/// Run a command, piping `input` to its stdin, and return the captured output.
+fn run_with_stdin(mut cmd: Command, input: &[u8]) -> Output {
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+    let mut child = cmd.spawn().expect("binary should launch");
+    child
+        .stdin
+        .take()
+        .expect("child stdin should be piped")
+        .write_all(input)
+        .expect("should write fixture to stdin");
+    child.wait_with_output().expect("child should complete")
+}
+
+/// Locate the large generated CycloneDX fixture without hard-coding its long name.
+fn large_fixture() -> Option<PathBuf> {
+    let dir = Path::new(FIXTURES_DIR).join("cyclonedx");
+    std::fs::read_dir(dir)
+        .ok()?
+        .filter_map(Result::ok)
+        .find_map(|e| {
+            let p = e.path();
+            let name = p.file_name()?.to_string_lossy().to_string();
+            (name.starts_with("sbom-cyclone-dx-json-") && name.ends_with(".json")).then_some(p)
+        })
+}
+
+#[test]
+fn quality_reads_sbom_from_stdin() {
+    let sbom = std::fs::read(fixture_path("cyclonedx/minimal.cdx.json")).expect("fixture readable");
+
+    let mut cmd = base_command();
+    cmd.arg("quality")
+        .arg("-")
+        .args(["--profile", "standard", "-o", "json"]);
+    let output = run_with_stdin(cmd, &sbom);
+
+    assert!(output.status.success(), "stderr: {}", stderr(&output));
+    let text = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        text.contains("overall_score") || text.contains("\"report\""),
+        "expected a quality JSON report, got: {text}"
+    );
+}
+
+#[test]
+fn validate_reads_sbom_from_stdin() {
+    let sbom = std::fs::read(fixture_path("cyclonedx/minimal.cdx.json")).expect("fixture readable");
+
+    let mut cmd = base_command();
+    cmd.arg("validate")
+        .arg("-")
+        .args(["--standard", "ntia", "-o", "json"]);
+    let output = run_with_stdin(cmd, &sbom);
+
+    // NTIA validation may exit non-zero on a minimal fixture, but it must have
+    // parsed the stdin document rather than erroring on a missing path.
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        stderr(&output)
+    );
+    assert!(
+        !combined.contains("No such file") && !combined.contains("Failed to read"),
+        "validate should have read from stdin, got: {combined}"
+    );
+    assert!(
+        combined.contains("compliant")
+            || combined.contains("Compliance")
+            || combined.contains("NTIA"),
+        "expected NTIA compliance output, got: {combined}"
+    );
+}
+
+#[test]
+fn diff_accepts_one_stdin_side() {
+    let new_sbom = std::fs::read(fixture_path("demo-new.cdx.json")).expect("fixture readable");
+
+    let mut cmd = base_command();
+    cmd.arg("diff")
+        .arg(fixture_path("demo-old.cdx.json"))
+        .arg("-")
+        .args(["-o", "summary"]);
+    let output = run_with_stdin(cmd, &new_sbom);
+
+    // Exit code may be non-zero (changes detected); only the parse must succeed.
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        stderr(&output)
+    );
+    assert!(
+        !combined.contains("Failed to read") && !combined.contains("No such file"),
+        "diff should read the new side from stdin, got: {combined}"
+    );
+}
+
+#[test]
+fn diff_rejects_two_stdin_sides() {
+    let mut cmd = base_command();
+    cmd.arg("diff").arg("-").arg("-").args(["-o", "summary"]);
+    let output = run_with_stdin(cmd, b"{}");
+
+    assert!(!output.status.success(), "two stdins must be rejected");
+    assert!(
+        stderr(&output).contains("both SBOMs from stdin")
+            || stderr(&output).contains("only one '-'"),
+        "expected a two-stdin rejection message, got: {}",
+        stderr(&output)
+    );
+}
+
+/// Parse + diff the orphaned 10 MB CycloneDX fixture end to end. Ignored by
+/// default (slow, large fixture excluded from the published crate); run with
+/// `cargo test --test stdin_input_tests -- --ignored`.
+#[test]
+#[ignore = "large fixture; run explicitly"]
+fn parse_and_diff_large_fixture() {
+    let Some(path) = large_fixture() else {
+        // The fixture is excluded from the published crate, so skip when absent.
+        eprintln!("large fixture not present; skipping");
+        return;
+    };
+
+    let sbom = sbom_tools::parsers::parse_sbom(&path).expect("large fixture should parse");
+    assert!(
+        sbom.component_count() > 100,
+        "expected a large component set, got {}",
+        sbom.component_count()
+    );
+
+    // Diff the document against itself: a valid no-op diff exercises the engine
+    // on a realistic, large input.
+    let config = sbom_tools::config::DiffConfigBuilder::new()
+        .old_path(path.clone())
+        .new_path(path.clone())
+        .build()
+        .expect("diff config should build");
+    let other = sbom_tools::parsers::parse_sbom(&path).expect("second parse should succeed");
+    let result = sbom_tools::pipeline::compute_diff(&config, &sbom, &other)
+        .expect("self-diff should succeed");
+    assert_eq!(
+        result.summary.total_changes, 0,
+        "self-diff should report no changes"
+    );
+}


### PR DESCRIPTION
## Summary

CI pipelines that generate or fetch SBOMs in-flight (`syft -o cyclonedx-json | ...`, `cosign download sbom`) previously had to write temp files because every command required a seekable file path. `StreamingConfig.stream_stdin` was set in `src/main.rs:1211` but never read by any input path. Separately, `parse_sbom_with_context` (`src/pipeline/parse.rs`) had **no** size guard while `parsers::parse_sbom` (`src/parsers/mod.rs`) rejected >512 MB inputs with advice to "use the streaming parser" — a path no CLI command can follow. The README advertised ">512MB streaming" that does not exist, and a ~10 MB CycloneDX fixture under `tests/fixtures/cyclonedx/` was referenced by nothing yet shipped in the published crate.

**Fix**
- **Stdin + shared guard** — `src/pipeline/parse.rs` gains `read_input(path)` plus `is_stdin_path`/`STDIN_PATH`. `-` reads the whole document from stdin; any other path reads the file. Both enforce the shared 512 MB cap (`MAX_SBOM_FILE_SIZE`, now `pub(crate)`). `parse_sbom_with_context` routes through it, so `diff`/`view`/`quality`/`validate`/`query`/`vex` all accept `-` **and** all carry the size guard consistently (item 1 + 2).
- **Single-consume stdin** — `diff` rejects two stdin sides (`src/cli/diff.rs`), `query` rejects >1 stdin path (`src/cli/query.rs`), and `split_query_args` now treats `-` as a path rather than a search pattern (`src/main.rs:1851`).
- **Truthful docs** — replaced the dead-end "use the streaming parser" message in `src/parsers/mod.rs:100` with accurate guidance; fixed the README ">512MB streaming" claims (`README.md` features list + architecture tree) and added a pipe recipe (item 3 + 5).
- **Orphaned fixture** — wired the large CycloneDX fixture into one `#[ignore]`-by-default integration test (`tests/stdin_input_tests.rs::parse_and_diff_large_fixture`) and added a `Cargo.toml` `exclude` so multi-MB fixtures stay out of the published crate; verified the fixture is absent and the new test file present via `cargo package --list` (item 4).

Out of scope (deferred): true incremental streaming parse.

## Test plan
- `cargo test --test stdin_input_tests` — 4 stdin CARGO_BIN_EXE tests pass (`quality -`, `validate -`, `diff <file> -`, two-stdin rejection); large-fixture test correctly ignored.
- `cargo test --test stdin_input_tests -- --ignored` — large-fixture parse + self-diff passes (3798 components, 0 changes).
- `cargo test --lib pipeline::parse` — new `is_stdin_path` / `read_input` unit tests pass.
- Full `cargo test` on pinned 1.88 — all suites green, no failures.
- `cargo clippy -- -D warnings` and `cargo clippy --all-features -- -D warnings` on pinned 1.88 — clean.
- `cargo package --list` — large fixture excluded (count 0), `tests/stdin_input_tests.rs` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)