### PR TITLE
feat(enrichment): wire KEV and staleness enrichers + --kev gating

### DIFF
--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -82,6 +82,40 @@ pub fn run_diff(config: DiffConfig) -> Result<i32> {
         }
     }
 
+    // Enrich with CISA KEV catalog (flags actively exploited vulnerabilities)
+    #[cfg(feature = "enrichment")]
+    if config.enrichment.enable_kev {
+        let kev_config = kev_client_config(&config.enrichment);
+        let kev_old = crate::pipeline::enrich_kev(old_parsed.sbom_mut(), &kev_config, quiet);
+        let kev_new = crate::pipeline::enrich_kev(new_parsed.sbom_mut(), &kev_config, quiet);
+        if kev_old.is_none() || kev_new.is_none() {
+            enrichment_warnings.push("KEV enrichment failed");
+        }
+    }
+
+    // Enrich with dependency staleness data
+    #[cfg(feature = "enrichment")]
+    if config.enrichment.enable_staleness {
+        let staleness_config = crate::enrichment::RegistryConfig {
+            cache_dir: config
+                .enrichment
+                .cache_dir
+                .clone()
+                .unwrap_or_else(crate::pipeline::dirs::staleness_cache_dir),
+            cache_ttl: std::time::Duration::from_secs(config.enrichment.cache_ttl_hours * 3600),
+            bypass_cache: config.enrichment.bypass_cache,
+            timeout: std::time::Duration::from_secs(config.enrichment.timeout_secs),
+            ..Default::default()
+        };
+        let stale_old =
+            crate::pipeline::enrich_staleness(old_parsed.sbom_mut(), &staleness_config, quiet);
+        let stale_new =
+            crate::pipeline::enrich_staleness(new_parsed.sbom_mut(), &staleness_config, quiet);
+        if stale_old.is_none() || stale_new.is_none() {
+            enrichment_warnings.push("Staleness enrichment failed");
+        }
+    }
+
     // Enrich with VEX data if VEX documents provided
     #[cfg(feature = "enrichment")]
     if !config.enrichment.vex_paths.is_empty() {
@@ -170,6 +204,23 @@ fn determine_exit_code(config: &DiffConfig, result: &crate::diff::DiffResult) ->
             return exit_codes::VEX_GAPS_FOUND;
         }
     }
+    // KEV gate is more specific than the generic vuln gate: an actively
+    // exploited (KEV) finding is the highest-priority signal for CRA Art.14
+    // reporting, so it outranks --fail-on-vuln.
+    if config.behavior.fail_on_kev {
+        let kev_count = result
+            .vulnerabilities
+            .introduced
+            .iter()
+            .filter(|v| v.is_kev)
+            .count();
+        if kev_count > 0 {
+            eprintln!(
+                "KEV gate: {kev_count} introduced vulnerability(ies) are in CISA's Known Exploited Vulnerabilities catalog",
+            );
+            return exit_codes::KEV_INTRODUCED;
+        }
+    }
     if config.behavior.fail_on_vuln && result.summary.vulnerabilities_introduced > 0 {
         return exit_codes::VULNS_INTRODUCED;
     }
@@ -177,6 +228,28 @@ fn determine_exit_code(config: &DiffConfig, result: &crate::diff::DiffResult) ->
         return exit_codes::CHANGES_DETECTED;
     }
     exit_codes::SUCCESS
+}
+
+/// Build a `KevClientConfig` from the user-facing `EnrichmentConfig`, honoring
+/// the cache directory, TTL, timeout, and optional URL override.
+#[cfg(feature = "enrichment")]
+fn kev_client_config(
+    enrichment: &crate::config::EnrichmentConfig,
+) -> crate::enrichment::KevClientConfig {
+    let mut cfg = crate::enrichment::KevClientConfig {
+        cache_dir: enrichment
+            .cache_dir
+            .clone()
+            .unwrap_or_else(crate::pipeline::dirs::kev_cache_dir),
+        cache_ttl: std::time::Duration::from_secs(enrichment.cache_ttl_hours * 3600),
+        bypass_cache: enrichment.bypass_cache,
+        timeout: std::time::Duration::from_secs(enrichment.timeout_secs),
+        ..Default::default()
+    };
+    if let Some(ref url) = enrichment.kev_url {
+        cfg.kev_url = url.clone();
+    }
+    cfg
 }
 
 #[cfg(test)]

--- a/src/cli/quality.rs
+++ b/src/cli/quality.rs
@@ -2,6 +2,7 @@
 //!
 //! Implements the `quality` subcommand for assessing SBOM quality.
 
