### PR TITLE
refactor(enrichment): EnrichmentSource trait + unified cache and HTTP client

### DIFF
--- a/src/enrichment/cache.rs
+++ b/src/enrichment/cache.rs
@@ -1,79 +1,29 @@
 //! File-based cache for vulnerability data.
+//!
+//! [`FileCache`] is the vulnerability-specific view over the shared
+//! [`JsonCache`](super::source::JsonCache): it stores `Vec<VulnerabilityRef>`
+//! payloads and inherits the shared cache's atomic writes, TTL eviction, and
+//! schema-versioned envelope.
 
+use super::source::{CacheStats, JsonCache};
 use crate::error::Result;
 use crate::model::VulnerabilityRef;
-use sha2::{Digest, Sha256};
-use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 
-/// Cache key for vulnerability lookups.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
-pub struct CacheKey {
-    /// Package URL (preferred)
-    pub purl: Option<String>,
-    /// Component name
-    pub name: String,
-    /// Ecosystem (npm, pypi, etc.)
-    pub ecosystem: Option<String>,
-    /// Version
-    pub version: Option<String>,
-}
+pub use super::source::CacheKey;
 
-impl CacheKey {
-    /// Create a cache key from component data.
-    #[must_use]
-    pub const fn new(
-        purl: Option<String>,
-        name: String,
-        ecosystem: Option<String>,
-        version: Option<String>,
-    ) -> Self {
-        Self {
-            purl,
-            name,
-            ecosystem,
-            version,
-        }
-    }
-
-    /// Convert to a filesystem-safe filename using SHA256 hash.
-    #[must_use]
-    pub fn to_filename(&self) -> String {
-        let mut hasher = Sha256::new();
-        hasher.update(format!(
-            "purl:{:?}|name:{}|eco:{:?}|ver:{:?}",
-            self.purl, self.name, self.ecosystem, self.version
-        ));
-        let hash = hasher.finalize();
-        let hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
-        format!("{hex}.json")
-    }
-
-    /// Check if this key can be used for an OSV query.
-    #[must_use]
-    pub const fn is_queryable(&self) -> bool {
-        // Need either a PURL or name + ecosystem + version
-        self.purl.is_some() || (self.ecosystem.is_some() && self.version.is_some())
-    }
-}
-
-/// File-based cache with TTL support.
+/// File-based cache of `Vec<VulnerabilityRef>` with TTL support.
 pub struct FileCache {
-    /// Cache directory
-    cache_dir: PathBuf,
-    /// Time-to-live for cached entries
-    ttl: Duration,
+    inner: JsonCache<Vec<VulnerabilityRef>>,
 }
 
 impl FileCache {
     /// Create a new file cache.
     pub fn new(cache_dir: PathBuf, ttl: Duration) -> Result<Self> {
-        // Ensure cache directory exists
-        if !cache_dir.exists() {
-            fs::create_dir_all(&cache_dir)?;
-        }
-        Ok(Self { cache_dir, ttl })
+        Ok(Self {
+            inner: JsonCache::new(cache_dir, ttl)?,
+        })
     }
 
     /// Get cached vulnerabilities for a key.
@@ -81,92 +31,29 @@ impl FileCache {
     /// Returns None if not cached or cache is expired.
     #[must_use]
     pub fn get(&self, key: &CacheKey) -> Option<Vec<VulnerabilityRef>> {
-        let path = self.cache_dir.join(key.to_filename());
-
-        // Check if file exists
-        let metadata = fs::metadata(&path).ok()?;
-
-        // Check TTL
-        let modified = metadata.modified().ok()?;
-        let age = modified.elapsed().ok()?;
-        if age > self.ttl {
-            // Cache expired, remove it
-            let _ = fs::remove_file(&path);
-            return None;
-        }
-
-        // Read and parse
-        let data = fs::read_to_string(&path).ok()?;
-        serde_json::from_str(&data).ok()
+        self.inner.get(key)
     }
 
     /// Store vulnerabilities in the cache.
     pub fn set(&self, key: &CacheKey, vulns: &[VulnerabilityRef]) -> Result<()> {
-        let path = self.cache_dir.join(key.to_filename());
-        let data = serde_json::to_string(vulns)?;
-        fs::write(path, data)?;
-        Ok(())
+        self.inner.set(key, vulns)
     }
 
     /// Remove a cached entry.
     pub fn remove(&self, key: &CacheKey) -> Result<()> {
-        let path = self.cache_dir.join(key.to_filename());
-        if path.exists() {
-            fs::remove_file(path)?;
-        }
-        Ok(())
+        self.inner.remove(key)
     }
 
     /// Clear all cached entries.
     pub fn clear(&self) -> Result<()> {
-        if self.cache_dir.exists() {
-            for entry in fs::read_dir(&self.cache_dir)? {
-                let entry = entry?;
-                if entry.path().extension().is_some_and(|e| e == "json") {
-                    let _ = fs::remove_file(entry.path());
-                }
-            }
-        }
-        Ok(())
+        self.inner.clear()
     }
 
     /// Get cache statistics.
     #[must_use]
     pub fn stats(&self) -> CacheStats {
-        let mut stats = CacheStats::default();
-
-        if let Ok(entries) = fs::read_dir(&self.cache_dir) {
-            for entry in entries.flatten() {
-                if entry.path().extension().is_some_and(|e| e == "json") {
-                    stats.total_entries += 1;
-                    if let Ok(metadata) = entry.metadata() {
-                        stats.total_size += metadata.len();
-
-                        // Check if expired
-                        if let Ok(modified) = metadata.modified()
-                            && let Ok(age) = modified.elapsed()
-                            && age > self.ttl
-                        {
-                            stats.expired_entries += 1;
-                        }
-                    }
-                }
-            }
-        }
-
-        stats
+        self.inner.stats()
     }
-}
-
-/// Cache statistics.
-#[derive(Debug, Default)]
-pub struct CacheStats {
-    /// Total number of cached entries
-    pub total_entries: usize,
-    /// Number of expired entries
-    pub expired_entries: usize,
-    /// Total size in bytes
-    pub total_size: u64,
 }
 
 #[cfg(test)]

--- a/src/enrichment/eol/client.rs
+++ b/src/enrichment/eol/client.rs
@@ -1,14 +1,15 @@
 //! EOL API client and enricher for the endoflife.date API.
 
 use super::mapping::ProductMapper;
+use crate::enrichment::source::{JsonCache, namespaced_cache_dir};
 use crate::enrichment::stats::EnrichmentError;
 use crate::model::{Component, EolInfo, EolStatus};
 use chrono::NaiveDate;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fs;
 use std::path::PathBuf;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 // ============================================================================
 // API response types
@@ -114,40 +115,7 @@ impl Default for EolClientConfig {
 }
 
 fn default_cache_dir() -> PathBuf {
-    dirs_cache_dir()
-        .unwrap_or_else(|| PathBuf::from(".cache"))
-        .join("sbom-tools")
-        .join("eol")
-}
-
-fn dirs_cache_dir() -> Option<PathBuf> {
-    #[cfg(target_os = "macos")]
-    {
-        std::env::var("HOME")
-            .ok()
-            .map(|h| PathBuf::from(h).join("Library").join("Caches"))
-    }
-    #[cfg(target_os = "linux")]
-    {
-        std::env::var("XDG_CACHE_HOME")
-            .ok()
-            .map(PathBuf::from)
-            .or_else(|| {
-                std::env::var("HOME")
-                    .ok()
-                    .map(|h| PathBuf::from(h).join(".cache"))
-            })
-    }
-    #[cfg(target_os = "windows")]
-    {
-        std::env::var("LOCALAPPDATA").ok().map(PathBuf::from)
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    {
-        std::env::var("HOME")
-            .ok()
-            .map(|h| PathBuf::from(h).join(".cache"))
-    }
+    namespaced_cache_dir("eol")
 }
 
 // ============================================================================
@@ -202,17 +170,16 @@ impl EolClient {
         stats: &mut EolEnrichmentStats,
     ) -> Result<Vec<String>, EnrichmentError> {
         let cache_key = "eol_products";
-        if self.is_cache_valid(cache_key, self.config.product_list_ttl)
-            && let Some(products) = self.load_from_cache::<Vec<String>>(cache_key)
+        let cache = self.cache::<Vec<String>>(self.config.product_list_ttl)?;
+        if !self.config.bypass_cache
+            && let Some(products) = cache.get_named(&cache_filename(cache_key))
         {
             stats.cache_hits += 1;
             return Ok(products);
         }
 
         let url = format!("{}/api/all.json", self.config.base_url);
-        let client = reqwest::blocking::Client::builder()
-            .timeout(self.config.timeout)
-            .build()
+        let client = crate::enrichment::source::http_client(self.config.timeout)
             .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
 
         stats.api_calls += 1;
@@ -233,7 +200,9 @@ impl EolClient {
             .json()
             .map_err(|e| EnrichmentError::ParseError(e.to_string()))?;
 
-        self.save_to_cache(cache_key, &products)?;
+        cache
+            .set_named(&cache_filename(cache_key), &products)
+            .map_err(|e| EnrichmentError::CacheError(e.to_string()))?;
         Ok(products)
     }
 
@@ -255,17 +224,16 @@ impl EolClient {
         stats: &mut EolEnrichmentStats,
     ) -> Result<Vec<EolCycle>, EnrichmentError> {
         let cache_key = format!("eol_{product}");
-        if self.is_cache_valid(&cache_key, self.config.cache_ttl)
-            && let Some(cycles) = self.load_from_cache::<Vec<EolCycle>>(&cache_key)
+        let cache = self.cache::<Vec<EolCycle>>(self.config.cache_ttl)?;
+        if !self.config.bypass_cache
+            && let Some(cycles) = cache.get_named(&cache_filename(&cache_key))
         {
             stats.cache_hits += 1;
             return Ok(cycles);
         }
 
         let url = format!("{}/api/{}.json", self.config.base_url, product);
-        let client = reqwest::blocking::Client::builder()
-            .timeout(self.config.timeout)
-            .build()
+        let client = crate::enrichment::source::http_client(self.config.timeout)
             .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
 
         stats.api_calls += 1;
@@ -286,7 +254,9 @@ impl EolClient {
             .json()
             .map_err(|e| EnrichmentError::ParseError(e.to_string()))?;
 
-        self.save_to_cache(&cache_key, &cycles)?;
+        cache
+            .set_named(&cache_filename(&cache_key), &cycles)
+            .map_err(|e| EnrichmentError::CacheError(e.to_string()))?;
         Ok(cycles)
     }
 
@@ -303,48 +273,25 @@ impl EolClient {
 
     // ---- Cache helpers ----
 
-    fn cache_file(&self, key: &str) -> PathBuf {
-        let safe_key = key.replace(['/', ':'], "_");
-        self.config.cache_dir.join(format!("{safe_key}.json"))
+    /// Open the shared file cache for payloads of type `T` with the given TTL.
+    ///
+    /// EOL uses two TTLs (a long one for the product list, a shorter one for
+    /// per-product cycles), so the cache is built per call with the relevant
+    /// TTL rather than stored on the client.
+    fn cache<T>(&self, ttl: Duration) -> Result<JsonCache<T>, EnrichmentError>
+    where
+        T: Serialize + DeserializeOwned,
+    {
+        JsonCache::new(self.config.cache_dir.clone(), ttl)
+            .map_err(|e| EnrichmentError::CacheError(e.to_string()))
     }
+}
 
-    fn is_cache_valid(&self, key: &str, ttl: Duration) -> bool {
-        if self.config.bypass_cache {
-            return false;
-        }
-        let cache_path = self.cache_file(key);
-        if !cache_path.exists() {
-            return false;
-        }
-        if let Ok(metadata) = fs::metadata(&cache_path)
-            && let Ok(modified) = metadata.modified()
-            && let Ok(elapsed) = SystemTime::now().duration_since(modified)
-        {
-            return elapsed < ttl;
-        }
-        false
-    }
-
-    fn load_from_cache<T: serde::de::DeserializeOwned>(&self, key: &str) -> Option<T> {
-        let cache_path = self.cache_file(key);
-        let content = fs::read_to_string(&cache_path).ok()?;
-        serde_json::from_str(&content).ok()
-    }
-
-    fn save_to_cache<T: serde::Serialize>(
-        &self,
-        key: &str,
-        data: &T,
-    ) -> Result<(), EnrichmentError> {
-        let cache_path = self.cache_file(key);
-        if let Some(parent) = cache_path.parent() {
-            fs::create_dir_all(parent).map_err(|e| EnrichmentError::CacheError(e.to_string()))?;
-        }
-        let content =
-            serde_json::to_string(data).map_err(|e| EnrichmentError::CacheError(e.to_string()))?;
-        fs::write(&cache_path, content).map_err(|e| EnrichmentError::CacheError(e.to_string()))?;
-        Ok(())
-    }
+/// Filesystem-safe cache file name for an EOL key (e.g. `eol_python` →
+/// `eol_python.json`).
+fn cache_filename(key: &str) -> String {
+    let safe_key = key.replace(['/', ':'], "_");
+    format!("{safe_key}.json")
 }
 
 // ============================================================================

--- a/src/enrichment/kev/client.rs
+++ b/src/enrichment/kev/client.rs
@@ -1,11 +1,14 @@
 //! KEV catalog client with caching support.
 
 use super::catalog::{KevCatalog, KevCatalogResponse};
+use crate::enrichment::source::{JsonCache, namespaced_cache_dir};
 use crate::enrichment::stats::EnrichmentError;
 use crate::model::{KevInfo, VulnerabilityRef};
-use std::fs;
 use std::path::PathBuf;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
+
+/// Cache file name for the serialized KEV catalog.
+const KEV_CACHE_FILE: &str = "kev_catalog.json";
 
 /// Default CISA KEV catalog URL
 pub const KEV_CATALOG_URL: &str =
@@ -40,41 +43,7 @@ impl Default for KevClientConfig {
 
 /// Get the default cache directory
 fn default_cache_dir() -> PathBuf {
-    dirs_cache_dir()
-        .unwrap_or_else(|| PathBuf::from(".cache"))
-        .join("sbom-tools")
-        .join("kev")
-}
-
-/// Get cache directory (platform-aware)
-fn dirs_cache_dir() -> Option<PathBuf> {
-    #[cfg(target_os = "macos")]
-    {
-        std::env::var("HOME")
-            .ok()
-            .map(|h| PathBuf::from(h).join("Library").join("Caches"))
-    }
-    #[cfg(target_os = "linux")]
-    {
-        std::env::var("XDG_CACHE_HOME")
-            .ok()
-            .map(PathBuf::from)
-            .or_else(|| {
-                std::env::var("HOME")
-                    .ok()
-                    .map(|h| PathBuf::from(h).join(".cache"))
-            })
-    }
-    #[cfg(target_os = "windows")]
-    {
-        std::env::var("LOCALAPPDATA").ok().map(PathBuf::from)
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    {
-        std::env::var("HOME")
-            .ok()
-            .map(|h| PathBuf::from(h).join(".cache"))
-    }
+    namespaced_cache_dir("kev")
 }
 
 /// KEV enrichment statistics
@@ -118,63 +87,38 @@ impl KevClient {
         Self::new(KevClientConfig::default())
     }
 
-    /// Get the cache file path
-    fn cache_file_path(&self) -> PathBuf {
-        self.config.cache_dir.join("kev_catalog.json")
+    /// Open the shared file cache for the serialized catalog.
+    fn cache(&self) -> Result<JsonCache<KevCatalog>, EnrichmentError> {
+        JsonCache::new(self.config.cache_dir.clone(), self.config.cache_ttl)
+            .map_err(|e| EnrichmentError::CacheError(e.to_string()))
     }
 
-    /// Check if cache is valid
+    /// Check if a valid (unexpired, current-schema) cached catalog exists.
     fn is_cache_valid(&self) -> bool {
         if self.config.bypass_cache {
             return false;
         }
-
-        let cache_path = self.cache_file_path();
-        if !cache_path.exists() {
-            return false;
-        }
-
-        // Check cache age
-        if let Ok(metadata) = fs::metadata(&cache_path)
-            && let Ok(modified) = metadata.modified()
-            && let Ok(elapsed) = SystemTime::now().duration_since(modified)
-        {
-            return elapsed < self.config.cache_ttl;
-        }
-
-        false
+        self.cache()
+            .ok()
+            .is_some_and(|c| c.get_named(KEV_CACHE_FILE).is_some())
     }
 
     /// Load catalog from cache
     fn load_from_cache(&self) -> Option<KevCatalog> {
-        let cache_path = self.cache_file_path();
-        let content = fs::read_to_string(&cache_path).ok()?;
-        serde_json::from_str(&content).ok()
+        self.cache().ok()?.get_named(KEV_CACHE_FILE)
     }
 
     /// Save catalog to cache
     fn save_to_cache(&self, catalog: &KevCatalog) -> Result<(), EnrichmentError> {
-        let cache_path = self.cache_file_path();
-
-        // Ensure cache directory exists
-        if let Some(parent) = cache_path.parent() {
-            fs::create_dir_all(parent).map_err(|e| EnrichmentError::CacheError(e.to_string()))?;
-        }
-
-        let content = serde_json::to_string(catalog)
-            .map_err(|e| EnrichmentError::CacheError(e.to_string()))?;
-
-        fs::write(&cache_path, content).map_err(|e| EnrichmentError::CacheError(e.to_string()))?;
-
-        Ok(())
+        self.cache()?
+            .set_named(KEV_CACHE_FILE, catalog)
+            .map_err(|e| EnrichmentError::CacheError(e.to_string()))
     }
 
     /// Fetch catalog from CISA API
     #[cfg(feature = "enrichment")]
     fn fetch_from_api(&self) -> Result<KevCatalog, EnrichmentError> {
-        let client = reqwest::blocking::Client::builder()
-            .timeout(self.config.timeout)
-            .build()
+        let client = crate::enrichment::source::http_client(self.config.timeout)
             .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
 
         let response = client

--- a/src/enrichment/mod.rs
+++ b/src/enrichment/mod.rs
@@ -20,6 +20,7 @@ mod cache;
 pub mod eol;
 pub mod kev;
 pub mod osv;
+pub mod source;
 pub mod staleness;
 mod stats;
 mod traits;
@@ -29,6 +30,7 @@ pub use cache::{CacheKey, FileCache};
 pub use eol::{EolClientConfig, EolEnricher, EolEnrichmentStats};
 pub use kev::{KevCatalog, KevClient, KevClientConfig, KevEnrichmentStats};
 pub use osv::{OsvEnricher, OsvEnricherConfig};
+pub use source::{CacheStats, EnrichmentSource, JsonCache};
 pub use staleness::{RegistryConfig, StalenessEnricher, StalenessEnrichmentStats};
 pub use stats::{EnrichmentError, EnrichmentStats};
 pub use traits::{NoOpEnricher, VulnerabilityEnricher};
@@ -76,45 +78,7 @@ impl Default for EnricherConfig {
     }
 }
 
-/// Get the default cache directory
+/// Get the default cache directory.
 fn default_cache_dir() -> PathBuf {
-    dirs::cache_dir()
-        .unwrap_or_else(|| PathBuf::from(".cache"))
-        .join("sbom-tools")
-        .join("osv")
-}
-
-/// Try to get dirs crate functionality, fallback to home dir
-mod dirs {
-    use std::path::PathBuf;
-
-    pub fn cache_dir() -> Option<PathBuf> {
-        #[cfg(target_os = "macos")]
-        {
-            std::env::var("HOME")
-                .ok()
-                .map(|h| PathBuf::from(h).join("Library").join("Caches"))
-        }
-        #[cfg(target_os = "linux")]
-        {
-            std::env::var("XDG_CACHE_HOME")
-                .ok()
-                .map(PathBuf::from)
-                .or_else(|| {
-                    std::env::var("HOME")
-                        .ok()
-                        .map(|h| PathBuf::from(h).join(".cache"))
-                })
-        }
-        #[cfg(target_os = "windows")]
-        {
-            std::env::var("LOCALAPPDATA").ok().map(PathBuf::from)
-        }
-        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-        {
-            std::env::var("HOME")
-                .ok()
-                .map(|h| PathBuf::from(h).join(".cache"))
-        }
-    }
+    source::namespaced_cache_dir("osv")
 }

--- a/src/enrichment/osv/client.rs
+++ b/src/enrichment/osv/client.rs
@@ -1,6 +1,7 @@
 //! OSV API HTTP client.
 
 use super::response::{OsvBatchRequest, OsvBatchResponse, OsvQuery};
+use crate::enrichment::source::{get_with_retry, http_client};
 use crate::error::{EnrichmentErrorKind, Result, SbomDiffError};
 use reqwest::blocking::Client;
 use std::time::Duration;
@@ -48,14 +49,7 @@ fn api_error(msg: impl Into<String>) -> SbomDiffError {
 impl OsvClient {
     /// Create a new OSV client.
     pub fn new(config: OsvClientConfig) -> Result<Self> {
-        let client = Client::builder()
-            .timeout(config.timeout)
-            .user_agent(concat!(
-                env!("CARGO_PKG_NAME"),
-                "/",
-                env!("CARGO_PKG_VERSION")
-            ))
-            .build()
+        let client = http_client(config.timeout)
             .map_err(|e| network_error("Failed to create HTTP client", &e))?;
 
         Ok(Self { client, config })
@@ -64,10 +58,7 @@ impl OsvClient {
     /// Check if the OSV API is available.
     pub fn health_check(&self) -> Result<bool> {
         let url = format!("{}/v1/vulns/OSV-2020-1", self.config.api_base);
-        let response = self
-            .client
-            .get(&url)
-            .send()
+        let response = get_with_retry(&self.client, &url, self.config.max_retries)
             .map_err(|e| network_error("Health check request failed", &e))?;
         Ok(response.status().is_success() || response.status().as_u16() == 404)
     }
@@ -159,10 +150,7 @@ impl OsvClient {
     ) -> Result<Option<super::response::OsvVulnerability>> {
         let url = format!("{}/v1/vulns/{}", self.config.api_base, vuln_id);
 
-        let response = self
-            .client
-            .get(&url)
-            .send()
+        let response = get_with_retry(&self.client, &url, self.config.max_retries)
             .map_err(|e| network_error("Failed to fetch vulnerability", &e))?;
 
         if response.status().as_u16() == 404 {

--- a/src/enrichment/osv/mod.rs
+++ b/src/enrichment/osv/mod.rs
@@ -40,7 +40,7 @@ pub struct OsvEnricherConfig {
 impl Default for OsvEnricherConfig {
     fn default() -> Self {
         Self {
-            cache_dir: PathBuf::from(".cache/sbom-tools/osv"),
+            cache_dir: crate::enrichment::source::namespaced_cache_dir("osv"),
             cache_ttl: Duration::from_secs(24 * 3600),
             bypass_cache: false,
             timeout: Duration::from_secs(30),

--- a/src/enrichment/source.rs
+++ b/src/enrichment/source.rs
@@ -1,0 +1,594 @@
+//! Shared enrichment infrastructure: cache directory, HTTP client, retry
+//! policy, and a generic versioned file cache.
+//!
+//! Every enrichment source (OSV, KEV, EOL, staleness) used to carry its own
+//! copy of the platform cache-directory shim and an ad-hoc, non-atomic
+//! mtime-TTL JSON file cache. This module centralizes that plumbing:
+//!
+//! - [`cache_dir`] / [`namespaced_cache_dir`] — one platform-aware helper.
+//! - [`http_client`] — one [`reqwest::blocking::Client`] builder with a
+//!   consistent `CARGO_PKG_NAME/CARGO_PKG_VERSION` User-Agent.
+//! - [`get_with_retry`] — a shared retry policy honoring `429`/`Retry-After`
+//!   with bounded exponential backoff.
+//! - [`JsonCache`] — a generic file cache with **atomic** writes
+//!   (temp-file + rename) and a `schema_version` envelope so that a version
+//!   bump transparently invalidates stale entries.
+
+use crate::error::Result;
+use crate::model::Component;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+/// Schema version embedded in every cache envelope.
+///
+/// Bumping this value invalidates all previously written cache entries: any
+/// envelope whose `schema_version` does not match is treated as a miss (and
+/// removed) so a changed payload shape can never be deserialized as the old
+/// one.
+pub const CACHE_SCHEMA_VERSION: u32 = 1;
+
+// ============================================================================
+// Cache directory
+// ============================================================================
+
+/// Platform-specific base cache directory.
+///
+/// - macOS: `$HOME/Library/Caches`
+/// - Linux: `$XDG_CACHE_HOME` or `$HOME/.cache`
+/// - Windows: `%LOCALAPPDATA%`
+/// - other: `$HOME/.cache`
+///
+/// Returns `None` when the relevant environment variables are unset.
+#[must_use]
+pub fn cache_dir() -> Option<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        std::env::var("HOME")
+            .ok()
+            .map(|h| PathBuf::from(h).join("Library").join("Caches"))
+    }
+    #[cfg(target_os = "linux")]
+    {
+        std::env::var("XDG_CACHE_HOME")
+            .ok()
+            .map(PathBuf::from)
+            .or_else(|| {
+                std::env::var("HOME")
+                    .ok()
+                    .map(|h| PathBuf::from(h).join(".cache"))
+            })
+    }
+    #[cfg(target_os = "windows")]
+    {
+        std::env::var("LOCALAPPDATA").ok().map(PathBuf::from)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        std::env::var("HOME")
+            .ok()
+            .map(|h| PathBuf::from(h).join(".cache"))
+    }
+}
+
+/// Cache directory for an enrichment source, e.g. `…/sbom-tools/osv`.
+///
+/// Falls back to a `.cache`-relative path only when no platform cache
+/// directory is available, matching the previous per-source behavior.
+#[must_use]
+pub fn namespaced_cache_dir(namespace: &str) -> PathBuf {
+    cache_dir()
+        .unwrap_or_else(|| PathBuf::from(".cache"))
+        .join("sbom-tools")
+        .join(namespace)
+}
+
+// ============================================================================
+// HTTP client + retry policy
+// ============================================================================
+
+/// Build the shared blocking HTTP client used by all enrichment sources.
+///
+/// All sources share the same `CARGO_PKG_NAME/CARGO_PKG_VERSION` User-Agent so
+/// upstream registries see a single, identifiable client.
+#[cfg(feature = "enrichment")]
+pub fn http_client(timeout: Duration) -> reqwest::Result<reqwest::blocking::Client> {
+    reqwest::blocking::Client::builder()
+        .timeout(timeout)
+        .user_agent(concat!(
+            env!("CARGO_PKG_NAME"),
+            "/",
+            env!("CARGO_PKG_VERSION")
+        ))
+        .build()
+}
+
+/// Maximum backoff applied between retries, regardless of attempt count or a
+/// server-provided `Retry-After`.
+const MAX_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Compute the backoff delay before retry `attempt` (1-based).
+///
+/// Honors a server-provided `Retry-After` (seconds) when present, otherwise
+/// applies bounded exponential backoff (1s, 2s, 4s, …) capped at
+/// [`MAX_BACKOFF`].
+#[must_use]
+pub fn backoff_delay(attempt: u32, retry_after: Option<Duration>) -> Duration {
+    if let Some(after) = retry_after {
+        return after.min(MAX_BACKOFF);
+    }
+    let secs = 1u64
+        .checked_shl(attempt.saturating_sub(1))
+        .unwrap_or(u64::MAX);
+    Duration::from_secs(secs).min(MAX_BACKOFF)
+}
+
+/// Parse a `Retry-After` header value expressed as a number of seconds.
+///
+/// The HTTP-date form of `Retry-After` is not supported (registries used here
+/// only emit the delta-seconds form); unparseable values yield `None`.
+#[cfg(feature = "enrichment")]
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    headers
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim()
+        .parse::<u64>()
+        .ok()
+        .map(Duration::from_secs)
+}
+
+/// Perform a `GET` with the shared retry policy.
+///
+/// Retries on transport errors and on `429`/`5xx` responses up to
+/// `max_retries` times, honoring `Retry-After` on `429`. Non-retryable
+/// responses (including `4xx` other than `429`) are returned to the caller on
+/// the first attempt for status inspection.
+#[cfg(feature = "enrichment")]
+pub fn get_with_retry(
+    client: &reqwest::blocking::Client,
+    url: &str,
+    max_retries: u8,
+) -> reqwest::Result<reqwest::blocking::Response> {
+    let mut last_err: Option<reqwest::Error> = None;
+
+    for attempt in 0..=u32::from(max_retries) {
+        if attempt > 0 {
+            tracing::debug!("retry attempt {attempt} for {url}");
+        }
+
+        match client.get(url).send() {
+            Ok(response) => {
+                let status = response.status();
+                let retryable =
+                    status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error();
+                if retryable && attempt < u32::from(max_retries) {
+                    let retry_after = if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                        parse_retry_after(response.headers())
+                    } else {
+                        None
+                    };
+                    std::thread::sleep(backoff_delay(attempt + 1, retry_after));
+                    continue;
+                }
+                return Ok(response);
+            }
+            Err(e) => {
+                if attempt < u32::from(max_retries) {
+                    std::thread::sleep(backoff_delay(attempt + 1, None));
+                    last_err = Some(e);
+                    continue;
+                }
+                return Err(e);
+            }
+        }
+    }
+
+    // Unreachable in practice: the loop always returns on the final attempt.
+    Err(last_err.expect("retry loop returns on final attempt"))
+}
+
+// ============================================================================
+// Cache key
+// ============================================================================
+
+/// Cache key for vulnerability lookups.
+#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+pub struct CacheKey {
+    /// Package URL (preferred)
+    pub purl: Option<String>,
+    /// Component name
+    pub name: String,
+    /// Ecosystem (npm, pypi, etc.)
+    pub ecosystem: Option<String>,
+    /// Version
+    pub version: Option<String>,
+}
+
+impl CacheKey {
+    /// Create a cache key from component data.
+    #[must_use]
+    pub const fn new(
+        purl: Option<String>,
+        name: String,
+        ecosystem: Option<String>,
+        version: Option<String>,
+    ) -> Self {
+        Self {
+            purl,
+            name,
+            ecosystem,
+            version,
+        }
+    }
+
+    /// Convert to a filesystem-safe filename using SHA256 hash.
+    #[must_use]
+    pub fn to_filename(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(format!(
+            "purl:{:?}|name:{}|eco:{:?}|ver:{:?}",
+            self.purl, self.name, self.ecosystem, self.version
+        ));
+        let hash = hasher.finalize();
+        let hex: String = hash.iter().map(|b| format!("{b:02x}")).collect();
+        format!("{hex}.json")
+    }
+
+    /// Check if this key can be used for an OSV query.
+    #[must_use]
+    pub const fn is_queryable(&self) -> bool {
+        // Need either a PURL or name + ecosystem + version
+        self.purl.is_some() || (self.ecosystem.is_some() && self.version.is_some())
+    }
+}
+
+// ============================================================================
+// Generic versioned file cache
+// ============================================================================
+
+/// Envelope wrapping every cached payload with a schema version.
+///
+/// The version is checked on read; a mismatch is treated as a miss so a
+/// changed payload shape can never be deserialized as the old one.
+#[derive(Debug, Serialize, serde::Deserialize)]
+struct CacheEnvelope<T> {
+    /// Schema version of the embedded payload.
+    schema_version: u32,
+    /// The cached value.
+    payload: T,
+}
+
+/// A generic file-based cache with atomic writes, TTL, and schema versioning.
+///
+/// Each entry is a JSON file under `cache_dir` whose name derives from the
+/// entry key. Writes go to a temporary sibling file that is then renamed over
+/// the target, so a reader never observes a torn write. Reads enforce both the
+/// configured TTL (via file mtime) and the [`CACHE_SCHEMA_VERSION`] envelope.
+pub struct JsonCache<T> {
+    cache_dir: PathBuf,
+    ttl: Duration,
+    _marker: std::marker::PhantomData<fn() -> T>,
+}
+
+impl<T> JsonCache<T>
+where
+    T: Serialize + DeserializeOwned,
+{
+    /// Create a cache rooted at `cache_dir`, creating the directory if needed.
+    pub fn new(cache_dir: PathBuf, ttl: Duration) -> Result<Self> {
+        if !cache_dir.exists() {
+            fs::create_dir_all(&cache_dir)?;
+        }
+        Ok(Self {
+            cache_dir,
+            ttl,
+            _marker: std::marker::PhantomData,
+        })
+    }
+
+    /// Path for a named entry (the name must already be filesystem-safe).
+    #[must_use]
+    pub fn path_for(&self, file_name: &str) -> PathBuf {
+        self.cache_dir.join(file_name)
+    }
+
+    /// Cache directory root.
+    #[must_use]
+    pub fn dir(&self) -> &Path {
+        &self.cache_dir
+    }
+
+    /// Read a cached value by file name.
+    ///
+    /// Returns `None` (evicting the file) when the entry is missing, older
+    /// than the TTL, has a mismatched schema version, or fails to parse.
+    #[must_use]
+    pub fn get_named(&self, file_name: &str) -> Option<T> {
+        let path = self.path_for(file_name);
+
+        let metadata = fs::metadata(&path).ok()?;
+        let modified = metadata.modified().ok()?;
+        if modified.elapsed().ok()? > self.ttl {
+            let _ = fs::remove_file(&path);
+            return None;
+        }
+
+        let data = fs::read_to_string(&path).ok()?;
+        let envelope: CacheEnvelope<T> = serde_json::from_str(&data).ok()?;
+        if envelope.schema_version != CACHE_SCHEMA_VERSION {
+            let _ = fs::remove_file(&path);
+            return None;
+        }
+        Some(envelope.payload)
+    }
+
+    /// Atomically write a value under `file_name`.
+    pub fn set_named<V: Serialize + ?Sized>(&self, file_name: &str, value: &V) -> Result<()> {
+        if !self.cache_dir.exists() {
+            fs::create_dir_all(&self.cache_dir)?;
+        }
+        let envelope = CacheEnvelope {
+            schema_version: CACHE_SCHEMA_VERSION,
+            payload: value,
+        };
+        let data = serde_json::to_string(&envelope)?;
+        write_atomic(&self.path_for(file_name), data.as_bytes())?;
+        Ok(())
+    }
+
+    /// Read a cached value by [`CacheKey`].
+    #[must_use]
+    pub fn get(&self, key: &CacheKey) -> Option<T> {
+        self.get_named(&key.to_filename())
+    }
+
+    /// Atomically write a value keyed by [`CacheKey`].
+    pub fn set<V: Serialize + ?Sized>(&self, key: &CacheKey, value: &V) -> Result<()> {
+        self.set_named(&key.to_filename(), value)
+    }
+
+    /// Remove a cached entry by [`CacheKey`].
+    pub fn remove(&self, key: &CacheKey) -> Result<()> {
+        let path = self.path_for(&key.to_filename());
+        if path.exists() {
+            fs::remove_file(path)?;
+        }
+        Ok(())
+    }
+
+    /// Remove every JSON entry from the cache directory.
+    pub fn clear(&self) -> Result<()> {
+        if self.cache_dir.exists() {
+            for entry in fs::read_dir(&self.cache_dir)? {
+                let entry = entry?;
+                if entry.path().extension().is_some_and(|e| e == "json") {
+                    let _ = fs::remove_file(entry.path());
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Aggregate statistics over the cache directory.
+    #[must_use]
+    pub fn stats(&self) -> CacheStats {
+        let mut stats = CacheStats::default();
+
+        if let Ok(entries) = fs::read_dir(&self.cache_dir) {
+            for entry in entries.flatten() {
+                if entry.path().extension().is_some_and(|e| e == "json") {
+                    stats.total_entries += 1;
+                    if let Ok(metadata) = entry.metadata() {
+                        stats.total_size += metadata.len();
+                        if let Ok(modified) = metadata.modified()
+                            && let Ok(age) = modified.elapsed()
+                            && age > self.ttl
+                        {
+                            stats.expired_entries += 1;
+                        }
+                    }
+                }
+            }
+        }
+
+        stats
+    }
+}
+
+/// Write `bytes` to `path` atomically via a temp file + rename.
+///
+/// The temp file lives in the same directory as the target so the final
+/// `rename` is a same-filesystem operation and therefore atomic.
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .map_or_else(|| "cache".to_string(), |n| n.to_string_lossy().into_owned());
+    let tmp = parent.join(format!(".{file_name}.{}.tmp", std::process::id()));
+
+    fs::write(&tmp, bytes)?;
+    match fs::rename(&tmp, path) {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            let _ = fs::remove_file(&tmp);
+            Err(e.into())
+        }
+    }
+}
+
+/// Cache statistics.
+#[derive(Debug, Default)]
+pub struct CacheStats {
+    /// Total number of cached entries
+    pub total_entries: usize,
+    /// Number of expired entries
+    pub expired_entries: usize,
+    /// Total size in bytes
+    pub total_size: u64,
+}
+
+// ============================================================================
+// EnrichmentSource trait
+// ============================================================================
+
+/// A source of external data that enriches SBOM components.
+///
+/// This models the shape shared by the OSV, KEV, EOL, and staleness enrichers:
+/// each has a stable name, a cache namespace and TTL, and an operation that
+/// applies fetched data to a slice of [`Component`]s in place, returning a
+/// source-specific statistics value.
+///
+/// It is a thin description layer over the existing enrichers — implementing it
+/// does not change what any source fetches or how results are mapped.
+pub trait EnrichmentSource {
+    /// Per-source statistics returned by [`enrich`](EnrichmentSource::enrich).
+    type Stats;
+
+    /// Stable, human-readable source name (e.g. `"OSV"`, `"KEV"`).
+    fn name(&self) -> &'static str;
+
+    /// Cache namespace (the directory under `…/sbom-tools/`).
+    fn cache_namespace(&self) -> &'static str;
+
+    /// Time-to-live for this source's cache entries.
+    fn cache_ttl(&self) -> Duration;
+
+    /// Apply this source's data to the given components in place.
+    fn enrich(&mut self, components: &mut [Component]) -> Result<Self::Stats>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct Payload {
+        value: u32,
+        label: String,
+    }
+
+    fn sample() -> Payload {
+        Payload {
+            value: 7,
+            label: "hello".to_string(),
+        }
+    }
+
+    #[test]
+    fn namespaced_cache_dir_includes_namespace() {
+        let dir = namespaced_cache_dir("osv");
+        let s = dir.to_string_lossy();
+        assert!(s.contains("sbom-tools"));
+        assert!(s.ends_with("osv"));
+    }
+
+    #[test]
+    fn backoff_is_exponential_and_capped() {
+        assert_eq!(backoff_delay(1, None), Duration::from_secs(1));
+        assert_eq!(backoff_delay(2, None), Duration::from_secs(2));
+        assert_eq!(backoff_delay(3, None), Duration::from_secs(4));
+        // Capped at MAX_BACKOFF regardless of attempt.
+        assert_eq!(backoff_delay(20, None), MAX_BACKOFF);
+    }
+
+    #[test]
+    fn backoff_honors_retry_after_but_caps_it() {
+        assert_eq!(
+            backoff_delay(1, Some(Duration::from_secs(3))),
+            Duration::from_secs(3)
+        );
+        assert_eq!(
+            backoff_delay(1, Some(Duration::from_secs(120))),
+            MAX_BACKOFF
+        );
+    }
+
+    #[test]
+    fn cache_roundtrip_survives_reopen() {
+        let tmp = tempfile::tempdir().unwrap();
+        {
+            let cache: JsonCache<Payload> =
+                JsonCache::new(tmp.path().to_path_buf(), Duration::from_secs(3600)).unwrap();
+            cache.set_named("entry", &sample()).unwrap();
+        }
+        // A freshly constructed cache reads the persisted, atomically written file.
+        let cache: JsonCache<Payload> =
+            JsonCache::new(tmp.path().to_path_buf(), Duration::from_secs(3600)).unwrap();
+        assert_eq!(cache.get_named("entry"), Some(sample()));
+    }
+
+    #[test]
+    fn atomic_write_leaves_no_temp_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache: JsonCache<Payload> =
+            JsonCache::new(tmp.path().to_path_buf(), Duration::from_secs(3600)).unwrap();
+        cache.set_named("entry", &sample()).unwrap();
+
+        let tmp_files: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.path().extension().is_some_and(|x| x == "tmp"))
+            .collect();
+        assert!(tmp_files.is_empty(), "temp file should be renamed away");
+    }
+
+    #[test]
+    fn schema_version_mismatch_invalidates_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache: JsonCache<Payload> =
+            JsonCache::new(tmp.path().to_path_buf(), Duration::from_secs(3600)).unwrap();
+
+        // Hand-write an envelope with a different schema version.
+        let stale = format!(
+            "{{\"schema_version\":{},\"payload\":{{\"value\":1,\"label\":\"x\"}}}}",
+            CACHE_SCHEMA_VERSION + 1
+        );
+        let path = cache.path_for("entry");
+        fs::write(&path, stale).unwrap();
+
+        assert!(
+            cache.get_named("entry").is_none(),
+            "mismatched schema version must be a miss"
+        );
+        assert!(!path.exists(), "stale entry should be evicted");
+    }
+
+    #[test]
+    fn ttl_expiry_evicts_entry() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache: JsonCache<Payload> =
+            JsonCache::new(tmp.path().to_path_buf(), Duration::from_millis(20)).unwrap();
+        cache.set_named("entry", &sample()).unwrap();
+        assert!(cache.get_named("entry").is_some());
+
+        std::thread::sleep(Duration::from_millis(60));
+        assert!(
+            cache.get_named("entry").is_none(),
+            "entry past TTL must be a miss"
+        );
+        assert!(
+            !cache.path_for("entry").exists(),
+            "expired entry should be evicted"
+        );
+    }
+
+    #[test]
+    fn clear_and_stats() {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache: JsonCache<Payload> =
+            JsonCache::new(tmp.path().to_path_buf(), Duration::from_secs(3600)).unwrap();
+        // `stats`/`clear` operate on `.json` entries, matching how all real
+        // callers name their files (CacheKey::to_filename, cache_filename, …).
+        cache.set_named("a.json", &sample()).unwrap();
+        cache.set_named("b.json", &sample()).unwrap();
+        assert_eq!(cache.stats().total_entries, 2);
+        cache.clear().unwrap();
+        assert_eq!(cache.stats().total_entries, 0);
+    }
+}

--- a/src/enrichment/staleness/registry.rs
+++ b/src/enrichment/staleness/registry.rs
@@ -1,13 +1,13 @@
 //! Package registry clients for staleness detection.
 
+use crate::enrichment::source::{JsonCache, namespaced_cache_dir};
 use crate::enrichment::stats::EnrichmentError;
 use crate::model::{Component, Ecosystem, StalenessInfo, StalenessLevel};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fs;
 use std::path::PathBuf;
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 /// Registry client configuration
 #[derive(Debug, Clone)]
@@ -40,40 +40,14 @@ impl Default for RegistryConfig {
 }
 
 fn default_cache_dir() -> PathBuf {
-    dirs_cache_dir()
-        .unwrap_or_else(|| PathBuf::from(".cache"))
-        .join("sbom-tools")
-        .join("staleness")
+    namespaced_cache_dir("staleness")
 }
 
-fn dirs_cache_dir() -> Option<PathBuf> {
-    #[cfg(target_os = "macos")]
-    {
-        std::env::var("HOME")
-            .ok()
-            .map(|h| PathBuf::from(h).join("Library").join("Caches"))
-    }
-    #[cfg(target_os = "linux")]
-    {
-        std::env::var("XDG_CACHE_HOME")
-            .ok()
-            .map(PathBuf::from)
-            .or_else(|| {
-                std::env::var("HOME")
-                    .ok()
-                    .map(|h| PathBuf::from(h).join(".cache"))
-            })
-    }
-    #[cfg(target_os = "windows")]
-    {
-        std::env::var("LOCALAPPDATA").ok().map(PathBuf::from)
-    }
-    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-    {
-        std::env::var("HOME")
-            .ok()
-            .map(|h| PathBuf::from(h).join(".cache"))
-    }
+/// Filesystem-safe cache file name for a registry key (e.g. `npm:lodash` →
+/// `npm_lodash.json`).
+fn cache_filename(key: &str) -> String {
+    let safe_key = key.replace(['/', ':'], "_");
+    format!("{safe_key}.json")
 }
 
 /// Package metadata from registry
@@ -145,54 +119,25 @@ impl RegistryClient {
         format!("{ecosystem}:{name}")
     }
 
-    /// Get cache file path
-    fn cache_file(&self, key: &str) -> PathBuf {
-        let safe_key = key.replace(['/', ':'], "_");
-        self.config.cache_dir.join(format!("{safe_key}.json"))
+    /// Open the shared file cache for package metadata.
+    fn disk_cache(&self) -> Result<JsonCache<PackageMetadata>, EnrichmentError> {
+        JsonCache::new(self.config.cache_dir.clone(), self.config.cache_ttl)
+            .map_err(|e| EnrichmentError::CacheError(e.to_string()))
     }
 
-    /// Check if cache is valid
-    fn is_cache_valid(&self, key: &str) -> bool {
-        if self.config.bypass_cache {
-            return false;
-        }
-
-        let cache_path = self.cache_file(key);
-        if !cache_path.exists() {
-            return false;
-        }
-
-        if let Ok(metadata) = fs::metadata(&cache_path)
-            && let Ok(modified) = metadata.modified()
-            && let Ok(elapsed) = SystemTime::now().duration_since(modified)
-        {
-            return elapsed < self.config.cache_ttl;
-        }
-
-        false
-    }
-
-    /// Load from cache
+    /// Load from disk cache
     fn load_from_cache(&self, key: &str) -> Option<PackageMetadata> {
-        let cache_path = self.cache_file(key);
-        let content = fs::read_to_string(&cache_path).ok()?;
-        serde_json::from_str(&content).ok()
+        if self.config.bypass_cache {
+            return None;
+        }
+        self.disk_cache().ok()?.get_named(&cache_filename(key))
     }
 
-    /// Save to cache
+    /// Save to disk cache
     fn save_to_cache(&self, key: &str, metadata: &PackageMetadata) -> Result<(), EnrichmentError> {
-        let cache_path = self.cache_file(key);
-
-        if let Some(parent) = cache_path.parent() {
-            fs::create_dir_all(parent).map_err(|e| EnrichmentError::CacheError(e.to_string()))?;
-        }
-
-        let content = serde_json::to_string(metadata)
-            .map_err(|e| EnrichmentError::CacheError(e.to_string()))?;
-
-        fs::write(&cache_path, content).map_err(|e| EnrichmentError::CacheError(e.to_string()))?;
-
-        Ok(())
+        self.disk_cache()?
+            .set_named(&cache_filename(key), metadata)
+            .map_err(|e| EnrichmentError::CacheError(e.to_string()))
     }
 
     /// Query npm registry
@@ -200,9 +145,7 @@ impl RegistryClient {
     fn query_npm(&self, name: &str) -> Result<Option<PackageMetadata>, EnrichmentError> {
         let url = format!("https://registry.npmjs.org/{name}");
 
-        let client = reqwest::blocking::Client::builder()
-            .timeout(self.config.timeout)
-            .build()
+        let client = crate::enrichment::source::http_client(self.config.timeout)
             .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
 
         let response = client.get(&url).send();
@@ -263,9 +206,7 @@ impl RegistryClient {
     fn query_pypi(&self, name: &str) -> Result<Option<PackageMetadata>, EnrichmentError> {
         let url = format!("https://pypi.org/pypi/{name}/json");
 
-        let client = reqwest::blocking::Client::builder()
-            .timeout(self.config.timeout)
-            .build()
+        let client = crate::enrichment::source::http_client(self.config.timeout)
             .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
 
         let response = client.get(&url).send();
@@ -343,10 +284,9 @@ impl RegistryClient {
     fn query_crates_io(&self, name: &str) -> Result<Option<PackageMetadata>, EnrichmentError> {
         let url = format!("https://crates.io/api/v1/crates/{name}");
 
-        let client = reqwest::blocking::Client::builder()
-            .timeout(self.config.timeout)
-            .user_agent("sbom-tools/1.0")
-            .build()
+        // The shared client already sends a CARGO_PKG_NAME/CARGO_PKG_VERSION
+        // User-Agent, which satisfies the crates.io UA requirement.
+        let client = crate::enrichment::source::http_client(self.config.timeout)
             .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
 
         let response = client.get(&url).send();
@@ -431,9 +371,7 @@ impl RegistryClient {
         }
 
         // Check disk cache
-        if self.is_cache_valid(&cache_key)
-            && let Some(metadata) = self.load_from_cache(&cache_key)
-        {
+        if let Some(metadata) = self.load_from_cache(&cache_key) {
             self.cache.insert(cache_key.clone(), metadata.clone());
             return Ok(Some(metadata));
         }


### PR DESCRIPTION
## Summary

The four enrichment sources (`osv`, `kev`, `eol`, `staleness`) each carried a **copy-pasted platform cache-dir shim** (4 copies) and a private mtime-TTL JSON file cache with **non-atomic writes** and **no schema versioning**. OSV's default cache was CWD-relative (`.cache/sbom-tools/osv`) unlike the others, and HTTP hygiene was inconsistent (varying User-Agent, only OSV retried, a fresh `Client` built per request in EOL/staleness).

This is a **behavior-preserving** refactor of the cache/client plumbing — no source changes what it fetches or how it maps results. The win is dedup + atomic writes + schema versioning + consistent HTTP. (Wiring the dormant KEV/staleness enrichers, EPSS, and offline mode are intentionally out of scope — separate later PRs.)

### New `src/enrichment/source.rs`
- **One** platform cache-dir helper (`cache_dir` / `namespaced_cache_dir`) replacing the 4 duplicated `dirs_cache_dir` shims.
- Shared `http_client(timeout)` with a `CARGO_PKG_NAME/CARGO_PKG_VERSION` User-Agent, plus `get_with_retry` honoring `429`/`Retry-After` with bounded exponential backoff (capped at 30s).
- Generic `JsonCache<T>` with **atomic** writes (temp file + rename) and a `CACHE_SCHEMA_VERSION` envelope — a version mismatch or TTL expiry is a miss and the entry is evicted.
- `EnrichmentSource` trait modeling the shared shape (name, cache namespace, TTL, in-place enrich) of the existing enrichers.

### Ports (plumbing only)
- **OSV**: default `cache_dir` now uses `namespaced_cache_dir("osv")` instead of the CWD-relative path (`osv/mod.rs:43`); client built via `http_client`, GET paths (`health_check`, `get_vulnerability`) routed through `get_with_retry`. The **#219 per-vuln hydration + 24h caching is intact** (`osv/mod.rs` `hydrate_vulns`).
- `cache.rs` `FileCache` is now a thin view over `JsonCache<Vec<VulnerabilityRef>>`, preserving its **exact public API** so `tests/enrichment_http_tests.rs` and all OSV call sites are untouched.
- **KEV/EOL/staleness**: dropped per-source `cache_file`/`is_cache_valid`/`load_from_cache`/`save_to_cache` in favor of `JsonCache`; every per-request `Client::builder()` (incl. the ad-hoc `"sbom-tools/1.0"` UA on crates.io) replaced with the shared `http_client`.

> Note: because the cache envelope is new, pre-existing on-disk cache files are treated as schema mismatches and transparently re-fetched on first run. This is the intended invalidation behavior.

## Test plan
- `cargo test --all-features` (1.88): **1361 passed, 0 failed**.
- The httpmock safety net `tests/enrichment_http_tests.rs` (OSV hydration, caching, retry, TTL-expiry) and `tests/eol_tests.rs` pass unchanged.
- New `JsonCache` unit tests: atomic write leaves no temp file, schema-version mismatch invalidates, TTL expiry evicts; plus backoff policy tests.
- `cargo clippy -- -D warnings` and `cargo clippy --all-features -- -D warnings` clean on pinned 1.88.
- `cargo build` (default) and `cargo check --no-default-features --features ffi` both verified (ffi warning count unchanged from baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)