### PR TITLE
feat(config): wire the global --config flag into command execution

### DIFF
--- a/src/cli_config.rs
+++ b/src/cli_config.rs
@@ -1,0 +1,149 @@
+//! Glue between the global `--config` flag and per-command config construction.
+//!
+//! [`EffectiveConfig::load`] discovers/loads/validates a YAML config file once,
+//! up front. The resulting [`EffectiveConfig`] is then threaded into each
+//! subcommand's config builder as the *base* layer. Per-command seeding asks
+//! [`resolve`] / [`resolve_bool`] for a value, which resolves precedence as:
+//!
+//!   explicit CLI flag > config file value > built-in default
+//!
+//! CLI explicitness is determined at the clap layer ([`ValueSource`]) so that a
+//! flag whose value happens to equal the default (e.g. `--output auto`) still
+//! overrides the file, while an unset flag falls through to the file value.
+
+use anyhow::{Context, Result};
+use clap::ArgMatches;
+use clap::parser::ValueSource;
+use sbom_tools::config::{
+    AppConfig, Validatable, discover_config_file, load_config_file, load_or_default,
+};
+use std::path::Path;
+
+/// Loaded config plus the discovered source path (for diagnostics).
+pub struct EffectiveConfig {
+    config: AppConfig,
+    loaded_from: Option<std::path::PathBuf>,
+}
+
+impl EffectiveConfig {
+    /// Discover, load, and validate the config file.
+    ///
+    /// When `no_config` is true, discovery is skipped entirely and built-in
+    /// defaults are returned. Otherwise the explicit `--config` path is
+    /// honoured first, falling back to standard discovery locations. Unlike the
+    /// lenient loader, a config file that exists but fails to *parse* or
+    /// *validate* is rejected with a hard error rather than silently falling
+    /// back to defaults — a broken file must never quietly change behaviour.
+    pub fn load(explicit_path: Option<&Path>, no_config: bool) -> Result<Self> {
+        if no_config {
+            return Ok(Self {
+                config: AppConfig::default(),
+                loaded_from: None,
+            });
+        }
+
+        // An explicit --config path that doesn't exist is a user error, not a
+        // silent fall-through to discovery.
+        if let Some(path) = explicit_path
+            && !path.exists()
+        {
+            anyhow::bail!("config file not found: {}", path.display());
+        }
+
+        let Some(path) = discover_config_file(explicit_path) else {
+            return Ok(Self {
+                config: AppConfig::default(),
+                loaded_from: None,
+            });
+        };
+
+        let config = load_config_file(&path)
+            .with_context(|| format!("failed to load config file {}", path.display()))?;
+        Self::validate(&config, Some(&path))?;
+        Ok(Self {
+            config,
+            loaded_from: Some(path),
+        })
+    }
+
+    /// Like [`load`](Self::load) but skips validation. Used by meta commands
+    /// (config management, completions, man, schema) that must run even when a
+    /// discovered config file is invalid. A missing explicit `--config` path is
+    /// tolerated here rather than erroring.
+    #[must_use]
+    pub fn load_lenient(explicit_path: Option<&Path>, no_config: bool) -> Self {
+        if no_config {
+            return Self {
+                config: AppConfig::default(),
+                loaded_from: None,
+            };
+        }
+        let (config, loaded_from) = load_or_default(explicit_path);
+        Self {
+            config,
+            loaded_from,
+        }
+    }
+
+    fn validate(config: &AppConfig, source: Option<&Path>) -> Result<()> {
+        let errors = config.validate();
+        if errors.is_empty() {
+            return Ok(());
+        }
+        let where_ = source.map_or_else(
+            || "configuration".to_string(),
+            |p| format!("config file {}", p.display()),
+        );
+        let detail = errors
+            .iter()
+            .map(|e| format!("  - {e}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        anyhow::bail!("invalid {where_}:\n{detail}");
+    }
+
+    /// The path the config was loaded from, if any.
+    pub fn loaded_from(&self) -> Option<&Path> {
+        self.loaded_from.as_deref()
+    }
+
+    /// The merged effective config (defaults + file).
+    pub fn into_app_config(self) -> AppConfig {
+        self.config
+    }
+}
+
+/// True when `name` was supplied on the command line (not a clap default).
+#[must_use]
+pub fn arg_was_set(matches: &ArgMatches, name: &str) -> bool {
+    matches!(matches.value_source(name), Some(ValueSource::CommandLine))
+}
+
+/// [`arg_was_set`] tolerant of an absent subcommand match.
+#[must_use]
+pub fn arg_was_set_sub(matches: Option<&ArgMatches>, name: &str) -> bool {
+    matches.is_some_and(|m| arg_was_set(m, name))
+}
+
+/// Resolve precedence for an optional value: explicit CLI > file > `None`.
+///
+/// `cli_value` is the parsed clap value (possibly a default). `was_set`
+/// reflects whether the user actually passed the flag.
+#[must_use]
+pub fn resolve<T>(cli_value: T, was_set: bool, file_value: Option<T>) -> T {
+    if was_set {
+        cli_value
+    } else {
+        file_value.unwrap_or(cli_value)
+    }
+}
+
+/// Resolve a boolean flag: an explicit `true` from either CLI or file wins.
+///
+/// Boolean clap flags default to `false` and only ever transition to `true`
+/// when present, so OR-ing the CLI flag with the file value yields the correct
+/// "either layer enabled it" semantics without needing `value_source`.
+#[must_use]
+pub const fn resolve_bool(cli_value: bool, file_value: bool) -> bool {
+    cli_value || file_value
+}

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -175,10 +175,17 @@ pub fn load_or_default(explicit_path: Option<&Path>) -> (AppConfig, Option<PathB
 impl AppConfig {
     /// Merge another config into this one, with `other` taking precedence.
     ///
-    /// This is useful for layering CLI args over file config.
+    /// This is useful for layering CLI args over file config. A field in
+    /// `other` overrides the corresponding field in `self` only when it
+    /// differs from the built-in default — a default-valued field is treated
+    /// as "unset" and leaves `self` untouched. The sentinel is read from
+    /// `Self::default()` rather than an inlined literal so it can never drift
+    /// away from the actual default.
     pub fn merge(&mut self, other: &Self) {
+        let defaults = Self::default();
+
         // Matching config
-        if other.matching.fuzzy_preset != crate::config::FuzzyPreset::Balanced {
+        if other.matching.fuzzy_preset != defaults.matching.fuzzy_preset {
             self.matching.fuzzy_preset = other.matching.fuzzy_preset.clone();
         }
         if other.matching.threshold.is_some() {
@@ -189,7 +196,7 @@ impl AppConfig {
         }
 
         // Output config - only override if explicitly set
-        if other.output.format != crate::reports::ReportFormat::Auto {
+        if other.output.format != defaults.output.format {
             self.output.format = other.output.format;
         }
         if other.output.file.is_some() {
@@ -258,7 +265,7 @@ impl AppConfig {
         }
 
         // TUI config
-        if other.tui.theme != crate::config::ThemeName::Dark {
+        if other.tui.theme != defaults.tui.theme {
             self.tui.theme = other.tui.theme.clone();
         }
 
@@ -465,6 +472,61 @@ behavior:
         );
         assert_eq!(base.matching.threshold, Some(0.95));
         assert!(base.behavior.fail_on_vuln);
+    }
+
+    #[test]
+    fn test_merge_default_valued_override_does_not_clobber_base() {
+        // A default-valued override field must NOT overwrite a non-default base
+        // value — the sentinel is the built-in default, read dynamically.
+        let mut base = AppConfig {
+            matching: super::super::types::MatchingConfig {
+                fuzzy_preset: crate::config::FuzzyPreset::Strict,
+                ..Default::default()
+            },
+            output: super::super::types::OutputConfig {
+                format: crate::reports::ReportFormat::Json,
+                ..Default::default()
+            },
+            ..AppConfig::default()
+        };
+
+        // `other` carries only defaults (Balanced / Auto) — nothing should win.
+        base.merge(&AppConfig::default());
+
+        assert_eq!(
+            base.matching.fuzzy_preset,
+            crate::config::FuzzyPreset::Strict,
+            "default fuzzy_preset must not clobber a non-default base"
+        );
+        assert_eq!(
+            base.output.format,
+            crate::reports::ReportFormat::Json,
+            "default output.format must not clobber a non-default base"
+        );
+    }
+
+    #[test]
+    fn test_from_file_with_overrides_cli_wins() {
+        // File sets Strict; an explicit non-default CLI override (Permissive)
+        // must take precedence after the merge.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("cfg.yaml");
+        std::fs::write(&path, "matching:\n  fuzzy_preset: strict\n").unwrap();
+
+        let cli = AppConfig {
+            matching: super::super::types::MatchingConfig {
+                fuzzy_preset: crate::config::FuzzyPreset::Permissive,
+                ..Default::default()
+            },
+            ..AppConfig::default()
+        };
+
+        let (merged, loaded_from) = AppConfig::from_file_with_overrides(Some(&path), &cli);
+        assert_eq!(loaded_from.as_deref(), Some(path.as_path()));
+        assert_eq!(
+            merged.matching.fuzzy_preset,
+            crate::config::FuzzyPreset::Permissive
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,13 +8,16 @@
     clippy::needless_pass_by_value
 )]
 
+mod cli_config;
+
 use anyhow::{Context, Result};
-use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
+use clap::{ArgMatches, Args, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use clap_complete::{Shell, generate};
+use cli_config::{EffectiveConfig, arg_was_set_sub, resolve, resolve_bool};
 use sbom_tools::{
     cli,
     config::{
-        BehaviorConfig, DiffConfig, DiffPaths, EcosystemRulesConfig, EnrichmentConfig,
+        AppConfig, BehaviorConfig, DiffConfig, DiffPaths, EcosystemRulesConfig, EnrichmentConfig,
         FilterConfig, FuzzyPreset, GraphAwareDiffConfig, MatchingConfig, MatchingRulesPathConfig,
         MatrixConfig, MultiDiffConfig, OutputConfig, QueryConfig, TimelineConfig, ViewConfig,
         WatchConfig,
@@ -121,6 +124,10 @@ struct Cli {
     #[arg(long, global = true)]
     config: Option<PathBuf>,
 
+    /// Skip config-file discovery entirely (ignore any `.sbom-tools.yaml`)
+    #[arg(long, global = true, conflicts_with = "config")]
+    no_config: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -180,6 +187,33 @@ impl SharedEnrichmentArgs {
             vex_paths: self.vex.clone(),
             ..Default::default()
         }
+    }
+}
+
+/// Build the effective `EnrichmentConfig`, layering CLI enrichment flags over
+/// the `enrichment:` section of the loaded config file.
+///
+/// The CLI value always wins when any enrichment flag was passed; otherwise the
+/// file's enrichment block (if present) supplies the base. When neither layer
+/// requested enrichment, the CLI-derived config (disabled) is returned so cache
+/// directory / timeout defaults stay intact.
+fn seed_enrichment(
+    args: &SharedEnrichmentArgs,
+    sub: Option<&ArgMatches>,
+    app: &AppConfig,
+) -> EnrichmentConfig {
+    let cli = args.to_enrichment_config();
+    let cli_touched = cli.enabled
+        || cli.enable_eol
+        || arg_was_set_sub(sub, "vuln_cache_dir")
+        || arg_was_set_sub(sub, "vuln_cache_ttl")
+        || arg_was_set_sub(sub, "api_timeout")
+        || arg_was_set_sub(sub, "refresh_vulns")
+        || !cli.vex_paths.is_empty();
+
+    match (&app.enrichment, cli_touched) {
+        (Some(file), false) => file.clone(),
+        _ => cli,
     }
 }
 
@@ -897,6 +931,19 @@ enum Commands {
     Man,
 }
 
+impl Commands {
+    /// Whether this command seeds a per-command config from the loaded
+    /// `AppConfig`. Meta commands (config management, shell completions, man
+    /// page, schema generation) don't, so a broken or missing config file must
+    /// never block them — they get a lenient (unvalidated) load instead.
+    const fn consumes_config(&self) -> bool {
+        !matches!(
+            self,
+            Self::Config { .. } | Self::Completions { .. } | Self::ConfigSchema { .. } | Self::Man
+        )
+    }
+}
+
 /// Sub-subcommands for the `config` command
 #[derive(Subcommand)]
 enum ConfigAction {
@@ -906,6 +953,8 @@ enum ConfigAction {
     Path,
     /// Generate an example .sbom-tools.yaml in the current directory
     Init,
+    /// Load + validate the config and print the effective merged settings
+    Check,
 }
 
 /// Sub-subcommands for the `vex` command
@@ -1235,7 +1284,8 @@ fn validate_vex_state(s: &str) -> std::result::Result<String, String> {
 }
 
 fn main() -> Result<()> {
-    let cli = Cli::parse();
+    let matches = Cli::command().get_matches();
+    let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
 
     // Initialize logging
     let log_level = if cli.verbose { "debug" } else { "info" };
@@ -1246,10 +1296,26 @@ fn main() -> Result<()> {
         .with(tracing_subscriber::fmt::layer().with_target(false))
         .init();
 
+    // Load the file-based config once, up front, so every command can use it
+    // as the base layer that explicit CLI flags override. Consuming commands
+    // get a strict (validated) load so a broken file fails loudly; meta
+    // commands (config management, completions, man, schema) get a lenient load
+    // so they are never blocked by an unrelated invalid config.
+    let effective = if cli.command.consumes_config() {
+        EffectiveConfig::load(cli.config.as_deref(), cli.no_config)?
+    } else {
+        EffectiveConfig::load_lenient(cli.config.as_deref(), cli.no_config)
+    };
+    let app = effective.into_app_config();
+    // Per-subcommand argument matches, used to detect which CLI flags were set
+    // explicitly (vs. left at their clap default).
+    let sub_matches = matches.subcommand().map(|(_, m)| m);
+
     // Dispatch to command handlers
     match cli.command {
         Commands::Diff(args) => {
-            let enrichment = args.enrichment.to_enrichment_config();
+            let sm = sub_matches;
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
 
             let config = DiffConfig {
                 paths: DiffPaths {
@@ -1257,10 +1323,14 @@ fn main() -> Result<()> {
                     new: args.new,
                 },
                 output: OutputConfig {
-                    format: args.output,
+                    format: resolve(
+                        args.output,
+                        arg_was_set_sub(sm, "output"),
+                        Some(app.output.format),
+                    ),
                     file: args.output_file,
                     report_types: args.reports,
-                    no_color: cli.no_color,
+                    no_color: resolve_bool(cli.no_color, app.output.no_color),
                     streaming: sbom_tools::config::StreamingConfig {
                         threshold_bytes: args.streaming_threshold * 1024 * 1024,
                         force: args.streaming,
@@ -1270,22 +1340,41 @@ fn main() -> Result<()> {
                     export_template: cli.export_template.clone(),
                 },
                 matching: MatchingConfig {
-                    fuzzy_preset: args.fuzzy_preset,
-                    threshold: None,
-                    include_unchanged: args.include_unchanged,
+                    fuzzy_preset: resolve(
+                        args.fuzzy_preset.clone(),
+                        arg_was_set_sub(sm, "fuzzy_preset"),
+                        Some(app.matching.fuzzy_preset.clone()),
+                    ),
+                    threshold: app.matching.threshold,
+                    include_unchanged: resolve_bool(
+                        args.include_unchanged,
+                        app.matching.include_unchanged,
+                    ),
                 },
                 filtering: FilterConfig {
-                    only_changes: args.only_changes,
-                    min_severity: args.severity,
-                    exclude_vex_resolved: args.exclude_vex_resolved,
-                    fail_on_vex_gap: args.fail_on_vex_gap,
+                    only_changes: resolve_bool(args.only_changes, app.filtering.only_changes),
+                    min_severity: args.severity.or_else(|| app.filtering.min_severity.clone()),
+                    exclude_vex_resolved: resolve_bool(
+                        args.exclude_vex_resolved,
+                        app.filtering.exclude_vex_resolved,
+                    ),
+                    fail_on_vex_gap: resolve_bool(
+                        args.fail_on_vex_gap,
+                        app.filtering.fail_on_vex_gap,
+                    ),
                 },
                 behavior: BehaviorConfig {
-                    fail_on_vuln: args.fail_on_vuln,
-                    fail_on_change: args.fail_on_change,
-                    quiet: cli.quiet,
-                    explain_matches: args.explain_matches,
-                    recommend_threshold: args.recommend_threshold,
+                    fail_on_vuln: resolve_bool(args.fail_on_vuln, app.behavior.fail_on_vuln),
+                    fail_on_change: resolve_bool(args.fail_on_change, app.behavior.fail_on_change),
+                    quiet: resolve_bool(cli.quiet, app.behavior.quiet),
+                    explain_matches: resolve_bool(
+                        args.explain_matches,
+                        app.behavior.explain_matches,
+                    ),
+                    recommend_threshold: resolve_bool(
+                        args.recommend_threshold,
+                        app.behavior.recommend_threshold,
+                    ),
                 },
                 graph_diff: if args.graph_diff {
                     let mut gdc = GraphAwareDiffConfig::enabled();
@@ -1299,16 +1388,24 @@ fn main() -> Result<()> {
                     }
                     gdc
                 } else {
-                    GraphAwareDiffConfig::default()
+                    app.graph_diff.clone()
                 },
                 rules: MatchingRulesPathConfig {
-                    rules_file: args.enrichment.matching_rules,
-                    dry_run: args.dry_run_rules,
+                    rules_file: args
+                        .enrichment
+                        .matching_rules
+                        .or_else(|| app.rules.rules_file.clone()),
+                    dry_run: resolve_bool(args.dry_run_rules, app.rules.dry_run),
                 },
                 ecosystem_rules: EcosystemRulesConfig {
-                    config_file: args.ecosystem_rules,
-                    disabled: args.no_ecosystem_rules,
-                    detect_typosquats: args.detect_typosquats,
+                    config_file: args
+                        .ecosystem_rules
+                        .or_else(|| app.ecosystem_rules.config_file.clone()),
+                    disabled: resolve_bool(args.no_ecosystem_rules, app.ecosystem_rules.disabled),
+                    detect_typosquats: resolve_bool(
+                        args.detect_typosquats,
+                        app.ecosystem_rules.detect_typosquats,
+                    ),
                 },
                 enrichment,
             };
@@ -1321,23 +1418,28 @@ fn main() -> Result<()> {
         }
 
         Commands::View(args) => {
-            let enrichment = args.enrichment.to_enrichment_config();
+            let sm = sub_matches;
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
 
             let config = ViewConfig {
                 sbom_path: args.sbom,
                 output: OutputConfig {
-                    format: args.output,
+                    format: resolve(
+                        args.output,
+                        arg_was_set_sub(sm, "output"),
+                        Some(app.output.format),
+                    ),
                     file: args.output_file,
                     report_types: ReportType::All,
-                    no_color: cli.no_color,
+                    no_color: resolve_bool(cli.no_color, app.output.no_color),
                     streaming: sbom_tools::config::StreamingConfig::default(),
                     export_template: cli.export_template.clone(),
                 },
                 validate_ntia: args.validate_ntia,
-                min_severity: args.severity,
+                min_severity: args.severity.or_else(|| app.filtering.min_severity.clone()),
                 vulnerable_only: args.vulnerable_only,
                 ecosystem_filter: args.ecosystem,
-                fail_on_vuln: args.fail_on_vuln,
+                fail_on_vuln: resolve_bool(args.fail_on_vuln, app.behavior.fail_on_vuln),
                 bom_profile: args
                     .bom_type
                     .as_deref()
@@ -1371,32 +1473,50 @@ fn main() -> Result<()> {
         }
 
         Commands::DiffMulti(args) => {
-            let enrichment = args.enrichment.to_enrichment_config();
+            let sm = sub_matches;
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
             let config = MultiDiffConfig {
                 baseline: args.baseline,
                 targets: args.targets,
                 output: OutputConfig {
-                    format: args.output,
+                    format: resolve(
+                        args.output,
+                        arg_was_set_sub(sm, "output"),
+                        Some(app.output.format),
+                    ),
                     file: args.output_file,
-                    no_color: cli.no_color,
+                    no_color: resolve_bool(cli.no_color, app.output.no_color),
                     export_template: cli.export_template.clone(),
                     ..Default::default()
                 },
                 matching: MatchingConfig {
-                    fuzzy_preset: args.fuzzy_preset,
-                    include_unchanged: args.include_unchanged,
-                    ..Default::default()
+                    fuzzy_preset: resolve(
+                        args.fuzzy_preset.clone(),
+                        arg_was_set_sub(sm, "fuzzy_preset"),
+                        Some(app.matching.fuzzy_preset.clone()),
+                    ),
+                    include_unchanged: resolve_bool(
+                        args.include_unchanged,
+                        app.matching.include_unchanged,
+                    ),
+                    threshold: app.matching.threshold,
                 },
                 filtering: FilterConfig {
-                    min_severity: args.severity,
-                    exclude_vex_resolved: args.exclude_vex_resolved,
-                    fail_on_vex_gap: args.fail_on_vex_gap,
+                    min_severity: args.severity.or_else(|| app.filtering.min_severity.clone()),
+                    exclude_vex_resolved: resolve_bool(
+                        args.exclude_vex_resolved,
+                        app.filtering.exclude_vex_resolved,
+                    ),
+                    fail_on_vex_gap: resolve_bool(
+                        args.fail_on_vex_gap,
+                        app.filtering.fail_on_vex_gap,
+                    ),
                     ..Default::default()
                 },
                 behavior: BehaviorConfig {
-                    fail_on_vuln: args.fail_on_vuln,
-                    fail_on_change: args.fail_on_change,
-                    quiet: cli.quiet,
+                    fail_on_vuln: resolve_bool(args.fail_on_vuln, app.behavior.fail_on_vuln),
+                    fail_on_change: resolve_bool(args.fail_on_change, app.behavior.fail_on_change),
+                    quiet: resolve_bool(cli.quiet, app.behavior.quiet),
                     ..Default::default()
                 },
                 graph_diff: if args.graph_diff {
@@ -1411,13 +1531,16 @@ fn main() -> Result<()> {
                     }
                     gdc
                 } else {
-                    GraphAwareDiffConfig::default()
+                    app.graph_diff.clone()
                 },
                 rules: MatchingRulesPathConfig {
-                    rules_file: args.enrichment.matching_rules,
+                    rules_file: args
+                        .enrichment
+                        .matching_rules
+                        .or_else(|| app.rules.rules_file.clone()),
                     ..Default::default()
                 },
-                ecosystem_rules: Default::default(),
+                ecosystem_rules: app.ecosystem_rules.clone(),
                 enrichment,
             };
             let exit_code = cli::run_diff_multi(config)?;
@@ -1428,30 +1551,46 @@ fn main() -> Result<()> {
         }
 
         Commands::Timeline(args) => {
-            let enrichment = args.enrichment.to_enrichment_config();
+            let sm = sub_matches;
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
             let config = TimelineConfig {
                 sbom_paths: args.sboms,
                 output: OutputConfig {
-                    format: args.output,
+                    format: resolve(
+                        args.output,
+                        arg_was_set_sub(sm, "output"),
+                        Some(app.output.format),
+                    ),
                     file: args.output_file,
-                    no_color: cli.no_color,
+                    no_color: resolve_bool(cli.no_color, app.output.no_color),
                     export_template: cli.export_template.clone(),
                     ..Default::default()
                 },
                 matching: MatchingConfig {
-                    fuzzy_preset: args.fuzzy_preset,
+                    fuzzy_preset: resolve(
+                        args.fuzzy_preset.clone(),
+                        arg_was_set_sub(sm, "fuzzy_preset"),
+                        Some(app.matching.fuzzy_preset.clone()),
+                    ),
+                    threshold: app.matching.threshold,
                     ..Default::default()
                 },
                 filtering: FilterConfig {
-                    min_severity: args.severity,
-                    exclude_vex_resolved: args.exclude_vex_resolved,
-                    fail_on_vex_gap: args.fail_on_vex_gap,
+                    min_severity: args.severity.or_else(|| app.filtering.min_severity.clone()),
+                    exclude_vex_resolved: resolve_bool(
+                        args.exclude_vex_resolved,
+                        app.filtering.exclude_vex_resolved,
+                    ),
+                    fail_on_vex_gap: resolve_bool(
+                        args.fail_on_vex_gap,
+                        app.filtering.fail_on_vex_gap,
+                    ),
                     ..Default::default()
                 },
                 behavior: BehaviorConfig {
-                    fail_on_vuln: args.fail_on_vuln,
-                    fail_on_change: args.fail_on_change,
-                    quiet: cli.quiet,
+                    fail_on_vuln: resolve_bool(args.fail_on_vuln, app.behavior.fail_on_vuln),
+                    fail_on_change: resolve_bool(args.fail_on_change, app.behavior.fail_on_change),
+                    quiet: resolve_bool(cli.quiet, app.behavior.quiet),
                     ..Default::default()
                 },
                 graph_diff: if args.graph_diff {
@@ -1466,13 +1605,16 @@ fn main() -> Result<()> {
                     }
                     gdc
                 } else {
-                    GraphAwareDiffConfig::default()
+                    app.graph_diff.clone()
                 },
                 rules: MatchingRulesPathConfig {
-                    rules_file: args.enrichment.matching_rules,
+                    rules_file: args
+                        .enrichment
+                        .matching_rules
+                        .or_else(|| app.rules.rules_file.clone()),
                     ..Default::default()
                 },
-                ecosystem_rules: Default::default(),
+                ecosystem_rules: app.ecosystem_rules.clone(),
                 enrichment,
             };
             let exit_code = cli::run_timeline(config)?;
@@ -1483,31 +1625,47 @@ fn main() -> Result<()> {
         }
 
         Commands::Matrix(args) => {
-            let enrichment = args.enrichment.to_enrichment_config();
+            let sm = sub_matches;
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
             let config = MatrixConfig {
                 sbom_paths: args.sboms,
                 output: OutputConfig {
-                    format: args.output,
+                    format: resolve(
+                        args.output,
+                        arg_was_set_sub(sm, "output"),
+                        Some(app.output.format),
+                    ),
                     file: args.output_file,
-                    no_color: cli.no_color,
+                    no_color: resolve_bool(cli.no_color, app.output.no_color),
                     export_template: cli.export_template.clone(),
                     ..Default::default()
                 },
                 matching: MatchingConfig {
-                    fuzzy_preset: args.fuzzy_preset,
+                    fuzzy_preset: resolve(
+                        args.fuzzy_preset.clone(),
+                        arg_was_set_sub(sm, "fuzzy_preset"),
+                        Some(app.matching.fuzzy_preset.clone()),
+                    ),
+                    threshold: app.matching.threshold,
                     ..Default::default()
                 },
                 cluster_threshold: args.cluster_threshold,
                 filtering: FilterConfig {
-                    min_severity: args.severity,
-                    exclude_vex_resolved: args.exclude_vex_resolved,
-                    fail_on_vex_gap: args.fail_on_vex_gap,
+                    min_severity: args.severity.or_else(|| app.filtering.min_severity.clone()),
+                    exclude_vex_resolved: resolve_bool(
+                        args.exclude_vex_resolved,
+                        app.filtering.exclude_vex_resolved,
+                    ),
+                    fail_on_vex_gap: resolve_bool(
+                        args.fail_on_vex_gap,
+                        app.filtering.fail_on_vex_gap,
+                    ),
                     ..Default::default()
                 },
                 behavior: BehaviorConfig {
-                    fail_on_vuln: args.fail_on_vuln,
-                    fail_on_change: args.fail_on_change,
-                    quiet: cli.quiet,
+                    fail_on_vuln: resolve_bool(args.fail_on_vuln, app.behavior.fail_on_vuln),
+                    fail_on_change: resolve_bool(args.fail_on_change, app.behavior.fail_on_change),
+                    quiet: resolve_bool(cli.quiet, app.behavior.quiet),
                     ..Default::default()
                 },
                 graph_diff: if args.graph_diff {
@@ -1522,13 +1680,16 @@ fn main() -> Result<()> {
                     }
                     gdc
                 } else {
-                    GraphAwareDiffConfig::default()
+                    app.graph_diff.clone()
                 },
                 rules: MatchingRulesPathConfig {
-                    rules_file: args.enrichment.matching_rules,
+                    rules_file: args
+                        .enrichment
+                        .matching_rules
+                        .or_else(|| app.rules.rules_file.clone()),
                     ..Default::default()
                 },
-                ecosystem_rules: Default::default(),
+                ecosystem_rules: app.ecosystem_rules.clone(),
                 enrichment,
             };
             let exit_code = cli::run_matrix(config)?;
@@ -1539,15 +1700,21 @@ fn main() -> Result<()> {
         }
 
         Commands::Quality(args) => {
+            let sm = sub_matches;
+            let output = resolve(
+                args.output,
+                arg_was_set_sub(sm, "output"),
+                Some(app.output.format),
+            );
             let exit_code = cli::run_quality(
                 args.sbom,
                 args.profile,
-                args.output,
+                output,
                 args.output_file,
                 args.recommendations,
                 args.metrics,
                 args.min_score,
-                cli.no_color,
+                resolve_bool(cli.no_color, app.output.no_color),
                 args.cra_sidecar,
                 args.cra_product_class,
             )?;
@@ -1671,7 +1838,8 @@ fn main() -> Result<()> {
         }
 
         Commands::Watch(args) => {
-            let enrichment = args.enrichment.to_enrichment_config();
+            let sm = sub_matches;
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
 
             let config = WatchConfig {
                 watch_dirs: args.dirs,
@@ -1679,10 +1847,14 @@ fn main() -> Result<()> {
                 enrich_interval: parse_duration(&args.enrich_interval)?,
                 debounce: parse_duration(&args.debounce)?,
                 output: OutputConfig {
-                    format: args.output,
+                    format: resolve(
+                        args.output,
+                        arg_was_set_sub(sm, "output"),
+                        Some(app.output.format),
+                    ),
                     file: args.output_file,
                     report_types: ReportType::All,
-                    no_color: cli.no_color,
+                    no_color: resolve_bool(cli.no_color, app.output.no_color),
                     streaming: sbom_tools::config::StreamingConfig::default(),
                     export_template: None,
                 },
@@ -1690,7 +1862,7 @@ fn main() -> Result<()> {
                 webhook_url: args.webhook,
                 exit_on_change: args.exit_on_change,
                 max_snapshots: args.max_snapshots,
-                quiet: cli.quiet,
+                quiet: resolve_bool(cli.quiet, app.behavior.quiet),
                 dry_run: args.dry_run,
                 cra_standards_enabled: args.cra_standards,
                 cra_standards_interval: parse_duration(&args.cra_standards_interval)?,
@@ -1721,10 +1893,15 @@ fn main() -> Result<()> {
 
         Commands::Config { action } => match action {
             ConfigAction::Show => {
-                let (config, loaded_from) =
-                    sbom_tools::config::load_or_default(cli.config.as_deref());
+                let (config, loaded_from) = if cli.no_config {
+                    (AppConfig::default(), None)
+                } else {
+                    sbom_tools::config::load_or_default(cli.config.as_deref())
+                };
                 if let Some(path) = &loaded_from {
                     eprintln!("# Loaded from: {}", path.display());
+                } else if cli.no_config {
+                    eprintln!("# Config discovery disabled (--no-config); showing defaults");
                 } else {
                     eprintln!("# No config file found; showing defaults");
                 }
@@ -1777,6 +1954,23 @@ fn main() -> Result<()> {
                 std::fs::write(&target, content)
                     .with_context(|| format!("failed to write {}", target.display()))?;
                 eprintln!("Created {}", target.display());
+                Ok(())
+            }
+            ConfigAction::Check => {
+                // Strict load: surfaces a hard error (with field-level detail)
+                // when the discovered config fails validation.
+                let checked = EffectiveConfig::load(cli.config.as_deref(), cli.no_config)?;
+                match checked.loaded_from() {
+                    Some(path) => eprintln!("# Valid. Loaded from: {}", path.display()),
+                    None if cli.no_config => eprintln!(
+                        "# Valid. Config discovery disabled (--no-config); showing defaults"
+                    ),
+                    None => eprintln!("# Valid. No config file found; showing defaults"),
+                }
+                let config = checked.into_app_config();
+                let yaml =
+                    serde_yaml_ng::to_string(&config).context("failed to serialize config")?;
+                print!("{yaml}");
                 Ok(())
             }
         },

--- a/tests/config_flag_tests.rs
+++ b/tests/config_flag_tests.rs
@@ -1,0 +1,226 @@
+//! End-to-end tests for the global `--config` / `--no-config` flags and the
+//! `config check` action. Exercises the real binary via `CARGO_BIN_EXE` so the
+//! full clap -> EffectiveConfig -> per-command seeding path is covered.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+use tempfile::TempDir;
+
+const FIXTURES_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn fixture_path(name: &str) -> PathBuf {
+    Path::new(FIXTURES_DIR).join(name)
+}
+
+fn sbom_tools_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_sbom-tools"))
+}
+
+fn base_command() -> Command {
+    let mut cmd = Command::new(sbom_tools_bin());
+    cmd.arg("--no-color");
+    cmd.env("RUST_LOG", "error");
+    cmd.env("RUST_LOG_STYLE", "never");
+    cmd
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("stdout should be utf-8")
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8(output.stderr.clone()).expect("stderr should be utf-8")
+}
+
+/// Write a config file inside a fresh temp dir and return its path.
+fn write_config(contents: &str) -> (TempDir, PathBuf) {
+    let dir = TempDir::new().expect("temp dir");
+    let path = dir.path().join(".sbom-tools.yaml");
+    std::fs::write(&path, contents).expect("write config");
+    (dir, path)
+}
+
+#[test]
+fn config_file_output_format_takes_effect_on_diff() {
+    // The non-TTY auto default is `summary`, so a config value of `Json` is
+    // observable: it can only come from the config file.
+    let (_dir, cfg) = write_config("output:\n  format: Json\n");
+
+    let output = base_command()
+        .args(["--config", cfg.to_str().unwrap(), "diff"])
+        .arg(fixture_path("demo-old.cdx.json"))
+        .arg(fixture_path("demo-new.cdx.json"))
+        .output()
+        .expect("diff should run");
+
+    assert!(output.status.success(), "{}", stderr(&output));
+    let text = stdout(&output);
+    assert!(
+        text.trim_start().starts_with('{'),
+        "config output.format=Json should produce JSON, got:\n{text}"
+    );
+}
+
+#[test]
+fn explicit_cli_flag_overrides_config_file_value() {
+    // File says Json, but an explicit `-o summary` on the CLI must win.
+    let (_dir, cfg) = write_config("output:\n  format: Json\n");
+
+    let output = base_command()
+        .args(["--config", cfg.to_str().unwrap(), "diff"])
+        .arg(fixture_path("demo-old.cdx.json"))
+        .arg(fixture_path("demo-new.cdx.json"))
+        .args(["-o", "summary"])
+        .output()
+        .expect("diff should run");
+
+    assert!(output.status.success(), "{}", stderr(&output));
+    let text = stdout(&output);
+    assert!(
+        text.contains("SBOM Diff Summary"),
+        "explicit -o summary should override config Json, got:\n{text}"
+    );
+    assert!(
+        !text.trim_start().starts_with('{'),
+        "output should not be JSON when -o summary is passed"
+    );
+}
+
+#[test]
+fn config_file_fail_on_change_changes_exit_code() {
+    // demo-old vs demo-new differ, so `fail_on_change: true` from the file must
+    // flip the exit code from 0 to 1.
+    let (_dir, cfg) = write_config("behavior:\n  fail_on_change: true\n");
+
+    let output = base_command()
+        .args(["--config", cfg.to_str().unwrap(), "diff"])
+        .arg(fixture_path("demo-old.cdx.json"))
+        .arg(fixture_path("demo-new.cdx.json"))
+        .args(["-o", "summary"])
+        .output()
+        .expect("diff should run");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "config fail_on_change should yield exit 1; stderr:\n{}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn no_config_ignores_discovered_file() {
+    // A `.sbom-tools.yaml` sits in the cwd with fail_on_change: true. Running
+    // with --no-config must skip discovery entirely, so the differing diff
+    // still exits 0.
+    let (dir, cfg) = write_config("behavior:\n  fail_on_change: true\n");
+
+    let output = base_command()
+        .arg("--no-config")
+        .arg("diff")
+        .arg(fixture_path("demo-old.cdx.json"))
+        .arg(fixture_path("demo-new.cdx.json"))
+        .args(["-o", "summary"])
+        .current_dir(dir.path())
+        .output()
+        .expect("diff should run");
+    let _ = &cfg;
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "--no-config should ignore the .sbom-tools.yaml in cwd; stderr:\n{}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn discovered_config_in_cwd_applies_without_explicit_flag() {
+    // Sanity check the discovery path (no --config): a fail_on_change file in
+    // the cwd must flip the exit code to 1.
+    let (dir, cfg) = write_config("behavior:\n  fail_on_change: true\n");
+
+    let output = base_command()
+        .arg("diff")
+        .arg(fixture_path("demo-old.cdx.json"))
+        .arg(fixture_path("demo-new.cdx.json"))
+        .args(["-o", "summary"])
+        .current_dir(dir.path())
+        .output()
+        .expect("diff should run");
+    let _ = &cfg;
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "discovered config fail_on_change should yield exit 1; stderr:\n{}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn config_check_prints_and_validates_effective_config() {
+    let (_dir, cfg) = write_config("matching:\n  fuzzy_preset: strict\n");
+
+    let output = base_command()
+        .args(["--config", cfg.to_str().unwrap(), "config", "check"])
+        .output()
+        .expect("config check should run");
+
+    assert!(output.status.success(), "{}", stderr(&output));
+    // The validated source is reported on stderr, the merged YAML on stdout.
+    assert!(
+        stderr(&output).contains("Valid."),
+        "config check should report validity; stderr:\n{}",
+        stderr(&output)
+    );
+    let text = stdout(&output);
+    assert!(
+        text.contains("fuzzy_preset: strict"),
+        "config check should print the merged config; got:\n{text}"
+    );
+}
+
+#[test]
+fn config_check_rejects_invalid_config() {
+    // threshold out of range -> validation failure -> non-zero exit.
+    let (_dir, cfg) = write_config("matching:\n  threshold: 5.0\n");
+
+    let output = base_command()
+        .args(["--config", cfg.to_str().unwrap(), "config", "check"])
+        .output()
+        .expect("config check should run");
+
+    assert!(
+        !output.status.success(),
+        "invalid config should fail config check"
+    );
+    assert!(
+        stderr(&output).contains("matching.threshold"),
+        "error should name the offending field; stderr:\n{}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn explicit_missing_config_path_is_an_error() {
+    let output = base_command()
+        .args([
+            "--config",
+            "/nonexistent/sbom-tools.yaml",
+            "config",
+            "check",
+        ])
+        .output()
+        .expect("command should run");
+
+    assert!(
+        !output.status.success(),
+        "a missing explicit --config path should be a hard error"
+    );
+    assert!(
+        stderr(&output).contains("not found"),
+        "stderr should explain the missing file; got:\n{}",
+        stderr(&output)
+    );
+}


### PR DESCRIPTION
## Summary

~2.4K LOC of config infrastructure (`AppConfig`, presets, `merge`, `Validatable`, schema in `src/config/`) was **dead in the execution path** — consumed only by `config show/path`. The global `--config` flag affected no subcommand; every command built its config purely from CLI args. `AppConfig::from_file_with_overrides` (`src/config/file.rs`) had zero callers and the entire `validation.rs` `validate()` path was never invoked from `main`/`cli`.

This PR makes the config file actually drive command behaviour, with correct precedence and validation.

### What changed

- **New `cli_config` module** (`src/cli_config.rs`): `EffectiveConfig::load` discovers, parses, and validates the config file once in the dispatch prologue.
  - Consuming commands get a **strict** load — parse errors and validation errors are hard errors, so a broken file never silently changes behaviour. (`load_or_default` previously swallowed parse errors and fell back to defaults.)
  - Meta commands (`config`, `completions`, `man`, `config-schema`) get a **lenient** load so they are never blocked by an unrelated invalid config.
- **Per-command seeding** (`src/main.rs`): `Diff`, `View`, `DiffMulti`, `Timeline`, `Matrix`, `Quality`, `Watch` now seed their config from the loaded `AppConfig` as the base layer. Precedence is **explicit CLI flag > config file value > built-in default**. CLI explicitness is detected at the clap layer via `ValueSource` (`arg_was_set_sub`), so an explicit flag whose value equals the default (e.g. `--output auto`) still overrides the file, while an unset flag falls through to the file value.
- **`merge()` sentinel-comparison fix** (`src/config/file.rs:179-269`): the three enum fields gated on inlined literal sentinels (`fuzzy_preset != Balanced`, `output.format != Auto`, `tui.theme != Dark`) could drift away from the real default. They now compare against `Self::default()` field-by-field, read dynamically.
- **New `--no-config` global flag** (skips discovery; `conflicts_with = "config"`) and a **`config check`** action that loads + validates + prints the effective merged config.

### Evidence

With `output.format: Json` in the config file (`src/main.rs` Diff arm now resolves format from the file):
- `diff a b` with no `-o` (non-TTY, where `auto` resolves to `summary`) emits **JSON** — proving the file value is applied.
- `diff a b -o summary` emits **summary** — explicit CLI overrides the file.
- `--no-config diff a b` emits **summary** — the file is ignored.
- `config check` on a file with `matching.threshold: 5.0` exits non-zero naming `matching.threshold`.

## Test plan

- New `tests/config_flag_tests.rs` (8 `CARGO_BIN_EXE` cases): config output-format takes effect on a real `diff`; explicit CLI flag overrides the file value; `fail_on_change` from the file flips the exit code; `--no-config` ignores a discovered file; discovery applies a cwd file without an explicit flag; `config check` prints + validates; invalid config is rejected; a missing explicit `--config` path is an error.
- Two new `config::file` unit tests pin the merge sentinel fix (default-valued override does not clobber a non-default base; `from_file_with_overrides` lets a non-default CLI override win).
- Full `cargo test` suite green (36 test binaries, all `ok`); `cargo test --all-features` on the new/affected targets green.
- `cargo clippy -- -D warnings` and `cargo clippy --all-features -- -D warnings` clean under the pinned 1.88 toolchain (0 new warnings vs HEAD baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)