### PR TITLE
feat(cli): per-command exit codes, typed value enums, NDJSON output

### DIFF
--- a/src/cli/quality.rs
+++ b/src/cli/quality.rs
@@ -126,7 +126,7 @@ fn run_quality_impl(config: QualityConfig) -> Result<i32> {
             report.overall_score,
             threshold
         );
-        return Ok(exit_codes::CHANGES_DETECTED);
+        return Ok(exit_codes::QUALITY_BELOW_THRESHOLD);
     }
 
     Ok(exit_codes::SUCCESS)

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -7,7 +7,7 @@ use crate::config::QueryConfig;
 use crate::model::{
     Component, ComponentType, CryptoAssetType, NormalizedSbom, NormalizedSbomIndex,
 };
-use crate::pipeline::{OutputTarget, auto_detect_format, write_output};
+use crate::pipeline::{OutputTarget, auto_detect_format, exit_codes, write_output};
 use crate::reports::ReportFormat;
 use anyhow::{Result, bail};
 use serde::Serialize;
@@ -354,9 +354,16 @@ pub(crate) struct QueryResult {
 // Core Implementation
 // ============================================================================
 
-/// Run the query command.
+/// Run the query command, returning the desired exit code.
+///
+/// # Exit codes
+/// - [`exit_codes::SUCCESS`] (0): at least one component matched the filter
+/// - [`exit_codes::NO_MATCHES`] (1): no components matched the filter
+///
+/// The caller is responsible for calling `std::process::exit()` with the
+/// returned code when it is non-zero.
 #[allow(clippy::needless_pass_by_value)]
-pub fn run_query(config: QueryConfig, filter: QueryFilter) -> Result<()> {
+pub fn run_query(config: QueryConfig, filter: QueryFilter) -> Result<i32> {
     if config.sbom_paths.is_empty() {
         bail!("No SBOM files specified");
     }
@@ -475,12 +482,11 @@ pub fn run_query(config: QueryConfig, filter: QueryFilter) -> Result<()> {
 
     write_output(&output, &target, false)?;
 
-    // Exit code: 1 if no matches
     if result.matches.is_empty() {
-        std::process::exit(1);
+        return Ok(exit_codes::NO_MATCHES);
     }
 
-    Ok(())
+    Ok(exit_codes::SUCCESS)
 }
 
 /// Build a `QueryMatch` from a component and its source.

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -3,7 +3,7 @@
 //! Implements the `validate` subcommand for validating SBOMs against compliance standards.
 
 use crate::model::{CreatorType, ExternalRefType, HashAlgorithm, NormalizedSbom, Severity};
-use crate::pipeline::{OutputTarget, parse_sbom_with_context, write_output};
+use crate::pipeline::{OutputTarget, exit_codes, parse_sbom_with_context, write_output};
 use crate::quality::{
     ComplianceChecker, ComplianceLevel, ComplianceResult, Violation, ViolationCategory,
     ViolationSeverity,
@@ -13,7 +13,17 @@ use anyhow::{Result, bail};
 use std::collections::HashSet;
 use std::path::PathBuf;
 
-/// Run the validate command
+/// Run the validate command, returning the desired exit code.
+///
+/// # Exit codes
+/// - [`exit_codes::SUCCESS`] (0): compliant (no errors; no warnings when
+///   `--fail-on-warning` is set)
+/// - [`exit_codes::COMPLIANCE_ERRORS`] (1): one or more compliance errors found
+/// - [`exit_codes::COMPLIANCE_WARNINGS`] (2): warnings found with
+///   `--fail-on-warning`
+///
+/// The caller is responsible for calling `std::process::exit()` with the
+/// returned code when it is non-zero.
 #[allow(clippy::needless_pass_by_value, clippy::too_many_arguments)]
 pub fn run_validate(
     sbom_path: PathBuf,
@@ -24,7 +34,7 @@ pub fn run_validate(
     summary: bool,
     cra_sidecar_path: Option<PathBuf>,
     cra_product_class: Option<String>,
-) -> Result<()> {
+) -> Result<i32> {
     let parsed = parse_sbom_with_context(&sbom_path, false)?;
 
     // Load CRA sidecar — explicit flag wins, otherwise auto-discover next to the SBOM
@@ -120,10 +130,10 @@ pub fn run_validate(
         }
 
         if result.error_count > 0 {
-            std::process::exit(1);
+            return Ok(exit_codes::COMPLIANCE_ERRORS);
         }
         if fail_on_warning && result.warning_count > 0 {
-            std::process::exit(2);
+            return Ok(exit_codes::COMPLIANCE_WARNINGS);
         }
     } else {
         // Multi-standard: merge results for output
@@ -136,14 +146,14 @@ pub fn run_validate(
         let has_errors = results.iter().any(|r| r.error_count > 0);
         let has_warnings = results.iter().any(|r| r.warning_count > 0);
         if has_errors {
-            std::process::exit(1);
+            return Ok(exit_codes::COMPLIANCE_ERRORS);
         }
         if fail_on_warning && has_warnings {
-            std::process::exit(2);
+            return Ok(exit_codes::COMPLIANCE_WARNINGS);
         }
     }
 
-    Ok(())
+    Ok(exit_codes::SUCCESS)
 }
 
 fn write_compliance_output(

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -204,7 +204,9 @@ impl std::str::FromStr for ThemeName {
 }
 
 /// Fuzzy matching preset
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[derive(
+    Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema, clap::ValueEnum,
+)]
 #[serde(rename_all = "kebab-case")]
 pub enum FuzzyPreset {
     /// Strict matching (fewer false positives)
@@ -215,10 +217,13 @@ pub enum FuzzyPreset {
     /// Permissive matching (fewer false negatives)
     Permissive,
     /// Strict matching optimized for multi-SBOM comparison
+    #[value(alias = "strict_multi")]
     StrictMulti,
     /// Balanced matching optimized for multi-SBOM comparison
+    #[value(alias = "balanced_multi")]
     BalancedMulti,
     /// Security-focused matching
+    #[value(alias = "security_focused")]
     SecurityFocused,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,14 +9,15 @@
 )]
 
 use anyhow::{Context, Result};
-use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{Shell, generate};
 use sbom_tools::{
     cli,
     config::{
         BehaviorConfig, DiffConfig, DiffPaths, EcosystemRulesConfig, EnrichmentConfig,
-        FilterConfig, GraphAwareDiffConfig, MatchingConfig, MatchingRulesPathConfig, MatrixConfig,
-        MultiDiffConfig, OutputConfig, QueryConfig, TimelineConfig, ViewConfig, WatchConfig,
+        FilterConfig, FuzzyPreset, GraphAwareDiffConfig, MatchingConfig, MatchingRulesPathConfig,
+        MatrixConfig, MultiDiffConfig, OutputConfig, QueryConfig, TimelineConfig, ViewConfig,
+        WatchConfig,
     },
     pipeline::dirs,
     reports::{ReportFormat, ReportType},
@@ -34,7 +35,7 @@ const fn build_long_version() -> &'static str {
         "\n  CycloneDX: 1.4, 1.5, 1.6, 1.7 (JSON, XML)",
         "\n  SPDX:      2.2, 2.3 (JSON, tag-value, RDF/XML), 3.0 (JSON-LD)",
         "\n\nOutput Formats:",
-        "\n  tui, json, sarif, markdown, html, summary, table, side-by-side",
+        "\n  tui, json, ndjson, sarif, markdown, html, summary, table, side-by-side",
         "\n\nFeatures:",
         "\n  Semantic diff, fuzzy matching, vulnerability tracking, license analysis"
     )
@@ -184,7 +185,14 @@ impl SharedEnrichmentArgs {
 
 /// Arguments for the `diff` subcommand
 #[derive(Parser)]
-#[command(after_help = "EXAMPLES:
+#[command(after_help = "EXIT CODES:
+    0  No changes detected (or --no-fail-on-change)
+    1  Changes detected (--fail-on-change)
+    2  Vulnerabilities introduced (--fail-on-vuln)
+    3  Error occurred
+    4  VEX gaps found (--fail-on-vex-gap)
+
+EXAMPLES:
     sbom-tools diff old.cdx.json new.cdx.json                    # Interactive TUI
     sbom-tools diff old.json new.json -o summary --fail-on-vuln   # CI gate
     sbom-tools diff old.json new.json --enrich-vulns -o sarif     # Enriched SARIF
@@ -209,9 +217,9 @@ struct DiffArgs {
     #[arg(long, default_value = "all")]
     reports: ReportType,
 
-    /// Fuzzy matching preset (strict, balanced, permissive)
-    #[arg(long, default_value = "balanced")]
-    fuzzy_preset: String,
+    /// Fuzzy matching preset
+    #[arg(long, value_enum, default_value_t = FuzzyPreset::Balanced)]
+    fuzzy_preset: FuzzyPreset,
 
     /// Include unchanged components in output
     #[arg(long)]
@@ -354,7 +362,13 @@ struct ViewArgs {
 
 /// Arguments for the `validate` subcommand
 #[derive(Parser)]
-#[command(after_help = "EXAMPLES:
+#[command(after_help = "EXIT CODES:
+    0  Compliant (no errors; no warnings with --fail-on-warning)
+    1  Compliance errors found (non-compliant)
+    2  Compliance warnings found (only with --fail-on-warning)
+    3  Error occurred
+
+EXAMPLES:
     sbom-tools validate app.cdx.json                              # NTIA minimum
     sbom-tools validate app.cdx.json --standard cra,eo14028       # Multi-standard
     sbom-tools validate app.cdx.json --standard ntia -o sarif     # SARIF for CI
@@ -419,9 +433,9 @@ struct DiffMultiArgs {
     #[arg(short = 'O', long)]
     output_file: Option<PathBuf>,
 
-    /// Fuzzy matching preset (strict, balanced, permissive)
-    #[arg(long, default_value = "balanced")]
-    fuzzy_preset: String,
+    /// Fuzzy matching preset
+    #[arg(long, value_enum, default_value_t = FuzzyPreset::Balanced)]
+    fuzzy_preset: FuzzyPreset,
 
     /// Include unchanged components in output
     #[arg(long)]
@@ -486,9 +500,9 @@ struct TimelineArgs {
     #[arg(short = 'O', long)]
     output_file: Option<PathBuf>,
 
-    /// Fuzzy matching preset (strict, balanced, permissive)
-    #[arg(long, default_value = "balanced")]
-    fuzzy_preset: String,
+    /// Fuzzy matching preset
+    #[arg(long, value_enum, default_value_t = FuzzyPreset::Balanced)]
+    fuzzy_preset: FuzzyPreset,
 
     /// Enable graph-aware diffing for timeline analysis
     #[arg(long)]
@@ -549,9 +563,9 @@ struct MatrixArgs {
     #[arg(short = 'O', long)]
     output_file: Option<PathBuf>,
 
-    /// Fuzzy matching preset (strict, balanced, permissive)
-    #[arg(long, default_value = "balanced")]
-    fuzzy_preset: String,
+    /// Fuzzy matching preset
+    #[arg(long, value_enum, default_value_t = FuzzyPreset::Balanced)]
+    fuzzy_preset: FuzzyPreset,
 
     /// Similarity threshold for clustering (0.0-1.0)
     #[arg(long, default_value = "0.8")]
@@ -599,7 +613,12 @@ struct MatrixArgs {
 
 /// Arguments for the `quality` subcommand
 #[derive(Parser)]
-#[command(after_help = "EXAMPLES:
+#[command(after_help = "EXIT CODES:
+    0  Score meets the --min-score threshold (or no threshold set)
+    1  Overall score below --min-score
+    3  Error occurred
+
+EXAMPLES:
     sbom-tools quality app.cdx.json                                # Score overview
     sbom-tools quality app.cdx.json --profile security --metrics   # Detailed metrics
     sbom-tools quality app.cdx.json --min-score 70 -o json         # CI gate with export
@@ -647,7 +666,12 @@ struct QualityArgs {
 
 /// Arguments for the `query` subcommand
 #[derive(Parser)]
-#[command(after_help = "EXAMPLES:
+#[command(after_help = "EXIT CODES:
+    0  At least one component matched the filter
+    1  No components matched the filter
+    3  Error occurred
+
+EXAMPLES:
     sbom-tools query log4j fleet/*.json                            # Search by name
     sbom-tools query --affected-by CVE-2021-44228 *.json           # Search by CVE
     sbom-tools query --ecosystem npm --license GPL fleet/*.json     # Multi-filter
@@ -908,8 +932,8 @@ struct VexExportArgs {
     vex: Vec<PathBuf>,
 
     /// Output advisory format. Currently: csaf (CSAF v2.0).
-    #[arg(short, long, default_value = "csaf")]
-    format: String,
+    #[arg(short, long, value_enum, default_value = "csaf")]
+    format: VexExportFormatArg,
 
     /// Output file path (stdout if not specified)
     #[arg(short = 'O', long)]
@@ -992,9 +1016,10 @@ enum VerifyAction {
             short = 'f',
             long = "output",
             alias = "format",
+            value_enum,
             default_value = "table"
         )]
-        format: String,
+        format: TableJsonFormat,
     },
 }
 
@@ -1026,9 +1051,10 @@ struct LicenseCheckArgs {
         short = 'f',
         long = "output",
         alias = "format",
+        value_enum,
         default_value = "table"
     )]
-    output_format: String,
+    output_format: TableJsonFormat,
 }
 
 /// Arguments for the `enrich` subcommand
@@ -1104,9 +1130,9 @@ struct MergeArgs {
     #[arg(short = 'O', long)]
     output_file: Option<PathBuf>,
 
-    /// Deduplication strategy (name, purl, none)
-    #[arg(long, default_value = "name")]
-    dedup: String,
+    /// Deduplication strategy
+    #[arg(long, value_enum, default_value = "name")]
+    dedup: sbom_tools::serialization::DeduplicationStrategy,
 }
 
 /// Arguments for the `cra-standards-watch` subcommand. Curated, offline-first
@@ -1118,8 +1144,8 @@ struct MergeArgs {
     sbom-tools cra-standards-watch --check-online    # HEAD-probe each URL")]
 struct CraStandardsWatchArgs {
     /// Output format: table (default) or json
-    #[arg(short, long, default_value = "table")]
-    format: String,
+    #[arg(short, long, value_enum, default_value = "table")]
+    format: TableJsonFormat,
 
     /// Issue HEAD requests against each tracked URL and report HTTP status
     #[arg(long)]
@@ -1156,6 +1182,37 @@ struct CraDocsArgs {
     /// Sidecar `productClass` wins.
     #[arg(long, value_name = "CLASS")]
     cra_product_class: Option<String>,
+}
+
+/// Dedicated table/json output format for commands that only emit those two
+/// shapes (`license-check`, `verify audit-hashes`, `cra-standards-watch`).
+///
+/// Kept separate from the 10-variant [`ReportFormat`] so that unknown values
+/// fail at parse time with a did-you-mean hint instead of silently degrading.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+enum TableJsonFormat {
+    /// Human-readable table (default)
+    #[default]
+    Table,
+    /// Machine-readable JSON
+    Json,
+}
+
+impl TableJsonFormat {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Table => "table",
+            Self::Json => "json",
+        }
+    }
+}
+
+/// Advisory export format for `vex export`. Currently only CSAF v2.0.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+enum VexExportFormatArg {
+    /// CSAF v2.0 advisory document (default)
+    #[default]
+    Csaf,
 }
 
 /// Validate VEX state filter values at the CLI boundary.
@@ -1213,7 +1270,7 @@ fn main() -> Result<()> {
                     export_template: cli.export_template.clone(),
                 },
                 matching: MatchingConfig {
-                    fuzzy_preset: args.fuzzy_preset.parse().unwrap_or_default(),
+                    fuzzy_preset: args.fuzzy_preset,
                     threshold: None,
                     include_unchanged: args.include_unchanged,
                 },
@@ -1296,16 +1353,22 @@ fn main() -> Result<()> {
             Ok(())
         }
 
-        Commands::Validate(args) => cli::run_validate(
-            args.sbom,
-            args.standard,
-            args.output,
-            args.output_file,
-            args.fail_on_warning,
-            args.summary,
-            args.cra_sidecar,
-            args.cra_product_class,
-        ),
+        Commands::Validate(args) => {
+            let exit_code = cli::run_validate(
+                args.sbom,
+                args.standard,
+                args.output,
+                args.output_file,
+                args.fail_on_warning,
+                args.summary,
+                args.cra_sidecar,
+                args.cra_product_class,
+            )?;
+            if exit_code != 0 {
+                std::process::exit(exit_code);
+            }
+            Ok(())
+        }
 
         Commands::DiffMulti(args) => {
             let enrichment = args.enrichment.to_enrichment_config();
@@ -1320,7 +1383,7 @@ fn main() -> Result<()> {
                     ..Default::default()
                 },
                 matching: MatchingConfig {
-                    fuzzy_preset: args.fuzzy_preset.parse().unwrap_or_default(),
+                    fuzzy_preset: args.fuzzy_preset,
                     include_unchanged: args.include_unchanged,
                     ..Default::default()
                 },
@@ -1376,7 +1439,7 @@ fn main() -> Result<()> {
                     ..Default::default()
                 },
                 matching: MatchingConfig {
-                    fuzzy_preset: args.fuzzy_preset.parse().unwrap_or_default(),
+                    fuzzy_preset: args.fuzzy_preset,
                     ..Default::default()
                 },
                 filtering: FilterConfig {
@@ -1431,7 +1494,7 @@ fn main() -> Result<()> {
                     ..Default::default()
                 },
                 matching: MatchingConfig {
-                    fuzzy_preset: args.fuzzy_preset.parse().unwrap_or_default(),
+                    fuzzy_preset: args.fuzzy_preset,
                     ..Default::default()
                 },
                 cluster_threshold: args.cluster_threshold,
@@ -1542,7 +1605,11 @@ fn main() -> Result<()> {
                 group_by_sbom: args.group_by_sbom,
             };
 
-            cli::run_query(config, filter)
+            let exit_code = cli::run_query(config, filter)?;
+            if exit_code != 0 {
+                std::process::exit(exit_code);
+            }
+            Ok(())
         }
 
         Commands::Vex { action } => {
@@ -1551,11 +1618,8 @@ fn main() -> Result<()> {
                 VexAction::Status(args) => (args, cli::VexAction::Status),
                 VexAction::Filter(args) => (args, cli::VexAction::Filter),
                 VexAction::Export(export_args) => {
-                    let fmt = match export_args.format.to_lowercase().as_str() {
-                        "csaf" | "csaf-v2.0" | "csaf2" => cli::VexExportFormat::Csaf,
-                        other => {
-                            anyhow::bail!("Unsupported VEX export format '{other}'. Valid: csaf")
-                        }
+                    let fmt = match export_args.format {
+                        VexExportFormatArg::Csaf => cli::VexExportFormat::Csaf,
                     };
                     let synth_args = VexArgs {
                         sbom: export_args.sbom,
@@ -1728,9 +1792,10 @@ fn main() -> Result<()> {
                     expected,
                     hash_file,
                 },
-                VerifyAction::AuditHashes { file, format } => {
-                    cli::VerifyAction::AuditHashes { file, format }
-                }
+                VerifyAction::AuditHashes { file, format } => cli::VerifyAction::AuditHashes {
+                    file,
+                    format: format.as_str().to_string(),
+                },
             };
 
             let exit_code = cli::run_verify(cli_action, cli.quiet)?;
@@ -1746,7 +1811,7 @@ fn main() -> Result<()> {
                 args.policy.as_ref(),
                 args.check_propagation,
                 args.strict,
-                &args.output_format,
+                args.output_format.as_str(),
                 cli.quiet,
             )?;
             if exit_code != 0 {
@@ -1792,13 +1857,9 @@ fn main() -> Result<()> {
         }
 
         Commands::Merge(args) => {
-            let dedup_strategy = match args.dedup.to_lowercase().as_str() {
-                "purl" => sbom_tools::serialization::DeduplicationStrategy::Purl,
-                "none" => sbom_tools::serialization::DeduplicationStrategy::None,
-                _ => sbom_tools::serialization::DeduplicationStrategy::Name,
+            let config = sbom_tools::serialization::MergeConfig {
+                dedup_strategy: args.dedup,
             };
-
-            let config = sbom_tools::serialization::MergeConfig { dedup_strategy };
 
             let exit_code = cli::run_merge(
                 &args.primary,
@@ -1821,7 +1882,7 @@ fn main() -> Result<()> {
         ),
 
         Commands::CraStandardsWatch(args) => cli::run_cra_standards_watch(
-            cli::WatchOutputFormat::parse(&args.format)?,
+            cli::WatchOutputFormat::parse(args.format.as_str())?,
             args.check_online,
             args.timeout,
         ),

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -58,6 +58,21 @@ pub mod exit_codes {
     pub const VEX_GAPS_FOUND: i32 = 4;
     /// License policy violations found
     pub const LICENSE_VIOLATIONS: i32 = 5;
+
+    // --- Per-command meanings (aliases preserving the numeric values above) ---
+
+    /// `validate`: compliance errors found (non-compliant SBOM). Same value as
+    /// [`CHANGES_DETECTED`].
+    pub const COMPLIANCE_ERRORS: i32 = CHANGES_DETECTED;
+    /// `validate --fail-on-warning`: compliance warnings found. Same value as
+    /// [`VULNS_INTRODUCED`].
+    pub const COMPLIANCE_WARNINGS: i32 = VULNS_INTRODUCED;
+    /// `quality --min-score`: overall score below the requested threshold. Same
+    /// value as [`CHANGES_DETECTED`].
+    pub const QUALITY_BELOW_THRESHOLD: i32 = CHANGES_DETECTED;
+    /// `query`: no components matched the filter. Same value as
+    /// [`CHANGES_DETECTED`].
+    pub const NO_MATCHES: i32 = CHANGES_DETECTED;
 }
 
 /// Platform-specific cache directory utilities
@@ -126,6 +141,22 @@ mod tests {
         assert_eq!(exit_codes::VULNS_INTRODUCED, 2);
         assert_eq!(exit_codes::ERROR, 3);
         assert_eq!(exit_codes::VEX_GAPS_FOUND, 4);
+        assert_eq!(exit_codes::LICENSE_VIOLATIONS, 5);
+    }
+
+    #[test]
+    fn test_per_command_exit_code_aliases_preserve_values() {
+        // Per-command aliases must not introduce new numeric exit codes.
+        assert_eq!(exit_codes::COMPLIANCE_ERRORS, exit_codes::CHANGES_DETECTED);
+        assert_eq!(
+            exit_codes::COMPLIANCE_WARNINGS,
+            exit_codes::VULNS_INTRODUCED
+        );
+        assert_eq!(
+            exit_codes::QUALITY_BELOW_THRESHOLD,
+            exit_codes::CHANGES_DETECTED
+        );
+        assert_eq!(exit_codes::NO_MATCHES, exit_codes::CHANGES_DETECTED);
     }
 
     #[test]

--- a/src/reports/mod.rs
+++ b/src/reports/mod.rs
@@ -38,7 +38,9 @@ pub use sarif::{
     generate_ai_readiness_sarif, generate_compliance_sarif, generate_multi_compliance_sarif,
 };
 pub use sidebyside::SideBySideReporter;
-pub use streaming::{NdjsonReporter, NdjsonWriter, StreamingJsonReporter, StreamingJsonWriter};
+pub use streaming::{
+    NdjsonReportGenerator, NdjsonReporter, NdjsonWriter, StreamingJsonReporter, StreamingJsonWriter,
+};
 pub use summary::{SummaryReporter, TableReporter};
 pub use types::{MinSeverity, ReportConfig, ReportFormat, ReportMetadata, ReportType};
 
@@ -228,5 +230,6 @@ pub fn create_reporter_with_options(
             }
         }
         ReportFormat::Csv => Box::new(CsvReporter::new()),
+        ReportFormat::Ndjson => Box::new(NdjsonReportGenerator::new()),
     }
 }

--- a/src/reports/streaming.rs
+++ b/src/reports/streaming.rs
@@ -29,7 +29,7 @@
 //! ndjson.write_components(&result.components)?;
 //! ```
 
-use super::{ReportConfig, ReportError, ReportFormat, ReportType, WriterReporter};
+use super::{ReportConfig, ReportError, ReportFormat, ReportGenerator, ReportType, WriterReporter};
 use crate::diff::DiffResult;
 use crate::model::NormalizedSbom;
 use chrono::Utc;
@@ -683,7 +683,53 @@ impl WriterReporter for NdjsonReporter {
     }
 
     fn format(&self) -> ReportFormat {
-        ReportFormat::Json // NDJSON is a variant of JSON
+        ReportFormat::Ndjson
+    }
+}
+
+/// `ReportGenerator` adapter for [`NdjsonReporter`].
+///
+/// [`NdjsonReporter`] implements [`WriterReporter`] directly so it can stream
+/// without buffering, which makes it incompatible with the blanket
+/// `WriterReporter` impl over `ReportGenerator`. This thin wrapper bridges it
+/// into the `Box<dyn ReportGenerator>` world used by `create_reporter`,
+/// buffering the NDJSON into a `String` on demand.
+#[derive(Default)]
+pub struct NdjsonReportGenerator;
+
+impl NdjsonReportGenerator {
+    /// Create a new NDJSON report generator.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+impl ReportGenerator for NdjsonReportGenerator {
+    fn generate_diff_report(
+        &self,
+        result: &DiffResult,
+        old_sbom: &NormalizedSbom,
+        new_sbom: &NormalizedSbom,
+        config: &ReportConfig,
+    ) -> Result<String, ReportError> {
+        let mut buf = Vec::new();
+        NdjsonReporter::new().write_diff_to(result, old_sbom, new_sbom, config, &mut buf)?;
+        String::from_utf8(buf).map_err(|e| ReportError::SerializationError(e.to_string()))
+    }
+
+    fn generate_view_report(
+        &self,
+        sbom: &NormalizedSbom,
+        config: &ReportConfig,
+    ) -> Result<String, ReportError> {
+        let mut buf = Vec::new();
+        NdjsonReporter::new().write_view_to(sbom, config, &mut buf)?;
+        String::from_utf8(buf).map_err(|e| ReportError::SerializationError(e.to_string()))
+    }
+
+    fn format(&self) -> ReportFormat {
+        ReportFormat::Ndjson
     }
 }
 
@@ -804,7 +850,30 @@ mod tests {
     #[test]
     fn test_ndjson_reporter_implements_writer_reporter() {
         let reporter = NdjsonReporter::new();
-        assert_eq!(WriterReporter::format(&reporter), ReportFormat::Json);
+        assert_eq!(WriterReporter::format(&reporter), ReportFormat::Ndjson);
+    }
+
+    #[test]
+    fn test_ndjson_report_generator_reports_ndjson_format() {
+        let generator = NdjsonReportGenerator::new();
+        assert_eq!(ReportGenerator::format(&generator), ReportFormat::Ndjson);
+    }
+
+    #[test]
+    fn test_ndjson_report_generator_view_yields_ndjson_lines() {
+        use crate::model::NormalizedSbom;
+
+        let sbom = NormalizedSbom::default();
+        let config = ReportConfig::default();
+        let generator = NdjsonReportGenerator::new();
+        let report = generator
+            .generate_view_report(&sbom, &config)
+            .expect("view report should render");
+
+        let first = report.lines().next().expect("at least one NDJSON line");
+        let value: serde_json::Value =
+            serde_json::from_str(first).expect("first line should be valid json");
+        assert_eq!(value["type"], "metadata");
     }
 
     #[test]

--- a/src/reports/types.rs
+++ b/src/reports/types.rs
@@ -32,6 +32,8 @@ pub enum ReportFormat {
     Table,
     /// CSV for spreadsheet import
     Csv,
+    /// Newline-delimited JSON (one record per line, streaming-friendly)
+    Ndjson,
 }
 
 impl std::fmt::Display for ReportFormat {
@@ -47,6 +49,7 @@ impl std::fmt::Display for ReportFormat {
             Self::Summary => write!(f, "summary"),
             Self::Table => write!(f, "table"),
             Self::Csv => write!(f, "csv"),
+            Self::Ndjson => write!(f, "ndjson"),
         }
     }
 }

--- a/src/serialization/merger.rs
+++ b/src/serialization/merger.rs
@@ -39,9 +39,11 @@ impl Default for MergeConfig {
 }
 
 /// Strategy for deduplicating components during merge
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, clap::ValueEnum)]
+#[serde(rename_all = "kebab-case")]
 pub enum DeduplicationStrategy {
     /// Deduplicate by package name + version
+    #[default]
     Name,
     /// Deduplicate by PURL (exact match)
     Purl,

--- a/tests/cli_contract_tests.rs
+++ b/tests/cli_contract_tests.rs
@@ -1,0 +1,198 @@
+//! CLI contract tests: per-command exit codes, typed value-enum parse
+//! validation, and NDJSON output wiring.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const FIXTURES_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn fixture_path(name: &str) -> PathBuf {
+    Path::new(FIXTURES_DIR).join(name)
+}
+
+fn base_command() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sbom-tools"));
+    cmd.arg("--no-color");
+    cmd.env("RUST_LOG", "error");
+    cmd.env("RUST_LOG_STYLE", "never");
+    cmd
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("stdout should be utf-8")
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8(output.stderr.clone()).expect("stderr should be utf-8")
+}
+
+#[test]
+fn validate_fail_on_warning_returns_exit_code_2() {
+    // minimal.cdx.json has 0 NTIA errors but several warnings (missing
+    // version/supplier), so --fail-on-warning must exit with code 2.
+    let output = base_command()
+        .arg("validate")
+        .arg(fixture_path("cyclonedx/minimal.cdx.json"))
+        .args(["--standard", "ntia", "--summary", "--fail-on-warning"])
+        .output()
+        .expect("validate command should run");
+
+    assert_eq!(output.status.code(), Some(2), "{}", stderr(&output));
+}
+
+#[test]
+fn validate_without_fail_on_warning_returns_exit_code_0_when_warnings_only() {
+    let output = base_command()
+        .arg("validate")
+        .arg(fixture_path("cyclonedx/minimal.cdx.json"))
+        .args(["--standard", "ntia", "--summary"])
+        .output()
+        .expect("validate command should run");
+
+    assert_eq!(output.status.code(), Some(0), "{}", stderr(&output));
+}
+
+#[test]
+fn validate_with_errors_returns_exit_code_1() {
+    let output = base_command()
+        .arg("validate")
+        .arg(fixture_path("showcase/supply-chain-incident.cdx.json"))
+        .args(["--standard", "ntia", "--summary"])
+        .output()
+        .expect("validate command should run");
+
+    assert_eq!(output.status.code(), Some(1), "{}", stderr(&output));
+}
+
+#[test]
+fn quality_below_min_score_returns_exit_code_1() {
+    let output = base_command()
+        .arg("quality")
+        .arg(fixture_path("demo-new.cdx.json"))
+        .args(["--min-score", "100", "-o", "json"])
+        .output()
+        .expect("quality command should run");
+
+    assert_eq!(output.status.code(), Some(1), "{}", stderr(&output));
+}
+
+#[test]
+fn quality_meeting_min_score_returns_exit_code_0() {
+    let output = base_command()
+        .arg("quality")
+        .arg(fixture_path("demo-new.cdx.json"))
+        .args(["--min-score", "0", "-o", "json"])
+        .output()
+        .expect("quality command should run");
+
+    assert_eq!(output.status.code(), Some(0), "{}", stderr(&output));
+}
+
+#[test]
+fn query_no_match_returns_exit_code_1() {
+    let output = base_command()
+        .arg("query")
+        .arg("zzz-no-such-component-zzz")
+        .arg(fixture_path("demo-new.cdx.json"))
+        .args(["-o", "json"])
+        .output()
+        .expect("query command should run");
+
+    assert_eq!(output.status.code(), Some(1), "{}", stderr(&output));
+}
+
+#[test]
+fn query_match_returns_exit_code_0() {
+    let output = base_command()
+        .arg("query")
+        .arg("lodash")
+        .arg(fixture_path("demo-new.cdx.json"))
+        .args(["-o", "json"])
+        .output()
+        .expect("query command should run");
+
+    assert_eq!(output.status.code(), Some(0), "{}", stderr(&output));
+}
+
+#[test]
+fn invalid_fuzzy_preset_is_rejected_at_parse() {
+    let output = base_command()
+        .arg("diff")
+        .arg(fixture_path("demo-old.cdx.json"))
+        .arg(fixture_path("demo-new.cdx.json"))
+        .args(["--fuzzy-preset", "not-a-preset"])
+        .output()
+        .expect("diff command should run");
+
+    // clap exits with code 2 on argument parse errors.
+    assert_eq!(output.status.code(), Some(2), "{}", stdout(&output));
+    let err = stderr(&output);
+    assert!(
+        err.contains("invalid value 'not-a-preset'"),
+        "stderr should explain the invalid value: {err}"
+    );
+    assert!(
+        err.contains("possible values"),
+        "stderr should list the valid presets (did-you-mean hint): {err}"
+    );
+}
+
+#[test]
+fn invalid_merge_dedup_strategy_is_rejected_at_parse() {
+    let output = base_command()
+        .arg("merge")
+        .arg(fixture_path("demo-old.cdx.json"))
+        .arg(fixture_path("demo-new.cdx.json"))
+        .args(["--dedup", "not-a-strategy"])
+        .output()
+        .expect("merge command should run");
+
+    assert_eq!(output.status.code(), Some(2), "{}", stdout(&output));
+    let err = stderr(&output);
+    assert!(
+        err.contains("invalid value 'not-a-strategy'"),
+        "stderr should explain the invalid value: {err}"
+    );
+    assert!(
+        err.contains("name") && err.contains("purl"),
+        "stderr should list valid dedup strategies: {err}"
+    );
+}
+
+#[test]
+fn diff_ndjson_output_emits_one_json_object_per_line() {
+    let output = base_command()
+        .arg("diff")
+        .arg(fixture_path("demo-old.cdx.json"))
+        .arg(fixture_path("demo-new.cdx.json"))
+        .args(["-o", "ndjson"])
+        .output()
+        .expect("diff command should run");
+
+    assert!(output.status.success(), "{}", stderr(&output));
+    let text = stdout(&output);
+
+    let lines: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
+    assert!(lines.len() >= 2, "expected multiple NDJSON lines: {text}");
+
+    // Every non-empty line must be a standalone JSON object.
+    for line in &lines {
+        let value: serde_json::Value = serde_json::from_str(line)
+            .unwrap_or_else(|e| panic!("line is not valid json: {line}: {e}"));
+        assert!(
+            value.is_object(),
+            "each NDJSON line should be an object: {line}"
+        );
+    }
+
+    // The first record is the metadata header; a summary record follows.
+    let first: serde_json::Value = serde_json::from_str(lines[0]).expect("first line json");
+    assert_eq!(first["type"], "metadata");
+    assert!(
+        lines
+            .iter()
+            .filter_map(|l| serde_json::from_str::<serde_json::Value>(l).ok())
+            .any(|v| v["type"] == "summary"),
+        "expected a summary NDJSON record: {text}"
+    );
+}

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -2665,7 +2665,7 @@ mod streaming_tests {
         let reporter = NdjsonReporter::new();
         assert_eq!(
             WriterReporter::format(&reporter),
-            sbom_tools::ReportFormat::Json,
+            sbom_tools::ReportFormat::Ndjson,
             "NdjsonReporter should implement WriterReporter"
         );
     }


### PR DESCRIPTION
## Summary

Three CLI-contract correctness fixes.

**(1) Exit-code contract.** `run_validate` (`src/cli/validate.rs:122-144`) and `run_query` (`src/cli/query.rs:478-481`) called `std::process::exit()` directly from inside the exported `cli` module (`src/lib.rs` `pub mod cli`), terminating any library consumer and skipping destructors — unlike `run_diff`/`run_quality`, which already follow the `Result<i32>` contract documented on `run_diff` (`src/cli/diff.rs:14-22`). Both now return `Result<i32>`; `main.rs` owns the single `process::exit`. Numeric values are preserved for CI back-compat (validate errors=1, `--fail-on-warning`=2; query no-match=1; quality below `--min-score`=1) and given named aliases in `pipeline::exit_codes` (`COMPLIANCE_ERRORS`/`COMPLIANCE_WARNINGS`/`QUALITY_BELOW_THRESHOLD`/`NO_MATCHES`) that resolve to the existing constants. Added per-command `EXIT CODES` sections to the `diff`/`validate`/`quality`/`query` clap `after_help`.

**(2) Silent typo degradation.** `args.fuzzy_preset.parse().unwrap_or_default()` at 4 dispatch sites in `main.rs` silently fell back to `Balanced` on a typo; `merge --dedup` fell back to `Name`. `FuzzyPreset` (`src/config/types.rs`) and `DeduplicationStrategy` (`src/serialization/merger.rs`) now derive `clap::ValueEnum`, so unknown values fail at parse with a did-you-mean / possible-values hint. `license-check` / `verify audit-hashes` / `cra-standards-watch` get a dedicated table/json `TableJsonFormat` ValueEnum and `vex export` a `VexExportFormatArg` (defined in `main.rs`), instead of raw `String` `-f` parsing. The `-f` / `--format` deprecated aliases are retained.

**(3) Unreachable NDJSON.** `NdjsonReporter` was fully implemented and exported (`src/reports/streaming.rs`) but `ReportFormat` had no `Ndjson` variant, so it was unreachable. Added `ReportFormat::Ndjson` (the enum is `#[non_exhaustive]`) plus a thin `NdjsonReportGenerator` adapter wired into `create_reporter` (`NdjsonReporter` implements `WriterReporter` directly, which conflicts with the blanket `ReportGenerator` impl, so the adapter bridges it). `NdjsonReporter::format()` now correctly reports `Ndjson` (was `Json`).

## Test plan

- New `tests/cli_contract_tests.rs` (CARGO_BIN_EXE, 10 tests):
  - exit codes for `validate --fail-on-warning` (2), `validate` errors (1) / warnings-only (0), `quality` below/at `--min-score` (1/0), `query` no-match/match (1/0)
  - invalid `--fuzzy-preset` and `--dedup` rejected at parse (clap exit 2 + possible-values hint)
  - `diff -o ndjson` emits one JSON object per line (metadata + summary records)
- New `pipeline::exit_codes` alias test asserts the per-command constants preserve the existing numeric values.
- New `reports::streaming` unit tests for `NdjsonReportGenerator` format + view rendering; updated the existing `NdjsonReporter` format assertions (lib + `tests/integration_tests.rs`) to expect `Ndjson`.
- `cargo fmt --check` clean; `cargo clippy --all-features` (pinned 1.88) lib+bin warning count unchanged vs HEAD (0 new); full `cargo test` green (854 lib + all integration suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)