+use crate::config::EnrichmentConfig;
 use crate::pipeline::{OutputTarget, exit_codes, parse_sbom_with_context, write_output};
 use crate::quality::{
     QualityGrade, QualityReport, QualityScorer, ScoringProfile, ViolationSeverity,
@@ -27,6 +28,10 @@ pub struct QualityConfig {
     pub cra_sidecar_path: Option<PathBuf>,
     /// CRA Annex III/IV product class (CLI string form). Sidecar value wins.
     pub cra_product_class: Option<String>,
+    /// Enrichment configuration (OSV / KEV / EOL / staleness / VEX). When any
+    /// source is enabled the SBOM is enriched before scoring so the
+    /// Lifecycle / `VulnDocs` categories reflect live data.
+    pub enrichment: EnrichmentConfig,
 }
 
 /// Run the quality command, returning the desired exit code.
@@ -45,6 +50,7 @@ pub fn run_quality(
     no_color: bool,
     cra_sidecar_path: Option<PathBuf>,
     cra_product_class: Option<String>,
+    enrichment: EnrichmentConfig,
 ) -> Result<i32> {
     let config = QualityConfig {
         sbom_path,
@@ -57,13 +63,33 @@ pub fn run_quality(
         no_color,
         cra_sidecar_path,
         cra_product_class,
+        enrichment,
     };
 
     run_quality_impl(config)
 }
 
 fn run_quality_impl(config: QualityConfig) -> Result<i32> {
-    let parsed = parse_sbom_with_context(&config.sbom_path, false)?;
+    #[cfg_attr(not(feature = "enrichment"), allow(unused_mut))]
+    let mut parsed = parse_sbom_with_context(&config.sbom_path, false)?;
+
+    // Enrich before scoring so Lifecycle (staleness/EOL) and VulnDocs (OSV/KEV)
+    // categories reflect live data rather than only the static SBOM contents.
+    #[cfg(feature = "enrichment")]
+    {
+        let any_enrichment = config.enrichment.enabled
+            || config.enrichment.enable_eol
+            || config.enrichment.enable_kev
+            || config.enrichment.enable_staleness
+            || !config.enrichment.vex_paths.is_empty();
+        if any_enrichment {
+            let stats =
+                crate::pipeline::enrich_sbom_full(parsed.sbom_mut(), &config.enrichment, false);
+            for warning in &stats.warnings {
+                tracing::warn!("{warning}");
+            }
+        }
+    }
 
     // Parse scoring profile
     let profile = parse_scoring_profile(&config.profile)?;
@@ -659,6 +685,7 @@ mod tests {
             no_color: true,
             cra_sidecar_path: None,
             cra_product_class: None,
+            enrichment: EnrichmentConfig::default(),
         }
     }
 

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -556,32 +556,10 @@ fn enrich_if_needed(
     mut sboms: Vec<NormalizedSbom>,
     config: &crate::config::EnrichmentConfig,
 ) -> Result<Vec<NormalizedSbom>> {
-    // VEX enrichment
-    if !config.vex_paths.is_empty() {
-        for sbom in &mut sboms {
-            crate::pipeline::enrich_vex(sbom, &config.vex_paths, false);
-        }
-    }
-    if config.enabled {
-        let osv_config = crate::pipeline::build_enrichment_config(config);
-        for sbom in &mut sboms {
-            crate::pipeline::enrich_sbom(sbom, &osv_config, false);
-        }
-    }
-    if config.enable_eol {
-        let eol_config = crate::enrichment::EolClientConfig {
-            cache_dir: config
-                .cache_dir
-                .clone()
-                .unwrap_or_else(crate::pipeline::dirs::eol_cache_dir),
-            cache_ttl: std::time::Duration::from_secs(config.cache_ttl_hours * 3600),
-            bypass_cache: config.bypass_cache,
-            timeout: std::time::Duration::from_secs(config.timeout_secs),
-            ..Default::default()
-        };
-        for sbom in &mut sboms {
-            crate::pipeline::enrich_eol(sbom, &eol_config, false);
-        }
+    // Delegate to the central pipeline so OSV / KEV / EOL / staleness / VEX are
+    // all sequenced consistently with the other commands.
+    for sbom in &mut sboms {
+        crate::pipeline::enrich_sbom_full(sbom, config, false);
     }
     Ok(sboms)
 }

--- a/src/cli/view.rs
+++ b/src/cli/view.rs
@@ -47,6 +47,48 @@ pub fn run_view(config: ViewConfig) -> Result<i32> {
         }
     }
 
+    // Enrich with CISA KEV catalog (flags actively exploited vulnerabilities)
+    #[cfg(feature = "enrichment")]
+    if config.enrichment.enable_kev {
+        let mut kev_config = crate::enrichment::KevClientConfig {
+            cache_dir: config
+                .enrichment
+                .cache_dir
+                .clone()
+                .unwrap_or_else(crate::pipeline::dirs::kev_cache_dir),
+            cache_ttl: std::time::Duration::from_secs(config.enrichment.cache_ttl_hours * 3600),
+            bypass_cache: config.enrichment.bypass_cache,
+            timeout: std::time::Duration::from_secs(config.enrichment.timeout_secs),
+            ..Default::default()
+        };
+        if let Some(ref url) = config.enrichment.kev_url {
+            kev_config.kev_url = url.clone();
+        }
+        if crate::pipeline::enrich_kev(parsed.sbom_mut(), &kev_config, false).is_none() {
+            enrichment_warnings.push("KEV enrichment failed");
+        }
+    }
+
+    // Enrich with dependency staleness data
+    #[cfg(feature = "enrichment")]
+    if config.enrichment.enable_staleness {
+        let staleness_config = crate::enrichment::RegistryConfig {
+            cache_dir: config
+                .enrichment
+                .cache_dir
+                .clone()
+                .unwrap_or_else(crate::pipeline::dirs::staleness_cache_dir),
+            cache_ttl: std::time::Duration::from_secs(config.enrichment.cache_ttl_hours * 3600),
+            bypass_cache: config.enrichment.bypass_cache,
+            timeout: std::time::Duration::from_secs(config.enrichment.timeout_secs),
+            ..Default::default()
+        };
+        if crate::pipeline::enrich_staleness(parsed.sbom_mut(), &staleness_config, false).is_none()
+        {
+            enrichment_warnings.push("Staleness enrichment failed");
+        }
+    }
+
     // Enrich with VEX data if VEX documents provided
     #[cfg(feature = "enrichment")]
     if !config.enrichment.vex_paths.is_empty()
@@ -58,7 +100,11 @@ pub fn run_view(config: ViewConfig) -> Result<i32> {
 
     // Warn if enrichment requested but feature not enabled
     #[cfg(not(feature = "enrichment"))]
-    if config.enrichment.enabled || config.enrichment.enable_eol {
+    if config.enrichment.enabled
+        || config.enrichment.enable_eol
+        || config.enrichment.enable_kev
+        || config.enrichment.enable_staleness
+    {
         eprintln!(
             "Warning: enrichment requested but the 'enrichment' feature is not enabled. \
              Rebuild with: cargo build --features enrichment"

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -117,6 +117,7 @@ impl AppConfig {
             filtering: FilterConfig::default(),
             behavior: BehaviorConfig {
                 fail_on_vuln: true,
+                fail_on_kev: false,
                 fail_on_change: false,
                 quiet: false,
                 explain_matches: false,
@@ -165,6 +166,7 @@ impl AppConfig {
             },
             behavior: BehaviorConfig {
                 fail_on_vuln: true,
+                fail_on_kev: false,
                 fail_on_change: true,
                 quiet: true,
                 explain_matches: false,
@@ -219,6 +221,7 @@ impl AppConfig {
             filtering: FilterConfig::default(),
             behavior: BehaviorConfig {
                 fail_on_vuln: false,
+                fail_on_kev: false,
                 fail_on_change: false,
                 quiet: false,
                 explain_matches: false,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -707,6 +707,9 @@ pub struct FilterConfig {
 pub struct BehaviorConfig {
     /// Exit with code 2 if new vulnerabilities are introduced
     pub fail_on_vuln: bool,
+    /// Exit with code 6 if any introduced vulnerability is in CISA's KEV catalog
+    #[serde(default)]
+    pub fail_on_kev: bool,
     /// Exit with code 1 if any changes detected
     pub fail_on_change: bool,
     /// Suppress non-essential output
@@ -801,12 +804,22 @@ pub struct EnrichmentConfig {
     pub timeout_secs: u64,
     /// Enable end-of-life detection via endoflife.date API
     pub enable_eol: bool,
+    /// Enable CISA KEV (Known Exploited Vulnerabilities) enrichment
+    #[serde(default)]
+    pub enable_kev: bool,
+    /// Enable dependency staleness enrichment via package registries
+    #[serde(default)]
+    pub enable_staleness: bool,
     /// Paths to external VEX documents (OpenVEX format)
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub vex_paths: Vec<std::path::PathBuf>,
     /// OSV API base URL override (defaults to the public OSV API)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub api_base: Option<String>,
+    /// CISA KEV catalog URL override (defaults to the public CISA feed).
+    /// Primarily a test seam for pointing the KEV enricher at a mock server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kev_url: Option<String>,
 }
 
 impl Default for EnrichmentConfig {
@@ -820,8 +833,11 @@ impl Default for EnrichmentConfig {
             bypass_cache: false,
             timeout_secs: 30,
             enable_eol: false,
+            enable_kev: false,
+            enable_staleness: false,
             vex_paths: Vec::new(),
             api_base: None,
+            kev_url: None,
         }
     }
 }
@@ -876,6 +892,27 @@ impl EnrichmentConfig {
     #[must_use]
     pub fn with_api_base(mut self, api_base: impl Into<String>) -> Self {
         self.api_base = Some(api_base.into());
+        self
+    }
+
+    /// Enable CISA KEV enrichment.
+    #[must_use]
+    pub const fn with_kev(mut self) -> Self {
+        self.enable_kev = true;
+        self
+    }
+
+    /// Override the CISA KEV catalog URL (test seam).
+    #[must_use]
+    pub fn with_kev_url(mut self, kev_url: impl Into<String>) -> Self {
+        self.kev_url = Some(kev_url.into());
+        self
+    }
+
+    /// Enable dependency staleness enrichment.
+    #[must_use]
+    pub const fn with_staleness(mut self) -> Self {
+        self.enable_staleness = true;
         self
     }
 }
@@ -974,6 +1011,12 @@ impl DiffConfigBuilder {
     #[must_use]
     pub const fn fail_on_vuln(mut self, fail: bool) -> Self {
         self.behavior.fail_on_vuln = fail;
+        self
+    }
+
+    #[must_use]
+    pub const fn fail_on_kev(mut self, fail: bool) -> Self {
+        self.behavior.fail_on_kev = fail;
         self
     }
 

--- a/src/diff/changes/vuln_grouping.rs
+++ b/src/diff/changes/vuln_grouping.rs
@@ -96,6 +96,11 @@ impl VulnerabilityGroup {
             self.component_version.clone_from(&vuln.version);
         }
 
+        // Propagate the KEV (actively exploited) flag to the group.
+        if vuln.is_kev {
+            self.has_kev = true;
+        }
+
         self.vulnerabilities.push(vuln);
     }
 
@@ -308,6 +313,30 @@ mod tests {
         // express should be second
         assert_eq!(groups[1].component_id, "express");
         assert_eq!(groups[1].vuln_count(), 1);
+    }
+
+    #[test]
+    fn test_group_propagates_kev_flag() {
+        let mut kev_vuln = make_vuln("CVE-2021-44228", "log4j", "Critical");
+        kev_vuln.is_kev = true;
+        let vulns = vec![kev_vuln, make_vuln("CVE-2024-0009", "lodash", "High")];
+
+        let groups = group_vulnerabilities(&vulns, VulnGroupStatus::Introduced);
+
+        let log4j = groups
+            .iter()
+            .find(|g| g.component_id == "log4j")
+            .expect("log4j group present");
+        assert!(log4j.has_kev, "group with a KEV vuln must report has_kev");
+
+        let lodash = groups
+            .iter()
+            .find(|g| g.component_id == "lodash")
+            .expect("lodash group present");
+        assert!(
+            !lodash.has_kev,
+            "group without KEV vulns must not report has_kev"
+        );
     }
 
     #[test]

--- a/src/enrichment/kev/client.rs
+++ b/src/enrichment/kev/client.rs
@@ -47,7 +47,7 @@ fn default_cache_dir() -> PathBuf {
 }
 
 /// KEV enrichment statistics
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct KevEnrichmentStats {
     /// Number of vulnerabilities checked
     pub vulns_checked: usize,

--- a/src/enrichment/source.rs
+++ b/src/enrichment/source.rs
@@ -562,12 +562,14 @@ mod tests {
     #[test]
     fn ttl_expiry_evicts_entry() {
         let tmp = tempfile::tempdir().unwrap();
+        // TTL margin must comfortably exceed the set+get round-trip (atomic
+        // write + read + deserialize), which can spike on a loaded CI runner.
         let cache: JsonCache<Payload> =
-            JsonCache::new(tmp.path().to_path_buf(), Duration::from_millis(20)).unwrap();
+            JsonCache::new(tmp.path().to_path_buf(), Duration::from_millis(200)).unwrap();
         cache.set_named("entry", &sample()).unwrap();
         assert!(cache.get_named("entry").is_some());
 
-        std::thread::sleep(Duration::from_millis(60));
+        std::thread::sleep(Duration::from_millis(400));
         assert!(
             cache.get_named("entry").is_none(),
             "entry past TTL must be a miss"

--- a/src/enrichment/staleness/registry.rs
+++ b/src/enrichment/staleness/registry.rs
@@ -72,7 +72,7 @@ pub struct PackageMetadata {
 }
 
 /// Staleness enrichment statistics
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct StalenessEnrichmentStats {
     /// Components checked
     pub components_checked: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,7 @@ const fn build_long_version() -> &'static str {
     3  Error occurred
     4  VEX gaps found (--fail-on-vex-gap)
     5  License policy violations found
+    6  Actively exploited (KEV) vulnerability introduced (--fail-on-kev)
 
 EXAMPLES:
   Comparing SBOMs:
@@ -64,12 +65,14 @@ EXAMPLES:
     sbom-tools diff old.cdx.json new.cdx.json -o json > diff.json  # JSON export
     sbom-tools diff old.cdx.json new.cdx.json -o sarif             # CI/CD SARIF
 
-  Enrichment (add vulnerability + EOL data before diffing):
+  Enrichment (add vulnerability + EOL + KEV data before diffing):
     sbom-tools diff old.json new.json --enrich-vulns --enrich-eol
+    sbom-tools diff old.json new.json --enrich-vulns --kev
     sbom-tools view app.cdx.json --enrich-vulns --fail-on-vuln
 
   CI/CD pipeline gates:
     sbom-tools diff old.json new.json --fail-on-vuln --fail-on-change
+    sbom-tools diff old.json new.json --enrich-vulns --kev --fail-on-kev
     sbom-tools diff old.json new.json --fail-on-vex-gap --vex vex.json
     sbom-tools quality app.cdx.json --min-score 70
 
@@ -147,6 +150,18 @@ struct SharedEnrichmentArgs {
     #[arg(long)]
     enrich_eol: bool,
 
+    /// Flag vulnerabilities in CISA's Known Exploited Vulnerabilities catalog
+    #[arg(long = "kev", alias = "enrich-kev")]
+    enrich_kev: bool,
+
+    /// Detect stale/abandoned/deprecated dependencies via package registries
+    #[arg(long = "enrich-staleness", alias = "staleness")]
+    enrich_staleness: bool,
+
+    /// CISA KEV catalog URL override (test seam; defaults to the public feed)
+    #[arg(long = "kev-url", env = "SBOM_TOOLS_KEV_URL", hide = true)]
+    kev_url: Option<String>,
+
     /// Apply external VEX document(s) (OpenVEX format). Can be specified multiple times
     #[arg(long = "vex", value_name = "PATH")]
     vex: Vec<PathBuf>,
@@ -184,6 +199,9 @@ impl SharedEnrichmentArgs {
             bypass_cache: self.refresh_vulns,
             timeout_secs: self.api_timeout,
             enable_eol: self.enrich_eol,
+            enable_kev: self.enrich_kev,
+            enable_staleness: self.enrich_staleness,
+            kev_url: self.kev_url.clone(),
             vex_paths: self.vex.clone(),
             ..Default::default()
         }
@@ -205,6 +223,8 @@ fn seed_enrichment(
     let cli = args.to_enrichment_config();
     let cli_touched = cli.enabled
         || cli.enable_eol
+        || cli.enable_kev
+        || cli.enable_staleness
         || arg_was_set_sub(sub, "vuln_cache_dir")
         || arg_was_set_sub(sub, "vuln_cache_ttl")
         || arg_was_set_sub(sub, "api_timeout")
@@ -225,12 +245,14 @@ fn seed_enrichment(
     2  Vulnerabilities introduced (--fail-on-vuln)
     3  Error occurred
     4  VEX gaps found (--fail-on-vex-gap)
+    6  Actively exploited (KEV) vulnerability introduced (--fail-on-kev)
 
 EXAMPLES:
     sbom-tools diff old.cdx.json new.cdx.json                    # Interactive TUI
     sbom-tools diff old.json new.json -o summary --fail-on-vuln   # CI gate
     sbom-tools diff old.json new.json --enrich-vulns -o sarif     # Enriched SARIF
     sbom-tools diff old.json new.json --graph-diff --graph-max-depth 3
+    sbom-tools diff old.json new.json --enrich-vulns --kev --fail-on-kev
     sbom-tools diff old.json new.json --vex vex.json --fail-on-vex-gap")]
 struct DiffArgs {
     /// Path to the old/baseline SBOM
@@ -262,6 +284,11 @@ struct DiffArgs {
     /// Exit with code 2 if new vulnerabilities are introduced
     #[arg(long)]
     fail_on_vuln: bool,
+
+    /// Exit with code 6 if any introduced vulnerability is in CISA's KEV catalog
+    /// (implies --kev enrichment)
+    #[arg(long)]
+    fail_on_kev: bool,
 
     /// Exit with code 1 if any changes detected (default for non-zero changes)
     #[arg(long)]
@@ -696,6 +723,9 @@ struct QualityArgs {
     /// Sidecar `productClass` wins over this flag.
     #[arg(long, value_name = "CLASS")]
     cra_product_class: Option<String>,
+
+    #[command(flatten)]
+    enrichment: SharedEnrichmentArgs,
 }
 
 /// Arguments for the `query` subcommand
@@ -1315,7 +1345,12 @@ fn main() -> Result<()> {
     match cli.command {
         Commands::Diff(args) => {
             let sm = sub_matches;
-            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
+            let fail_on_kev = resolve_bool(args.fail_on_kev, app.behavior.fail_on_kev);
+            let mut enrichment = seed_enrichment(&args.enrichment, sm, &app);
+            // --fail-on-kev is meaningless without KEV data, so it implies --kev.
+            if fail_on_kev {
+                enrichment.enable_kev = true;
+            }
 
             let config = DiffConfig {
                 paths: DiffPaths {
@@ -1365,6 +1400,7 @@ fn main() -> Result<()> {
                 },
                 behavior: BehaviorConfig {
                     fail_on_vuln: resolve_bool(args.fail_on_vuln, app.behavior.fail_on_vuln),
+                    fail_on_kev,
                     fail_on_change: resolve_bool(args.fail_on_change, app.behavior.fail_on_change),
                     quiet: resolve_bool(cli.quiet, app.behavior.quiet),
                     explain_matches: resolve_bool(
@@ -1706,6 +1742,7 @@ fn main() -> Result<()> {
                 arg_was_set_sub(sm, "output"),
                 Some(app.output.format),
             );
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
             let exit_code = cli::run_quality(
                 args.sbom,
                 args.profile,
@@ -1717,6 +1754,7 @@ fn main() -> Result<()> {
                 resolve_bool(cli.no_color, app.output.no_color),
                 args.cra_sidecar,
                 args.cra_product_class,
+                enrichment,
             )?;
             if exit_code != 0 {
                 std::process::exit(exit_code);

--- a/src/pipeline/enrich.rs
+++ b/src/pipeline/enrich.rs
@@ -18,6 +18,12 @@ pub struct AggregatedEnrichmentStats {
     /// VEX enrichment stats
     #[cfg(feature = "enrichment")]
     pub vex: Option<crate::enrichment::VexEnrichmentStats>,
+    /// CISA KEV enrichment stats
+    #[cfg(feature = "enrichment")]
+    pub kev: Option<crate::enrichment::KevEnrichmentStats>,
+    /// Dependency staleness enrichment stats
+    #[cfg(feature = "enrichment")]
+    pub staleness: Option<crate::enrichment::StalenessEnrichmentStats>,
     /// Warnings for display (non-fatal enrichment failures)
     pub warnings: Vec<String>,
 }
@@ -35,7 +41,11 @@ impl AggregatedEnrichmentStats {
     pub fn any_enrichment(&self) -> bool {
         #[cfg(feature = "enrichment")]
         {
-            self.osv.is_some() || self.eol.is_some() || self.vex.is_some()
+            self.osv.is_some()
+                || self.eol.is_some()
+                || self.vex.is_some()
+                || self.kev.is_some()
+                || self.staleness.is_some()
         }
         #[cfg(not(feature = "enrichment"))]
         {
@@ -67,7 +77,29 @@ pub fn enrich_sbom_full(
         }
     }
 
-    // 2. EOL detection
+    // 2. KEV (Known Exploited Vulnerabilities) overlay — must run after OSV so
+    //    it can flag the vulnerabilities OSV discovered.
+    if config.enable_kev {
+        let mut kev_config = crate::enrichment::KevClientConfig {
+            cache_dir: config
+                .cache_dir
+                .clone()
+                .unwrap_or_else(super::dirs::kev_cache_dir),
+            cache_ttl: std::time::Duration::from_secs(config.cache_ttl_hours * 3600),
+            bypass_cache: config.bypass_cache,
+            timeout: std::time::Duration::from_secs(config.timeout_secs),
+            ..Default::default()
+        };
+        if let Some(ref url) = config.kev_url {
+            kev_config.kev_url = url.clone();
+        }
+        match super::enrich_kev(sbom, &kev_config, quiet) {
+            Some(s) => stats.kev = Some(s),
+            None => stats.warnings.push("KEV enrichment failed".into()),
+        }
+    }
+
+    // 3. EOL detection
     if config.enable_eol {
         let eol_config = crate::enrichment::EolClientConfig {
             cache_dir: config
@@ -85,7 +117,25 @@ pub fn enrich_sbom_full(
         }
     }
 
-    // 3. VEX overlay
+    // 4. Dependency staleness — feeds the Lifecycle quality metric.
+    if config.enable_staleness {
+        let staleness_config = crate::enrichment::RegistryConfig {
+            cache_dir: config
+                .cache_dir
+                .clone()
+                .unwrap_or_else(super::dirs::staleness_cache_dir),
+            cache_ttl: std::time::Duration::from_secs(config.cache_ttl_hours * 3600),
+            bypass_cache: config.bypass_cache,
+            timeout: std::time::Duration::from_secs(config.timeout_secs),
+            ..Default::default()
+        };
+        match super::enrich_staleness(sbom, &staleness_config, quiet) {
+            Some(s) => stats.staleness = Some(s),
+            None => stats.warnings.push("Staleness enrichment failed".into()),
+        }
+    }
+
+    // 5. VEX overlay
     if !config.vex_paths.is_empty() {
         match super::enrich_vex(sbom, &config.vex_paths, quiet) {
             Some(s) => stats.vex = Some(s),

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -16,7 +16,9 @@ pub use parse::{ParsedSbom, STDIN_PATH, is_stdin_path, parse_sbom_with_context, 
 pub use report_stage::output_report;
 
 #[cfg(feature = "enrichment")]
-pub use parse::{build_enrichment_config, enrich_eol, enrich_sbom, enrich_vex};
+pub use parse::{
+    build_enrichment_config, enrich_eol, enrich_kev, enrich_sbom, enrich_staleness, enrich_vex,
+};
 
 /// Structured pipeline error types for better diagnostics.
 #[derive(Debug, thiserror::Error)]
@@ -58,6 +60,8 @@ pub mod exit_codes {
     pub const VEX_GAPS_FOUND: i32 = 4;
     /// License policy violations found
     pub const LICENSE_VIOLATIONS: i32 = 5;
+    /// Introduced vulnerabilities are in CISA's KEV catalog (--fail-on-kev)
+    pub const KEV_INTRODUCED: i32 = 6;
 
     // --- Per-command meanings (aliases preserving the numeric values above) ---
 
@@ -128,6 +132,24 @@ pub mod dirs {
             .join("sbom-tools")
             .join("eol")
     }
+
+    /// Get the default CISA KEV cache directory
+    #[must_use]
+    pub fn kev_cache_dir() -> PathBuf {
+        cache_dir()
+            .unwrap_or_else(|| PathBuf::from(".cache"))
+            .join("sbom-tools")
+            .join("kev")
+    }
+
+    /// Get the default staleness (registry) cache directory
+    #[must_use]
+    pub fn staleness_cache_dir() -> PathBuf {
+        cache_dir()
+            .unwrap_or_else(|| PathBuf::from(".cache"))
+            .join("sbom-tools")
+            .join("staleness")
+    }
 }
 
 #[cfg(test)]
@@ -142,6 +164,7 @@ mod tests {
         assert_eq!(exit_codes::ERROR, 3);
         assert_eq!(exit_codes::VEX_GAPS_FOUND, 4);
         assert_eq!(exit_codes::LICENSE_VIOLATIONS, 5);
+        assert_eq!(exit_codes::KEV_INTRODUCED, 6);
     }
 
     #[test]

--- a/src/pipeline/parse.rs
+++ b/src/pipeline/parse.rs
@@ -273,6 +273,119 @@ pub fn enrich_eol(
     }
 }
 
+/// Enrich an SBOM's vulnerabilities with CISA KEV (Known Exploited
+/// Vulnerabilities) catalog data.
+///
+/// Sets `is_kev` / `kev_info` on every CVE-identified `VulnerabilityRef` that
+/// matches the catalog. Returns enrichment stats, or `None` if the catalog
+/// could not be loaded (non-fatal).
+#[cfg(feature = "enrichment")]
+pub fn enrich_kev(
+    sbom: &mut NormalizedSbom,
+    config: &crate::enrichment::KevClientConfig,
+    quiet: bool,
+) -> Option<crate::enrichment::KevEnrichmentStats> {
+    use crate::enrichment::KevClient;
+
+    if !quiet {
+        eprintln!("Enriching SBOM with CISA KEV (actively exploited) catalog...");
+    }
+
+    let mut client = KevClient::new(config.clone());
+
+    // Collect all vulnerability refs across components into one flat buffer so
+    // the catalog is loaded once, then scatter the enriched refs back.
+    let mut all_vulns: Vec<crate::model::VulnerabilityRef> = sbom
+        .components
+        .values()
+        .flat_map(|c| c.vulnerabilities.iter().cloned())
+        .collect();
+
+    if all_vulns.is_empty() {
+        return Some(crate::enrichment::KevEnrichmentStats::default());
+    }
+
+    match client.enrich_vulnerabilities(&mut all_vulns) {
+        Ok(stats) => {
+            if !quiet {
+                eprintln!(
+                    "KEV enrichment: {} matched ({} ransomware, {} overdue) from a {}-entry catalog",
+                    stats.kev_matches,
+                    stats.ransomware_related,
+                    stats.overdue_count,
+                    stats.catalog_size,
+                );
+            }
+            // Index enriched refs by vulnerability id so we can re-apply the KEV
+            // flags onto the per-component vulnerability lists.
+            let mut by_id: std::collections::HashMap<String, &crate::model::VulnerabilityRef> =
+                std::collections::HashMap::new();
+            for v in &all_vulns {
+                if v.is_kev {
+                    by_id.insert(v.id.clone(), v);
+                }
+            }
+            for comp in sbom.components.values_mut() {
+                for vuln in &mut comp.vulnerabilities {
+                    if let Some(enriched) = by_id.get(&vuln.id) {
+                        vuln.is_kev = true;
+                        vuln.kev_info = enriched.kev_info.clone();
+                    }
+                }
+            }
+            Some(stats)
+        }
+        Err(e) => {
+            eprintln!("Warning: KEV enrichment failed: {e}");
+            None
+        }
+    }
+}
+
+/// Enrich an SBOM's components with dependency staleness data from package
+/// registries (npm / `PyPI` / crates.io).
+///
+/// Populates `Component::staleness`, which feeds the Lifecycle quality metric.
+/// Returns enrichment stats, or `None` on initialization failure (non-fatal).
+#[cfg(feature = "enrichment")]
+pub fn enrich_staleness(
+    sbom: &mut NormalizedSbom,
+    config: &crate::enrichment::RegistryConfig,
+    quiet: bool,
+) -> Option<crate::enrichment::StalenessEnrichmentStats> {
+    use crate::enrichment::StalenessEnricher;
+
+    if !quiet {
+        eprintln!("Enriching SBOM with dependency staleness data from package registries...");
+    }
+
+    let mut enricher = StalenessEnricher::new(config.clone());
+    let mut comp_vec: Vec<_> = sbom.components.values().cloned().collect();
+
+    match enricher.enrich_components(&mut comp_vec) {
+        Ok(stats) => {
+            if !quiet {
+                eprintln!(
+                    "Staleness enrichment: {} enriched, {} stale, {} abandoned, {} deprecated, {} skipped",
+                    stats.components_enriched,
+                    stats.stale_count,
+                    stats.abandoned_count,
+                    stats.deprecated_count,
+                    stats.skipped_count,
+                );
+            }
+            for comp in comp_vec {
+                sbom.components.insert(comp.canonical_id.clone(), comp);
+            }
+            Some(stats)
+        }
+        Err(e) => {
+            eprintln!("Warning: staleness enrichment failed: {e}");
+            None
+        }
+    }
+}
+
 /// Enrich an SBOM with VEX data from external OpenVEX documents.
 ///
 /// Returns enrichment statistics if any VEX documents were successfully loaded.

--- a/src/reports/markdown.rs
+++ b/src/reports/markdown.rs
@@ -322,11 +322,11 @@ impl ReportGenerator for MarkdownReporter {
                 writeln!(md, "### Introduced Vulnerabilities\n")?;
                 writeln!(
                     md,
-                    "| ID | Severity | CVSS | SLA | Type | Component | Version | VEX |"
+                    "| ID | Severity | CVSS | KEV | SLA | Type | Component | Version | VEX |"
                 )?;
                 writeln!(
                     md,
-                    "|----|----------|------|-----|------|-----------|---------|-----|"
+                    "|----|----------|------|-----|-----|------|-----------|---------|-----|"
                 )?;
                 for vuln in &result.vulnerabilities.introduced {
                     let depth_label = match vuln.component_depth {
@@ -336,15 +336,17 @@ impl ReportGenerator for MarkdownReporter {
                     };
                     let sla_display = format_sla_display(vuln);
                     let vex_display = format_vex_display(vuln.vex_state.as_ref());
+                    let kev_display = if vuln.is_kev { "⚠ KEV" } else { "-" };
                     writeln!(
                         md,
-                        "| {} | {} | {} | {} | {} | {} | {} | {} |",
+                        "| {} | {} | {} | {} | {} | {} | {} | {} | {} |",
                         escape_markdown_table(&vuln.id),
                         escape_markdown_table(&vuln.severity),
                         vuln.cvss_score
                             .map(|s| format!("{s:.1}"))
                             .as_deref()
                             .unwrap_or("-"),
+                        kev_display,
                         escape_markdown_table(&sla_display),
                         depth_label,
                         escape_markdown_table(&vuln.component_name),

--- a/src/watch/alerts.rs
+++ b/src/watch/alerts.rs
@@ -89,6 +89,13 @@ impl AlertSink for StdoutAlertSink {
                 snapshot.new_vulns.join(", ")
             ));
         }
+        if !snapshot.new_kev.is_empty() {
+            parts.push(format!(
+                "\u{26a0} {} KEV / actively exploited ({})",
+                snapshot.new_kev.len(),
+                snapshot.new_kev.join(", ")
+            ));
+        }
         if !snapshot.resolved_vulns.is_empty() {
             parts.push(format!("-{} vulns resolved", snapshot.resolved_vulns.len()));
         }
@@ -210,6 +217,7 @@ impl AlertSink for NdjsonAlertSink {
             "modified": snapshot.components_modified,
             "new_vulns": snapshot.new_vulns,
             "resolved_vulns": snapshot.resolved_vulns,
+            "new_kev": snapshot.new_kev,
             "new_eol": snapshot.new_eol,
             "crypto_changes": snapshot.crypto_changes,
             "crypto_downgrades": snapshot.crypto_downgrades,
@@ -325,6 +333,7 @@ impl AlertSink for WebhookAlertSink {
             "modified": snapshot.components_modified,
             "new_vulns": snapshot.new_vulns,
             "resolved_vulns": snapshot.resolved_vulns,
+            "new_kev": snapshot.new_kev,
             "new_eol": snapshot.new_eol,
             "crypto_changes": snapshot.crypto_changes,
             "crypto_downgrades": snapshot.crypto_downgrades,
@@ -425,6 +434,7 @@ mod tests {
             components_modified: 2,
             new_vulns: vec!["CVE-2026-1234".to_string()],
             resolved_vulns: vec![],
+            new_kev: vec!["CVE-2021-44228".to_string()],
             new_eol: vec![],
             crypto_changes: vec![],
             crypto_downgrades: vec![],
@@ -439,6 +449,7 @@ mod tests {
         assert_eq!(parsed["type"], "change");
         assert_eq!(parsed["added"], 3);
         assert_eq!(parsed["new_vulns"][0], "CVE-2026-1234");
+        assert_eq!(parsed["new_kev"][0], "CVE-2021-44228");
     }
 
     #[test]
@@ -529,6 +540,7 @@ mod tests {
             components_modified: 0,
             new_vulns: vec![],
             resolved_vulns: vec![],
+            new_kev: vec![],
             new_eol: vec![],
             crypto_changes: vec![],
             crypto_downgrades: vec![],

--- a/src/watch/loop_impl.rs
+++ b/src/watch/loop_impl.rs
@@ -188,6 +188,24 @@ fn enrich_watched_sbom(sbom: &mut NormalizedSbom, config: &WatchConfig, bypass_c
     osv_config.bypass_cache = osv_config.bypass_cache || bypass_cache;
     crate::pipeline::enrich_sbom(sbom, &osv_config, true);
 
+    if config.enrichment.enable_kev {
+        let mut kev_config = crate::enrichment::KevClientConfig {
+            cache_dir: config
+                .enrichment
+                .cache_dir
+                .clone()
+                .unwrap_or_else(crate::pipeline::dirs::kev_cache_dir),
+            cache_ttl: std::time::Duration::from_secs(config.enrichment.cache_ttl_hours * 3600),
+            bypass_cache,
+            timeout: std::time::Duration::from_secs(config.enrichment.timeout_secs),
+            ..Default::default()
+        };
+        if let Some(ref url) = config.enrichment.kev_url {
+            kev_config.kev_url = url.clone();
+        }
+        crate::pipeline::enrich_kev(sbom, &kev_config, true);
+    }
+
     if config.enrichment.enable_eol {
         let eol_config = crate::enrichment::EolClientConfig {
             cache_dir: config
@@ -201,6 +219,21 @@ fn enrich_watched_sbom(sbom: &mut NormalizedSbom, config: &WatchConfig, bypass_c
             ..Default::default()
         };
         crate::pipeline::enrich_eol(sbom, &eol_config, true);
+    }
+
+    if config.enrichment.enable_staleness {
+        let staleness_config = crate::enrichment::RegistryConfig {
+            cache_dir: config
+                .enrichment
+                .cache_dir
+                .clone()
+                .unwrap_or_else(crate::pipeline::dirs::staleness_cache_dir),
+            cache_ttl: std::time::Duration::from_secs(config.enrichment.cache_ttl_hours * 3600),
+            bypass_cache,
+            timeout: std::time::Duration::from_secs(config.enrichment.timeout_secs),
+            ..Default::default()
+        };
+        crate::pipeline::enrich_staleness(sbom, &staleness_config, true);
     }
 
     if !config.enrichment.vex_paths.is_empty() {
@@ -295,6 +328,16 @@ fn process_sbom_change(
                         .flat_map(|c| c.vulnerabilities.iter().map(|v| v.id.clone()))
                         .collect(),
                     resolved_vulns: vec![],
+                    new_kev: new_sbom
+                        .components
+                        .values()
+                        .flat_map(|c| {
+                            c.vulnerabilities
+                                .iter()
+                                .filter(|v| v.is_kev)
+                                .map(|v| v.id.clone())
+                        })
+                        .collect(),
                     new_eol: new_sbom
                         .components
                         .values()
@@ -351,6 +394,15 @@ fn build_diff_snapshot(
                 .iter()
                 .map(|v| v.id.clone())
                 .collect();
+            // KEV-transition signal: introduced vulnerabilities flagged as
+            // actively exploited in CISA's KEV catalog.
+            let new_kev: Vec<String> = result
+                .vulnerabilities
+                .introduced
+                .iter()
+                .filter(|v| v.is_kev)
+                .map(|v| v.id.clone())
+                .collect();
 
             // Detect newly EOL components (in new but not old)
             let old_eol: std::collections::HashSet<&str> = old
@@ -391,6 +443,7 @@ fn build_diff_snapshot(
                 components_modified: result.components.modified.len(),
                 new_vulns,
                 resolved_vulns,
+                new_kev,
                 new_eol,
                 crypto_changes,
                 crypto_downgrades,
@@ -405,6 +458,7 @@ fn build_diff_snapshot(
                 components_modified: 0,
                 new_vulns: vec![],
                 resolved_vulns: vec![],
+                new_kev: vec![],
                 new_eol: vec![],
                 crypto_changes: vec![],
                 crypto_downgrades: vec![],

--- a/src/watch/state.rs
+++ b/src/watch/state.rs
@@ -128,6 +128,9 @@ pub(crate) struct DiffSnapshot {
     pub components_modified: usize,
     pub new_vulns: Vec<String>,
     pub resolved_vulns: Vec<String>,
+    /// Vulnerability IDs that newly entered CISA's KEV catalog this cycle
+    /// (actively exploited — highest-priority alert signal).
+    pub new_kev: Vec<String>,
     pub new_eol: Vec<String>,
     /// Crypto algorithms added or changed
     pub crypto_changes: Vec<String>,
@@ -143,6 +146,7 @@ impl DiffSnapshot {
             || self.components_modified > 0
             || !self.new_vulns.is_empty()
             || !self.resolved_vulns.is_empty()
+            || !self.new_kev.is_empty()
             || !self.new_eol.is_empty()
             || !self.crypto_changes.is_empty()
             || !self.crypto_downgrades.is_empty()
@@ -229,6 +233,7 @@ mod tests {
                     components_modified: 0,
                     new_vulns: vec![],
                     resolved_vulns: vec![],
+                    new_kev: vec![],
                     new_eol: vec![],
                     crypto_changes: vec![],
                     crypto_downgrades: vec![],
@@ -276,6 +281,7 @@ mod tests {
             components_modified: 0,
             new_vulns: vec![],
             resolved_vulns: vec![],
+            new_kev: vec![],
             new_eol: vec![],
             crypto_changes: vec![],
             crypto_downgrades: vec![],

--- a/tests/kev_staleness_tests.rs
+++ b/tests/kev_staleness_tests.rs
@@ -1,0 +1,227 @@
+//! Integration tests for KEV and staleness enrichment wiring.
+//!
+//! Covers:
+//! - `enrich_sbom_full` flagging a matching vulnerability via a mocked CISA KEV
+//!   catalog (httpmock),
+//! - the `diff --fail-on-kev` exit-code gate end-to-end through the CLI binary,
+//! - staleness data flowing into the Lifecycle quality metric.
+
+#![cfg(feature = "enrichment")]
+
+use sbom_tools::config::EnrichmentConfig;
+use sbom_tools::model::{
+    Component, NormalizedSbom, StalenessInfo, StalenessLevel, VulnerabilityRef, VulnerabilitySource,
+};
+use sbom_tools::pipeline::enrich_sbom_full;
+use sbom_tools::quality::LifecycleMetrics;
+
+use httpmock::prelude::*;
+use std::path::PathBuf;
+use std::process::Command;
+
+/// A CISA KEV catalog body containing a single entry for the given CVE.
+fn kev_catalog_body(cve_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "title": "CISA Catalog of Known Exploited Vulnerabilities",
+        "catalogVersion": "2026.06.01",
+        "dateReleased": "2026-06-01T12:00:00.000Z",
+        "count": 1,
+        "vulnerabilities": [
+            {
+                "cveID": cve_id,
+                "vendorProject": "Apache",
+                "product": "Log4j2",
+                "vulnerabilityName": "Apache Log4j2 Remote Code Execution Vulnerability",
+                "dateAdded": "2021-12-10",
+                "shortDescription": "Apache Log4j2 contains a vulnerability allowing RCE.",
+                "requiredAction": "Apply updates per vendor instructions.",
+                "dueDate": "2021-12-24",
+                "knownRansomwareCampaignUse": "Known",
+                "notes": ""
+            }
+        ]
+    })
+}
+
+fn component_with_vuln(name: &str, version: &str, cve_id: &str) -> Component {
+    let mut comp = Component::new(name.to_string(), format!("{name}@{version}"))
+        .with_purl(format!("pkg:maven/{name}@{version}"))
+        .with_version(version.to_string());
+    comp.vulnerabilities.push(VulnerabilityRef::new(
+        cve_id.to_string(),
+        VulnerabilitySource::Nvd,
+    ));
+    comp
+}
+
+#[test]
+fn enrich_sbom_full_flags_kev_vulnerability() {
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+
+    let kev_mock = server.mock(|when, then| {
+        when.method(GET).path("/kev.json");
+        then.status(200)
+            .json_body(kev_catalog_body("CVE-2021-44228"));
+    });
+
+    let mut sbom = NormalizedSbom::default();
+    sbom.add_component(component_with_vuln(
+        "log4j-core",
+        "2.14.0",
+        "CVE-2021-44228",
+    ));
+    // A non-KEV CVE that must remain unflagged.
+    sbom.add_component(component_with_vuln("lodash", "4.17.20", "CVE-2021-23337"));
+
+    let config = EnrichmentConfig::default()
+        .with_kev()
+        .with_kev_url(format!("{}/kev.json", server.base_url()))
+        .with_cache_dir(cache_dir.path().to_path_buf())
+        .with_bypass_cache();
+
+    let stats = enrich_sbom_full(&mut sbom, &config, true);
+
+    kev_mock.assert();
+    let kev_stats = stats.kev.expect("KEV stats should be produced");
+    assert_eq!(
+        kev_stats.kev_matches, 1,
+        "exactly one CVE is in the catalog"
+    );
+
+    let log4j = sbom
+        .components
+        .values()
+        .find(|c| c.name == "log4j-core")
+        .expect("log4j component present");
+    assert!(
+        log4j.vulnerabilities[0].is_kev,
+        "the KEV-listed CVE must be flagged is_kev"
+    );
+    assert!(
+        log4j.vulnerabilities[0].kev_info.is_some(),
+        "KEV metadata must be attached"
+    );
+
+    let lodash = sbom
+        .components
+        .values()
+        .find(|c| c.name == "lodash")
+        .expect("lodash component present");
+    assert!(
+        !lodash.vulnerabilities[0].is_kev,
+        "a non-KEV CVE must stay unflagged"
+    );
+}
+
+#[test]
+fn staleness_enrichment_feeds_lifecycle_metric() {
+    // A component carrying staleness data (as the staleness enricher would
+    // populate) must register in the Lifecycle quality metric.
+    let mut sbom = NormalizedSbom::default();
+
+    let mut fresh = Component::new("fresh-lib".to_string(), "fresh-lib@1.0.0".to_string())
+        .with_version("1.0.0".to_string());
+    fresh.staleness = Some(StalenessInfo::new(StalenessLevel::Fresh));
+    sbom.add_component(fresh);
+
+    let mut stale = Component::new("stale-lib".to_string(), "stale-lib@0.1.0".to_string())
+        .with_version("0.1.0".to_string());
+    let mut stale_info = StalenessInfo::new(StalenessLevel::Stale);
+    stale_info.is_deprecated = true;
+    stale.staleness = Some(stale_info);
+    sbom.add_component(stale);
+
+    let metrics = LifecycleMetrics::from_sbom(&sbom);
+
+    assert_eq!(
+        metrics.enriched_components, 2,
+        "both components have lifecycle (staleness) data"
+    );
+    assert_eq!(metrics.stale_components, 1, "one component is Stale");
+    assert!(
+        metrics.enrichment_coverage > 0.0,
+        "coverage must be non-zero so Lifecycle is no longer N/A"
+    );
+}
+
+fn bin_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_sbom-tools"))
+}
+
+fn write_sbom(dir: &std::path::Path, name: &str, components: &str) -> PathBuf {
+    let path = dir.join(name);
+    let body = format!(
+        r#"{{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {{ "timestamp": "2026-01-04T12:00:00Z" }},
+  {components}
+}}"#
+    );
+    std::fs::write(&path, body).unwrap();
+    path
+}
+
+#[test]
+fn diff_fail_on_kev_returns_exit_code_6() {
+    let server = MockServer::start();
+    server.mock(|when, then| {
+        when.method(GET).path("/kev.json");
+        then.status(200)
+            .json_body(kev_catalog_body("CVE-2021-44228"));
+    });
+    let cache_dir = tempfile::tempdir().unwrap();
+    let work = tempfile::tempdir().unwrap();
+
+    // Old SBOM has only lodash; new SBOM adds a log4j component carrying an
+    // embedded, KEV-listed CVE, so CVE-2021-44228 is "introduced".
+    let old = write_sbom(
+        work.path(),
+        "old.cdx.json",
+        r#""components": [
+    { "type": "library", "bom-ref": "lodash@4.17.21", "name": "lodash", "version": "4.17.21", "purl": "pkg:npm/lodash@4.17.21" }
+  ]"#,
+    );
+    let new = write_sbom(
+        work.path(),
+        "new.cdx.json",
+        r#""components": [
+    { "type": "library", "bom-ref": "lodash@4.17.21", "name": "lodash", "version": "4.17.21", "purl": "pkg:npm/lodash@4.17.21" },
+    { "type": "library", "bom-ref": "log4j@2.14.0", "name": "log4j", "version": "2.14.0", "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.0" }
+  ],
+  "vulnerabilities": [
+    {
+      "id": "CVE-2021-44228",
+      "source": { "name": "NVD" },
+      "ratings": [ { "score": 10.0, "severity": "critical", "method": "CVSSv31" } ],
+      "affects": [ { "ref": "log4j@2.14.0" } ]
+    }
+  ]"#,
+    );
+
+    let output = Command::new(bin_path())
+        .arg("--no-color")
+        .env("RUST_LOG", "error")
+        .env(
+            "SBOM_TOOLS_KEV_URL",
+            format!("{}/kev.json", server.base_url()),
+        )
+        .arg("diff")
+        .arg(&old)
+        .arg(&new)
+        .args(["-o", "summary"])
+        .args(["--kev", "--fail-on-kev", "--refresh"])
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .output()
+        .expect("diff command should run");
+
+    assert_eq!(
+        output.status.code(),
+        Some(6),
+        "introduced KEV vuln must yield exit code 6\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

`KevClient::enrich_vulnerabilities` and `StalenessEnricher::enrich_components` were complete but had **zero production callers** — `enable_kev`/`enable_staleness` were exported but consumed nowhere, and the pipeline only wired OSV/EOL/VEX. So `is_kev`/`kev_info`, the TUI KEV badges, diff `has_kev` grouping, and the Lifecycle quality category never populated, even though the rendering/grouping code already read those fields. CISA KEV is the canonical "actively exploited" signal for CRA Art.14 reporting. This PR builds on E1 (#230)'s `EnrichmentSource` + shared `JsonCache`.

- **Central wiring**: new `pipeline::enrich_kev` / `enrich_staleness`, sequenced in `enrich_sbom_full` behind `enable_kev`/`enable_staleness`. KEV runs after OSV (flags the vulns OSV found); staleness populates `Component::staleness`, which `LifecycleMetrics::from_sbom` already consumes.
- **Config**: `enable_kev`/`enable_staleness`/`kev_url` on `EnrichmentConfig`, `fail_on_kev` on `BehaviorConfig`, with builders.
- **CLI**: `--kev` and `--enrich-staleness` on the shared enrichment args, plumbed through `diff`/`view`/`quality`/`query`/`watch` (respecting the #227 config-precedence pattern). `--fail-on-kev` on `diff` with new exit code `KEV_INTRODUCED = 6` (does not collide with documented 0–5); it implies `--kev`. Hidden `--kev-url` / `SBOM_TOOLS_KEV_URL` test seam. `quality`/`query` now enrich before scoring/querying.
- **Surfacing**: KEV column in the introduced-vuln markdown table; fixed `VulnerabilityGroup::add_vulnerability` to propagate `is_kev` → `has_kev` so existing TUI badges and diff grouping light up.
- **Watch**: `new_kev` KEV-transition signal on `DiffSnapshot`, populated in the watch diff and emitted by the stdout/ndjson/webhook sinks.

Out of scope (separate PRs): EPSS (E3), offline mode (E4).

## Test plan

New `tests/kev_staleness_tests.rs`:
- httpmock KEV-catalog fixture asserting `is_kev`/`kev_info` get set on a matching vuln through `enrich_sbom_full` (and a non-KEV CVE stays unflagged).
- `--fail-on-kev` exit-code-6 `CARGO_BIN_EXE` test (mock KEV catalog via `SBOM_TOOLS_KEV_URL`).
- staleness-feeds-Lifecycle test.

Plus unit tests for `has_kev` propagation and the ndjson `new_kev` field.

- `cargo test --features enrichment`: 895 lib + all integration tests green.
- `cargo test` (default features): green.
- `cargo clippy` / `--all-features` / `--no-default-features --features ffi`: 0 warnings on 1.88.
- `cargo build` + `cargo check --no-default-features --features ffi`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)