### PR TITLE
perf(pipeline): in-place enrichment mutation + lazy report compliance

### DIFF
--- a/src/pipeline/parse.rs
+++ b/src/pipeline/parse.rs
@@ -170,6 +170,32 @@ pub fn build_enrichment_config(
     osv_config
 }
 
+/// Run an enricher over an SBOM's components without deep-cloning the map.
+///
+/// `NormalizedSbom::components` is an `IndexMap<CanonicalId, Component>`; the
+/// enricher APIs all want a contiguous `&mut [Component]` slice, which the map's
+/// non-contiguous bucket storage cannot provide directly. Rather than the old
+/// pattern of `values().cloned().collect()` (a full deep clone of every
+/// component — doubling peak memory) followed by a reinsert, this moves the
+/// entries out (`mem::take`, no clone), splits them into a key vec plus a
+/// component slice the enricher mutates in place, then re-zips the original
+/// keys back. Keys are never cloned and component values are moved, not cloned.
+///
+/// The enricher must not change any component's `canonical_id`; the OSV/EOL/
+/// staleness enrichers only populate `vulnerabilities`/`eol`/`staleness`, so the
+/// key↔value pairing is preserved by index.
+#[cfg(feature = "enrichment")]
+fn enrich_components_in_place<S, E, F>(sbom: &mut NormalizedSbom, enrich: F) -> Result<S, E>
+where
+    F: FnOnce(&mut [crate::model::Component]) -> Result<S, E>,
+{
+    let (keys, mut comps): (Vec<_>, Vec<crate::model::Component>) =
+        std::mem::take(&mut sbom.components).into_iter().unzip();
+    let result = enrich(&mut comps);
+    sbom.components = keys.into_iter().zip(comps).collect();
+    result
+}
+
 /// Enrich an SBOM with vulnerability data from OSV
 #[cfg(feature = "enrichment")]
 pub fn enrich_sbom(
@@ -193,21 +219,13 @@ pub fn enrich_sbom(
                 return None;
             }
 
-            // Get mutable references to components
-            let components: Vec<_> = sbom.components.values().cloned().collect();
-            let mut comp_vec: Vec<_> = components;
-
-            match enricher.enrich(&mut comp_vec) {
+            match enrich_components_in_place(sbom, |comps| enricher.enrich(comps)) {
                 Ok(stats) => {
                     if !quiet {
                         eprintln!(
                             "Enriched: {} components with vulns, {} total vulns found",
                             stats.components_with_vulns, stats.total_vulns_found
                         );
-                    }
-                    // Update SBOM with enriched components
-                    for comp in comp_vec {
-                        sbom.components.insert(comp.canonical_id.clone(), comp);
                     }
                     Some(stats)
                 }
@@ -239,10 +257,7 @@ pub fn enrich_eol(
 
     match EolEnricher::new(config.clone()) {
         Ok(mut enricher) => {
-            let components: Vec<_> = sbom.components.values().cloned().collect();
-            let mut comp_vec = components;
-
-            match enricher.enrich_components(&mut comp_vec) {
+            match enrich_components_in_place(sbom, |comps| enricher.enrich_components(comps)) {
                 Ok(stats) => {
                     if !quiet {
                         eprintln!(
@@ -253,10 +268,6 @@ pub fn enrich_eol(
                             stats.supported_count,
                             stats.skipped_count,
                         );
-                    }
-                    // Update SBOM with enriched components
-                    for comp in comp_vec {
-                        sbom.components.insert(comp.canonical_id.clone(), comp);
                     }
                     Some(stats)
                 }
@@ -360,9 +371,8 @@ pub fn enrich_staleness(
     }
 
     let mut enricher = StalenessEnricher::new(config.clone());
-    let mut comp_vec: Vec<_> = sbom.components.values().cloned().collect();
 
-    match enricher.enrich_components(&mut comp_vec) {
+    match enrich_components_in_place(sbom, |comps| enricher.enrich_components(comps)) {
         Ok(stats) => {
             if !quiet {
                 eprintln!(
@@ -373,9 +383,6 @@ pub fn enrich_staleness(
                     stats.deprecated_count,
                     stats.skipped_count,
                 );
-            }
-            for comp in comp_vec {
-                sbom.components.insert(comp.canonical_id.clone(), comp);
             }
             Some(stats)
         }
@@ -430,6 +437,54 @@ pub fn enrich_vex(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "enrichment")]
+    #[test]
+    fn test_enrich_components_in_place_preserves_pairing() {
+        use crate::model::{Component, VulnerabilityRef, VulnerabilitySource};
+
+        // Three distinct components in a known insertion order.
+        let mut sbom = NormalizedSbom::default();
+        for name in ["alpha", "bravo", "charlie"] {
+            sbom.add_component(Component::new(name.to_string(), format!("pkg:test/{name}")));
+        }
+        assert_eq!(sbom.component_count(), 3);
+
+        // Enricher that only touches indices 0 and 2 — mirrors how the real
+        // enrichers mutate a subset of the `&mut [Component]` slice in place.
+        let result: Result<usize, std::convert::Infallible> =
+            enrich_components_in_place(&mut sbom, |comps| {
+                assert_eq!(comps.len(), 3);
+                comps[0].vulnerabilities.push(VulnerabilityRef::new(
+                    "CVE-A".into(),
+                    VulnerabilitySource::Cve,
+                ));
+                comps[2].vulnerabilities.push(VulnerabilityRef::new(
+                    "CVE-C".into(),
+                    VulnerabilitySource::Cve,
+                ));
+                Ok(comps.len())
+            });
+        assert_eq!(result.unwrap(), 3);
+
+        // Count, order, and key↔value pairing must survive the move-out/write-back.
+        assert_eq!(sbom.component_count(), 3);
+        let by_name: std::collections::HashMap<&str, &Component> = sbom
+            .components
+            .values()
+            .map(|c| (c.name.as_str(), c))
+            .collect();
+        assert_eq!(by_name["alpha"].vulnerabilities.len(), 1);
+        assert_eq!(by_name["alpha"].vulnerabilities[0].id, "CVE-A");
+        assert!(by_name["bravo"].vulnerabilities.is_empty());
+        assert_eq!(by_name["charlie"].vulnerabilities.len(), 1);
+        assert_eq!(by_name["charlie"].vulnerabilities[0].id, "CVE-C");
+
+        // Each component still maps to its own canonical id (no key/value swap).
+        for (id, comp) in &sbom.components {
+            assert_eq!(*id, comp.canonical_id);
+        }
+    }
 
     #[test]
     fn test_parsed_sbom_creation() {

--- a/src/pipeline/report_stage.rs
+++ b/src/pipeline/report_stage.rs
@@ -28,11 +28,28 @@ pub fn output_report(
     let output_target = OutputTarget::from_option(config.output.file.clone());
     let effective_output = auto_detect_format(config.output.format, &output_target);
 
-    // Pre-compute CRA compliance once, pass to reporters to avoid redundant checks
-    let cra_checker =
-        crate::quality::ComplianceChecker::new(crate::quality::ComplianceLevel::CraPhase2);
-    let old_cra = cra_checker.check(old_sbom);
-    let new_cra = cra_checker.check(new_sbom);
+    // Check if we should use streaming mode for JSON output. Decided up front so
+    // the compliance gate below can also skip the streaming JSON path, whose
+    // reporter does not emit CRA compliance.
+    let use_streaming = should_use_streaming(config) && effective_output == ReportFormat::Json;
+
+    // Pre-compute CRA (Phase 2) compliance once and pass it to the reporter so it
+    // doesn't recompute per SBOM — but ONLY for formats that actually render it.
+    // Compliance-free formats (summary/table/csv/side-by-side/ndjson, and the
+    // streaming JSON path) never read these fields, so running the checker for
+    // them is wasted O(V+E) work on both SBOMs. Consuming reporters fall back to
+    // computing it themselves when the field is `None`, so leaving it unset for
+    // non-consuming formats is output-identical.
+    let (old_cra, new_cra) = if !use_streaming && format_uses_compliance(effective_output) {
+        let cra_checker =
+            crate::quality::ComplianceChecker::new(crate::quality::ComplianceLevel::CraPhase2);
+        (
+            Some(cra_checker.check(old_sbom)),
+            Some(cra_checker.check(new_sbom)),
+        )
+    } else {
+        (None, None)
+    };
 
     let report_config = ReportConfig {
         report_types: vec![config.output.report_types],
@@ -48,13 +65,10 @@ pub fn output_report(
             new_sbom_path: Some(config.paths.new.to_string_lossy().to_string()),
             ..Default::default()
         },
-        old_cra_compliance: Some(old_cra),
-        new_cra_compliance: Some(new_cra),
+        old_cra_compliance: old_cra,
+        new_cra_compliance: new_cra,
         ..Default::default()
     };
-
-    // Check if we should use streaming mode for JSON output
-    let use_streaming = should_use_streaming(config) && effective_output == ReportFormat::Json;
 
     if use_streaming {
         if !config.behavior.quiet {
@@ -68,6 +82,22 @@ pub fn output_report(
     let report = reporter.generate_diff_report(result, old_sbom, new_sbom, &report_config)?;
 
     write_output(&report, &output_target, config.behavior.quiet)
+}
+
+/// Whether a report format renders the pre-computed CRA compliance results.
+///
+/// Only Markdown, HTML, non-streaming JSON, and SARIF read
+/// `ReportConfig::{old,new}_cra_compliance`; every other format
+/// (summary/table/csv/side-by-side/ndjson/streaming-JSON, plus TUI/auto which
+/// don't reach this stage) ignores them, so pre-computing compliance for those
+/// is wasted work. Consuming reporters fall back to computing compliance
+/// themselves when the field is unset, so this gate only changes *where* the
+/// work happens for consumers (here vs. in the reporter) — never the output.
+const fn format_uses_compliance(format: ReportFormat) -> bool {
+    matches!(
+        format,
+        ReportFormat::Markdown | ReportFormat::Html | ReportFormat::Json | ReportFormat::Sarif
+    )
 }
 
 /// Check if streaming mode should be used based on file sizes and config.
@@ -108,4 +138,63 @@ fn output_streaming(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compliance_consuming_formats_are_gated() {
+        // Exactly the formats whose reporters read the cra_compliance fields.
+        assert!(format_uses_compliance(ReportFormat::Markdown));
+        assert!(format_uses_compliance(ReportFormat::Html));
+        assert!(format_uses_compliance(ReportFormat::Json));
+        assert!(format_uses_compliance(ReportFormat::Sarif));
+        // Everything else ignores compliance, so pre-computing it is wasted work.
+        assert!(!format_uses_compliance(ReportFormat::Summary));
+        assert!(!format_uses_compliance(ReportFormat::Table));
+        assert!(!format_uses_compliance(ReportFormat::Csv));
+        assert!(!format_uses_compliance(ReportFormat::SideBySide));
+        assert!(!format_uses_compliance(ReportFormat::Ndjson));
+    }
+
+    /// A compliance-free format must render identically whether or not the
+    /// pre-computed compliance results are supplied — proving that gating the
+    /// `ComplianceChecker` off for such formats is output-preserving.
+    #[test]
+    fn compliance_free_format_output_is_independent_of_compliance() {
+        use crate::quality::{ComplianceChecker, ComplianceLevel};
+
+        let result = DiffResult::default();
+        let old_sbom = NormalizedSbom::default();
+        let new_sbom = NormalizedSbom::default();
+
+        let make_config = |with_compliance: bool| {
+            let (old_cra, new_cra) = if with_compliance {
+                let checker = ComplianceChecker::new(ComplianceLevel::CraPhase2);
+                (
+                    Some(checker.check(&old_sbom)),
+                    Some(checker.check(&new_sbom)),
+                )
+            } else {
+                (None, None)
+            };
+            ReportConfig {
+                old_cra_compliance: old_cra,
+                new_cra_compliance: new_cra,
+                ..Default::default()
+            }
+        };
+
+        // Summary is a non-consumer: gated path (None) vs eager path (Some).
+        let reporter = create_reporter_with_options(ReportFormat::Summary, false);
+        let gated = reporter
+            .generate_diff_report(&result, &old_sbom, &new_sbom, &make_config(false))
+            .expect("gated summary report");
+        let eager = reporter
+            .generate_diff_report(&result, &old_sbom, &new_sbom, &make_config(true))
+            .expect("eager summary report");
+        assert_eq!(gated, eager, "summary output must not depend on compliance");
+    }
 }


### PR DESCRIPTION
## Summary

Two small, separable allocation/compute wins on the shared enrichment + report path.

**(a) In-place enrichment — `src/pipeline/parse.rs`**

`enrich_sbom` (OSV), `enrich_eol`, and `enrich_staleness` each ran `sbom.components.values().cloned().collect::<Vec<_>>()` — a full deep clone of every `Component` (each carries Vecs of vulns/hashes/refs plus several Strings) — then re-inserted the enriched copies key-by-key, rehashing the whole map. On a large SBOM this doubled peak memory per pass and cloned the entire component set up to three times (OSV + EOL + staleness).

A new shared helper `enrich_components_in_place` (`parse.rs`) `mem::take`s the `IndexMap`, `unzip`s it into a keys vec plus a `&mut [Component]` slice the enricher mutates in place, then re-zips the original keys back. `IndexMap` stores values in non-contiguous buckets, so a contiguous `&mut [Component]` can't come straight from `values_mut()`; the move-out/write-back gives the enrichers the slice they need with **no per-component clone and no key clone**. The enrichers only populate `vulnerabilities`/`eol`/`staleness` (never `canonical_id`), so the key↔value pairing is preserved by index — behavior is identical.

**(b) Lazy report compliance — `src/pipeline/report_stage.rs`**

`output_report` unconditionally ran `ComplianceChecker` (CRA Phase 2) on **both** SBOMs for every format, even though only Markdown / HTML / non-streaming-JSON / SARIF render the result (summary, table, csv, side-by-side, ndjson, and `StreamingJsonReporter` never read the `cra_compliance` fields). Added a `format_uses_compliance` predicate and gated the two checks behind it (and behind `!use_streaming`). Consuming reporters already fall back to `unwrap_or_else(|| ComplianceChecker::new(..).check(sbom))` when the field is `None`, so output is unchanged for every format — non-consumers just skip the wasted O(V+E) work.

## Test plan

- New `parse.rs` test: 3-component SBOM, an enricher closure touches only indices 0 and 2, then asserts vulns land on the right components and every key still maps to its own `canonical_id` (proves the move-out/write-back preserves pairing & order).
- New `report_stage.rs` tests: predicate consistency (exactly md/html/json/sarif gated on), and that the Summary reporter renders byte-identically with vs without precomputed compliance.
- `rustup run 1.88 cargo test --features enrichment` — full suite green (898 lib + integration incl. `cra_golden_fixtures`, `cra_readiness`, `golden_fixtures`, `integration_tests`).
- No-feature `cargo test --lib pipeline::` green.
- `rustup run 1.88 cargo clippy --features enrichment` — 0 new warnings vs HEAD (36 == 36 baseline false-positives).
- No new dependencies; `cargo fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)