### PR TITLE
feat(enrichment): offline mode + cache management subcommand

### DIFF
--- a/src/cli/cache.rs
+++ b/src/cli/cache.rs
@@ -1,0 +1,364 @@
+//! CLI handler for the `cache` command.
+//!
+//! Manages the on-disk enrichment cache so that air-gapped (`--offline`) runs
+//! are fully served from local data:
+//!
+//! - `cache status` — list cached sources, entry counts, ages, total size.
+//! - `cache warm <sbom>` — pre-fetch enrichment data for an SBOM's components.
+//! - `cache clear` — remove all cached entries.
+//! - `cache export <path>` / `cache import <path>` — copy the whole cache tree
+//!   for sneakernet transfer between an online and an air-gapped machine.
+//!
+//! Export/import use a plain recursive directory copy (no archive format, no new
+//! dependency): the cache is already a tree of small JSON files, so a directory
+//! copy is the simplest portable bundle and keeps the tool dependency-free under
+//! cargo-deny. The destination is a self-contained `sbom-tools` cache tree the
+//! `--offline` reader consumes directly.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+
+use crate::enrichment::source::root_cache_dir;
+use crate::pipeline::exit_codes;
+
+/// Cache management action.
+#[derive(Debug, Clone, clap::Subcommand)]
+pub enum CacheAction {
+    /// List cached sources with entry counts, ages, and total size
+    Status,
+    /// Pre-fetch enrichment data for an SBOM so a later --offline run is served
+    Warm {
+        /// SBOM file to warm the cache for
+        sbom: PathBuf,
+        /// Warm every source (OSV, EOL, KEV, staleness), not just OSV
+        #[arg(long)]
+        all_sources: bool,
+    },
+    /// Remove all cached enrichment entries
+    Clear,
+    /// Copy the whole cache tree to a directory for sneakernet transfer
+    Export {
+        /// Destination directory (created if absent)
+        path: PathBuf,
+    },
+    /// Import a previously exported cache tree into the local cache
+    Import {
+        /// Source directory produced by `cache export`
+        path: PathBuf,
+    },
+}
+
+/// Run the `cache` command.
+pub fn run_cache(action: CacheAction, quiet: bool) -> Result<i32> {
+    match action {
+        CacheAction::Status => cache_status(quiet),
+        CacheAction::Warm { sbom, all_sources } => cache_warm(&sbom, all_sources, quiet),
+        CacheAction::Clear => cache_clear(quiet),
+        CacheAction::Export { path } => cache_export(&path, quiet),
+        CacheAction::Import { path } => cache_import(&path, quiet),
+    }
+}
+
+/// The enrichment source namespaces that live under the root cache directory.
+const SOURCE_NAMESPACES: &[&str] = &["osv", "eol", "kev", "staleness"];
+
+/// Aggregate counts for one source's cache directory.
+struct SourceStatus {
+    name: String,
+    entries: usize,
+    total_size: u64,
+    oldest: Option<Duration>,
+    newest: Option<Duration>,
+}
+
+fn source_status(name: &str, dir: &Path) -> SourceStatus {
+    let mut entries = 0usize;
+    let mut total_size = 0u64;
+    let mut oldest: Option<Duration> = None;
+    let mut newest: Option<Duration> = None;
+
+    if let Ok(read_dir) = fs::read_dir(dir) {
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            if path.extension().is_none_or(|e| e != "json") {
+                continue;
+            }
+            entries += 1;
+            if let Ok(meta) = entry.metadata() {
+                total_size += meta.len();
+                if let Ok(modified) = meta.modified()
+                    && let Ok(age) = modified.elapsed()
+                {
+                    oldest = Some(oldest.map_or(age, |o| o.max(age)));
+                    newest = Some(newest.map_or(age, |n| n.min(age)));
+                }
+            }
+        }
+    }
+
+    SourceStatus {
+        name: name.to_string(),
+        entries,
+        total_size,
+        oldest,
+        newest,
+    }
+}
+
+fn cache_status(quiet: bool) -> Result<i32> {
+    let root = root_cache_dir();
+    if !root.exists() {
+        if !quiet {
+            println!("No cache directory yet ({}).", root.display());
+        }
+        return Ok(exit_codes::SUCCESS);
+    }
+
+    let mut total_entries = 0usize;
+    let mut total_size = 0u64;
+    let mut rows: Vec<SourceStatus> = Vec::new();
+    for ns in SOURCE_NAMESPACES {
+        let dir = root.join(ns);
+        if dir.exists() {
+            let status = source_status(ns, &dir);
+            total_entries += status.entries;
+            total_size += status.total_size;
+            rows.push(status);
+        }
+    }
+
+    if quiet {
+        return Ok(exit_codes::SUCCESS);
+    }
+
+    println!("Cache directory: {}", root.display());
+    if rows.is_empty() {
+        println!("  (no cached enrichment data)");
+        return Ok(exit_codes::SUCCESS);
+    }
+
+    println!(
+        "{:<12} {:>8} {:>12} {:>12} {:>12}",
+        "SOURCE", "ENTRIES", "SIZE", "OLDEST", "NEWEST"
+    );
+    for row in &rows {
+        println!(
+            "{:<12} {:>8} {:>12} {:>12} {:>12}",
+            row.name,
+            row.entries,
+            human_size(row.total_size),
+            row.oldest.map_or_else(|| "-".to_string(), human_age),
+            row.newest.map_or_else(|| "-".to_string(), human_age),
+        );
+    }
+    println!(
+        "{:<12} {:>8} {:>12}",
+        "TOTAL",
+        total_entries,
+        human_size(total_size)
+    );
+
+    Ok(exit_codes::SUCCESS)
+}
+
+/// Warm the cache by enriching the SBOM with all (or just OSV) sources, forcing
+/// fresh fetches so the on-disk cache is fully populated for a later offline run.
+fn cache_warm(sbom_path: &Path, all_sources: bool, quiet: bool) -> Result<i32> {
+    use crate::config::EnrichmentConfig;
+
+    // Warming requires the network, so it must not run in offline mode.
+    if crate::enrichment::source::is_offline() {
+        anyhow::bail!("cannot warm the cache in offline mode: run `cache warm` while online");
+    }
+
+    let mut parsed = crate::pipeline::parse_sbom_with_context(sbom_path, quiet)?;
+
+    let mut config = EnrichmentConfig::osv();
+    config.enable_eol = all_sources;
+    config.enable_kev = all_sources;
+    config.enable_staleness = all_sources;
+    // Force fresh fetches so every queryable component lands in the cache.
+    config.bypass_cache = true;
+    config.offline = false;
+
+    let stats = crate::pipeline::enrich_sbom_full(parsed.sbom_mut(), &config, quiet);
+
+    if !quiet {
+        for warning in &stats.warnings {
+            eprintln!("Warning: {warning}");
+        }
+        let n = parsed.sbom().component_count();
+        println!(
+            "Warmed cache for {n} component(s) from {} ({}).",
+            sbom_path.display(),
+            if all_sources {
+                "OSV, EOL, KEV, staleness"
+            } else {
+                "OSV"
+            }
+        );
+    }
+
+    Ok(exit_codes::SUCCESS)
+}
+
+fn cache_clear(quiet: bool) -> Result<i32> {
+    let root = root_cache_dir();
+    if !root.exists() {
+        if !quiet {
+            println!("Nothing to clear ({} does not exist).", root.display());
+        }
+        return Ok(exit_codes::SUCCESS);
+    }
+
+    let mut removed = 0usize;
+    for ns in SOURCE_NAMESPACES {
+        let dir = root.join(ns);
+        if let Ok(read_dir) = fs::read_dir(&dir) {
+            for entry in read_dir.flatten() {
+                let path = entry.path();
+                if path.extension().is_some_and(|e| e == "json") && fs::remove_file(&path).is_ok() {
+                    removed += 1;
+                }
+            }
+        }
+    }
+
+    if !quiet {
+        println!("Cleared {removed} cached entr{}.", plural(removed));
+    }
+    Ok(exit_codes::SUCCESS)
+}
+
+fn cache_export(dest: &Path, quiet: bool) -> Result<i32> {
+    let root = root_cache_dir();
+    if !root.exists() {
+        anyhow::bail!("no cache to export ({} does not exist)", root.display());
+    }
+
+    fs::create_dir_all(dest)
+        .with_context(|| format!("creating export directory {}", dest.display()))?;
+    let copied = copy_dir_recursive(&root, dest)?;
+
+    if !quiet {
+        println!(
+            "Exported {copied} cache file(s) to {} (copy this to the air-gapped host, then `cache import`).",
+            dest.display()
+        );
+    }
+    Ok(exit_codes::SUCCESS)
+}
+
+fn cache_import(src: &Path, quiet: bool) -> Result<i32> {
+    if !src.exists() {
+        anyhow::bail!("import source {} does not exist", src.display());
+    }
+
+    let root = root_cache_dir();
+    fs::create_dir_all(&root)
+        .with_context(|| format!("creating cache directory {}", root.display()))?;
+    let copied = copy_dir_recursive(src, &root)?;
+
+    if !quiet {
+        println!(
+            "Imported {copied} cache file(s) into {}. Run with --offline to use them.",
+            root.display()
+        );
+    }
+    Ok(exit_codes::SUCCESS)
+}
+
+/// Recursively copy every file from `src` into `dest`, mirroring the directory
+/// structure. Returns the number of files copied.
+fn copy_dir_recursive(src: &Path, dest: &Path) -> Result<usize> {
+    let mut copied = 0usize;
+    for entry in
+        fs::read_dir(src).with_context(|| format!("reading directory {}", src.display()))?
+    {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let from = entry.path();
+        let to = dest.join(entry.file_name());
+        if file_type.is_dir() {
+            fs::create_dir_all(&to).with_context(|| format!("creating {}", to.display()))?;
+            copied += copy_dir_recursive(&from, &to)?;
+        } else if file_type.is_file() {
+            if let Some(parent) = to.parent() {
+                fs::create_dir_all(parent).ok();
+            }
+            fs::copy(&from, &to)
+                .with_context(|| format!("copying {} -> {}", from.display(), to.display()))?;
+            copied += 1;
+        }
+    }
+    Ok(copied)
+}
+
+/// Human-readable byte size (e.g. `12.3 KB`).
+fn human_size(bytes: u64) -> String {
+    const KB: f64 = 1024.0;
+    const MB: f64 = KB * 1024.0;
+    let b = bytes as f64;
+    if b >= MB {
+        format!("{:.1} MB", b / MB)
+    } else if b >= KB {
+        format!("{:.1} KB", b / KB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+/// Human-readable age (e.g. `3d`, `5h`, `12m`, `<1m`).
+fn human_age(age: Duration) -> String {
+    let secs = age.as_secs();
+    if secs >= 86_400 {
+        format!("{}d", secs / 86_400)
+    } else if secs >= 3_600 {
+        format!("{}h", secs / 3_600)
+    } else if secs >= 60 {
+        format!("{}m", secs / 60)
+    } else {
+        "<1m".to_string()
+    }
+}
+
+const fn plural(n: usize) -> &'static str {
+    if n == 1 { "y" } else { "ies" }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn human_size_formats() {
+        assert_eq!(human_size(512), "512 B");
+        assert_eq!(human_size(2048), "2.0 KB");
+        assert_eq!(human_size(3 * 1024 * 1024), "3.0 MB");
+    }
+
+    #[test]
+    fn human_age_formats() {
+        assert_eq!(human_age(Duration::from_secs(30)), "<1m");
+        assert_eq!(human_age(Duration::from_secs(120)), "2m");
+        assert_eq!(human_age(Duration::from_secs(7200)), "2h");
+        assert_eq!(human_age(Duration::from_secs(2 * 86_400)), "2d");
+    }
+
+    #[test]
+    fn copy_dir_recursive_roundtrip() {
+        let src = tempfile::tempdir().unwrap();
+        let dst = tempfile::tempdir().unwrap();
+        fs::create_dir_all(src.path().join("osv")).unwrap();
+        fs::write(src.path().join("osv").join("a.json"), "{}").unwrap();
+        fs::write(src.path().join("osv").join("b.json"), "{}").unwrap();
+
+        let copied = copy_dir_recursive(src.path(), dst.path()).unwrap();
+        assert_eq!(copied, 2);
+        assert!(dst.path().join("osv").join("a.json").exists());
+        assert!(dst.path().join("osv").join("b.json").exists());
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,6 +3,8 @@
 //! This module provides testable command handlers that are invoked by main.rs.
 //! Each handler implements the business logic for a specific CLI subcommand.
 
+#[cfg(feature = "enrichment")]
+mod cache;
 mod cra_docs;
 mod cra_standards_watch;
 mod diff;
@@ -20,6 +22,8 @@ mod vex;
 mod view;
 mod watch;
 
+#[cfg(feature = "enrichment")]
+pub use cache::{CacheAction, run_cache};
 pub use cra_docs::run_cra_docs;
 pub use cra_standards_watch::{
     OnlineProbe, TrackedStandard, WatchOutputFormat, cra_catalogue, probe_cra_standards,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -827,6 +827,10 @@ pub struct EnrichmentConfig {
     /// Primarily a test seam for pointing the EPSS enricher at a mock server.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub epss_url: Option<String>,
+    /// Offline mode: never make network calls. Enrichment is served purely
+    /// from cache (including TTL-expired entries, with a staleness warning).
+    #[serde(default)]
+    pub offline: bool,
 }
 
 impl Default for EnrichmentConfig {
@@ -847,6 +851,7 @@ impl Default for EnrichmentConfig {
             api_base: None,
             kev_url: None,
             epss_url: None,
+            offline: false,
         }
     }
 }
@@ -936,6 +941,13 @@ impl EnrichmentConfig {
     #[must_use]
     pub const fn with_staleness(mut self) -> Self {
         self.enable_staleness = true;
+        self
+    }
+
+    /// Enable offline mode (serve enrichment purely from cache).
+    #[must_use]
+    pub const fn with_offline(mut self) -> Self {
+        self.offline = true;
         self
     }
 }

--- a/src/enrichment/eol/client.rs
+++ b/src/enrichment/eol/client.rs
@@ -179,6 +179,8 @@ impl EolClient {
         }
 
         let url = format!("{}/api/all.json", self.config.base_url);
+        crate::enrichment::source::offline_guard(&url)
+            .map_err(|e| EnrichmentError::Offline(e.to_string()))?;
         let client = crate::enrichment::source::http_client(self.config.timeout)
             .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
 
@@ -233,6 +235,8 @@ impl EolClient {
         }
 
         let url = format!("{}/api/{}.json", self.config.base_url, product);
+        crate::enrichment::source::offline_guard(&url)
+            .map_err(|e| EnrichmentError::Offline(e.to_string()))?;
         let client = crate::enrichment::source::http_client(self.config.timeout)
             .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
 
@@ -309,11 +313,24 @@ pub struct EolEnricher {
 impl EolEnricher {
     /// Create a new EOL enricher.
     ///
-    /// Fetches the product list from the API (or cache) and initializes the mapper.
+    /// Fetches the product list from the API (or cache) and initializes the
+    /// mapper. In offline mode the product-list fetch is served from cache when
+    /// present; when it is not cached the enricher is still constructed with an
+    /// empty product list so an `--offline` run degrades gracefully (every
+    /// component is skipped) rather than failing outright.
     pub fn new(config: EolClientConfig) -> Result<Self, EnrichmentError> {
         let client = EolClient::new(config);
         let mut stats = EolEnrichmentStats::default();
-        let product_list = client.fetch_product_list(&mut stats)?;
+        let product_list = match client.fetch_product_list(&mut stats) {
+            Ok(list) => list,
+            Err(EnrichmentError::Offline(_)) if crate::enrichment::source::is_offline() => {
+                tracing::warn!(
+                    "EOL product list not in cache while offline; EOL enrichment will be skipped"
+                );
+                Vec::new()
+            }
+            Err(e) => return Err(e),
+        };
         let mapper = ProductMapper::new(product_list);
 
         Ok(Self {

--- a/src/enrichment/kev/client.rs
+++ b/src/enrichment/kev/client.rs
@@ -118,6 +118,8 @@ impl KevClient {
     /// Fetch catalog from CISA API
     #[cfg(feature = "enrichment")]
     fn fetch_from_api(&self) -> Result<KevCatalog, EnrichmentError> {
+        crate::enrichment::source::offline_guard(&self.config.kev_url)
+            .map_err(|e| EnrichmentError::Offline(e.to_string()))?;
         let client = crate::enrichment::source::http_client(self.config.timeout)
             .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
 

--- a/src/enrichment/osv/client.rs
+++ b/src/enrichment/osv/client.rs
@@ -58,8 +58,7 @@ impl OsvClient {
     /// Check if the OSV API is available.
     pub fn health_check(&self) -> Result<bool> {
         let url = format!("{}/v1/vulns/OSV-2020-1", self.config.api_base);
-        let response = get_with_retry(&self.client, &url, self.config.max_retries)
-            .map_err(|e| network_error("Health check request failed", &e))?;
+        let response = get_with_retry(&self.client, &url, self.config.max_retries)?;
         Ok(response.status().is_success() || response.status().as_u16() == 404)
     }
 
@@ -116,6 +115,7 @@ impl OsvClient {
         url: &str,
         request_body: &OsvBatchRequest,
     ) -> Result<OsvBatchResponse> {
+        crate::enrichment::source::offline_guard(url)?;
         let response = self
             .client
             .post(url)
@@ -150,8 +150,7 @@ impl OsvClient {
     ) -> Result<Option<super::response::OsvVulnerability>> {
         let url = format!("{}/v1/vulns/{}", self.config.api_base, vuln_id);
 
-        let response = get_with_retry(&self.client, &url, self.config.max_retries)
-            .map_err(|e| network_error("Failed to fetch vulnerability", &e))?;
+        let response = get_with_retry(&self.client, &url, self.config.max_retries)?;
 
         if response.status().as_u16() == 404 {
             return Ok(None);

--- a/src/enrichment/source.rs
+++ b/src/enrichment/source.rs
@@ -21,7 +21,30 @@ use serde::de::DeserializeOwned;
 use sha2::{Digest, Sha256};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
+
+/// Process-global offline switch.
+///
+/// In air-gapped (CRA / FDA / defense) deployments the tool must serve
+/// enrichment data purely from cache and never attempt a network call. This is
+/// a process-wide flag rather than per-config because the HTTP choke point
+/// ([`http_client`]) and the cache ([`JsonCache`]) are reached through many
+/// independently-constructed source configs; threading a bool through every one
+/// would be invasive and easy to miss. It is set once, early, from the global
+/// `--offline` flag / `SBOM_TOOLS_OFFLINE` env.
+static OFFLINE: AtomicBool = AtomicBool::new(false);
+
+/// Enable or disable offline mode for the whole process.
+pub fn set_offline(offline: bool) {
+    OFFLINE.store(offline, Ordering::Relaxed);
+}
+
+/// Whether the process is running in offline mode.
+#[must_use]
+pub fn is_offline() -> bool {
+    OFFLINE.load(Ordering::Relaxed)
+}
 
 /// Schema version embedded in every cache envelope.
 ///
@@ -74,16 +97,26 @@ pub fn cache_dir() -> Option<PathBuf> {
     }
 }
 
+/// Root cache directory for all enrichment sources, i.e. `…/sbom-tools`.
+///
+/// This is the parent of every per-source namespace directory; the `cache`
+/// subcommand uses it to enumerate, size, export, and import the cache as a
+/// whole. Falls back to a `.cache`-relative path when no platform cache
+/// directory is available, matching [`namespaced_cache_dir`].
+#[must_use]
+pub fn root_cache_dir() -> PathBuf {
+    cache_dir()
+        .unwrap_or_else(|| PathBuf::from(".cache"))
+        .join("sbom-tools")
+}
+
 /// Cache directory for an enrichment source, e.g. `…/sbom-tools/osv`.
 ///
 /// Falls back to a `.cache`-relative path only when no platform cache
 /// directory is available, matching the previous per-source behavior.
 #[must_use]
 pub fn namespaced_cache_dir(namespace: &str) -> PathBuf {
-    cache_dir()
-        .unwrap_or_else(|| PathBuf::from(".cache"))
-        .join("sbom-tools")
-        .join(namespace)
+    root_cache_dir().join(namespace)
 }
 
 // ============================================================================
@@ -94,6 +127,23 @@ pub fn namespaced_cache_dir(namespace: &str) -> PathBuf {
 ///
 /// All sources share the same `CARGO_PKG_NAME/CARGO_PKG_VERSION` User-Agent so
 /// upstream registries see a single, identifiable client.
+/// Refuse a network operation when the process is in offline mode.
+///
+/// Building a [`reqwest`] client makes no network call, so [`http_client`] is
+/// not gated; the guard is applied at the request-dispatch layer
+/// ([`get_with_retry`] and each source's direct `.send()`) so that a warm cache
+/// is still served before any refusal. `what` describes the resource the caller
+/// was about to fetch, for a clear "offline: not in cache (<what>)" error.
+pub fn offline_guard(what: &str) -> Result<()> {
+    if is_offline() {
+        return Err(crate::error::SbomDiffError::enrichment(
+            "offline mode",
+            crate::error::EnrichmentErrorKind::Offline(what.to_string()),
+        ));
+    }
+    Ok(())
+}
+
 #[cfg(feature = "enrichment")]
 pub fn http_client(timeout: Duration) -> reqwest::Result<reqwest::blocking::Client> {
     reqwest::blocking::Client::builder()
@@ -148,13 +198,17 @@ fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
 /// `max_retries` times, honoring `Retry-After` on `429`. Non-retryable
 /// responses (including `4xx` other than `429`) are returned to the caller on
 /// the first attempt for status inspection.
+///
+/// In offline mode the request is refused up front with an
+/// [`EnrichmentErrorKind::Offline`](crate::error::EnrichmentErrorKind::Offline)
+/// error before any socket is opened.
 #[cfg(feature = "enrichment")]
 pub fn get_with_retry(
     client: &reqwest::blocking::Client,
     url: &str,
     max_retries: u8,
-) -> reqwest::Result<reqwest::blocking::Response> {
-    let mut last_err: Option<reqwest::Error> = None;
+) -> Result<reqwest::blocking::Response> {
+    offline_guard(url)?;
 
     for attempt in 0..=u32::from(max_retries) {
         if attempt > 0 {
@@ -180,16 +234,33 @@ pub fn get_with_retry(
             Err(e) => {
                 if attempt < u32::from(max_retries) {
                     std::thread::sleep(backoff_delay(attempt + 1, None));
-                    last_err = Some(e);
                     continue;
                 }
-                return Err(e);
+                return Err(network_error("request failed", &e));
             }
         }
     }
 
     // Unreachable in practice: the loop always returns on the final attempt.
-    Err(last_err.expect("retry loop returns on final attempt"))
+    Err(network_error_msg("retry loop returned no response"))
+}
+
+/// Wrap a [`reqwest::Error`] in our enrichment network-error variant.
+#[cfg(feature = "enrichment")]
+fn network_error(context: &str, err: &reqwest::Error) -> crate::error::SbomDiffError {
+    crate::error::SbomDiffError::enrichment(
+        context,
+        crate::error::EnrichmentErrorKind::NetworkError(err.to_string()),
+    )
+}
+
+/// Build a network-error variant from a bare message.
+#[cfg(feature = "enrichment")]
+fn network_error_msg(msg: &str) -> crate::error::SbomDiffError {
+    crate::error::SbomDiffError::enrichment(
+        "network",
+        crate::error::EnrichmentErrorKind::NetworkError(msg.to_string()),
+    )
 }
 
 // ============================================================================
@@ -307,24 +378,62 @@ where
     ///
     /// Returns `None` (evicting the file) when the entry is missing, older
     /// than the TTL, has a mismatched schema version, or fails to parse.
+    ///
+    /// One exception: in process-wide [offline](is_offline) mode a TTL-expired
+    /// entry is **served** (and *not* evicted) so an air-gapped run can fall
+    /// back to whatever data is on disk. A staleness warning is logged. The
+    /// online path is unchanged — expired entries are still evicted on read.
     #[must_use]
     pub fn get_named(&self, file_name: &str) -> Option<T> {
+        let (value, stale_by) = self.get_named_allow_stale(file_name)?;
+        if let Some(age) = stale_by {
+            tracing::warn!(
+                "serving stale cache entry {file_name}: {} day(s) past its TTL (offline mode)",
+                age.as_secs() / 86_400
+            );
+        }
+        Some(value)
+    }
+
+    /// Read a cached value, tolerating TTL expiry when offline.
+    ///
+    /// Returns the payload together with a staleness signal: `Some(age)` is the
+    /// amount the entry is *past* its TTL when it was served despite being
+    /// expired (only possible in offline mode), or `None` when the entry was
+    /// still fresh.
+    ///
+    /// Unlike [`get_named`](Self::get_named), this never logs; it is the
+    /// building block callers use when they want to surface the staleness
+    /// (e.g. as CRA evidence) rather than only warn.
+    #[must_use]
+    pub fn get_named_allow_stale(&self, file_name: &str) -> Option<(T, Option<Duration>)> {
         let path = self.path_for(file_name);
 
         let metadata = fs::metadata(&path).ok()?;
         let modified = metadata.modified().ok()?;
-        if modified.elapsed().ok()? > self.ttl {
-            let _ = fs::remove_file(&path);
-            return None;
+        let age = modified.elapsed().ok()?;
+        let mut stale_by = None;
+        if age > self.ttl {
+            // Online: an expired entry is a miss and is evicted on read (the
+            // E1 cache tests assert this). Offline: keep it and serve it so an
+            // air-gapped run has a stale-if-offline fallback.
+            if is_offline() {
+                stale_by = Some(age - self.ttl);
+            } else {
+                let _ = fs::remove_file(&path);
+                return None;
+            }
         }
 
         let data = fs::read_to_string(&path).ok()?;
         let envelope: CacheEnvelope<T> = serde_json::from_str(&data).ok()?;
         if envelope.schema_version != CACHE_SCHEMA_VERSION {
+            // A schema mismatch is a hard miss in every mode: the payload shape
+            // changed and must never be deserialized as the old one.
             let _ = fs::remove_file(&path);
             return None;
         }
-        Some(envelope.payload)
+        Some((envelope.payload, stale_by))
     }
 
     /// Atomically write a value under `file_name`.

--- a/src/enrichment/staleness/registry.rs
+++ b/src/enrichment/staleness/registry.rs
@@ -145,6 +145,8 @@ impl RegistryClient {
     fn query_npm(&self, name: &str) -> Result<Option<PackageMetadata>, EnrichmentError> {
         let url = format!("https://registry.npmjs.org/{name}");
 
+        crate::enrichment::source::offline_guard(&url)
+            .map_err(|e| EnrichmentError::Offline(e.to_string()))?;
         let client = crate::enrichment::source::http_client(self.config.timeout)
             .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
 
@@ -206,6 +208,8 @@ impl RegistryClient {
     fn query_pypi(&self, name: &str) -> Result<Option<PackageMetadata>, EnrichmentError> {
         let url = format!("https://pypi.org/pypi/{name}/json");
 
+        crate::enrichment::source::offline_guard(&url)
+            .map_err(|e| EnrichmentError::Offline(e.to_string()))?;
         let client = crate::enrichment::source::http_client(self.config.timeout)
             .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
 
@@ -284,6 +288,8 @@ impl RegistryClient {
     fn query_crates_io(&self, name: &str) -> Result<Option<PackageMetadata>, EnrichmentError> {
         let url = format!("https://crates.io/api/v1/crates/{name}");
 
+        crate::enrichment::source::offline_guard(&url)
+            .map_err(|e| EnrichmentError::Offline(e.to_string()))?;
         // The shared client already sends a CARGO_PKG_NAME/CARGO_PKG_VERSION
         // User-Agent, which satisfies the crates.io UA requirement.
         let client = crate::enrichment::source::http_client(self.config.timeout)

--- a/src/enrichment/stats.rs
+++ b/src/enrichment/stats.rs
@@ -98,6 +98,8 @@ pub enum EnrichmentError {
     Timeout,
     /// Component missing required identifiers
     MissingIdentifiers(String),
+    /// Offline mode: the requested resource was not in cache
+    Offline(String),
 }
 
 impl fmt::Display for EnrichmentError {
@@ -111,6 +113,7 @@ impl fmt::Display for EnrichmentError {
             Self::MissingIdentifiers(name) => {
                 write!(f, "Component '{name}' missing identifiers for query")
             }
+            Self::Offline(what) => write!(f, "offline: not in cache ({what})"),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -169,6 +169,9 @@ pub enum EnrichmentErrorKind {
 
     #[error("Provider unavailable: {0}")]
     ProviderUnavailable(String),
+
+    #[error("offline: not in cache ({0})")]
+    Offline(String),
 }
 
 // ============================================================================

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,12 @@ struct Cli {
     #[arg(long, global = true, conflicts_with = "config")]
     no_config: bool,
 
+    /// Offline mode: never make network calls; enrichment is served purely from
+    /// cache (including TTL-expired entries, with a staleness warning). For
+    /// air-gapped environments. Also settable via `SBOM_TOOLS_OFFLINE`.
+    #[arg(long, global = true, env = "SBOM_TOOLS_OFFLINE")]
+    offline: bool,
+
     #[command(subcommand)]
     command: Commands,
 }
@@ -229,6 +235,7 @@ fn seed_enrichment(
     args: &SharedEnrichmentArgs,
     sub: Option<&ArgMatches>,
     app: &AppConfig,
+    offline: bool,
 ) -> EnrichmentConfig {
     let cli = args.to_enrichment_config();
     let cli_touched = cli.enabled
@@ -242,10 +249,14 @@ fn seed_enrichment(
         || arg_was_set_sub(sub, "refresh_vulns")
         || !cli.vex_paths.is_empty();
 
-    match (&app.enrichment, cli_touched) {
+    let mut config = match (&app.enrichment, cli_touched) {
         (Some(file), false) => file.clone(),
         _ => cli,
-    }
+    };
+    // The global --offline flag (or config) wins; either layer enabling it is
+    // honored so an air-gapped config file can't be silently overridden.
+    config.offline = offline || config.offline;
+    config
 }
 
 /// Arguments for the `diff` subcommand
@@ -949,6 +960,13 @@ enum Commands {
         action: VerifyAction,
     },
 
+    /// Manage the enrichment cache (status, warm, clear, export, import)
+    #[cfg(feature = "enrichment")]
+    Cache {
+        #[command(subcommand)]
+        action: cli::CacheAction,
+    },
+
     /// Check license policy compliance
     LicenseCheck(LicenseCheckArgs),
 
@@ -976,8 +994,16 @@ impl Commands {
     /// Whether this command seeds a per-command config from the loaded
     /// `AppConfig`. Meta commands (config management, shell completions, man
     /// page, schema generation) don't, so a broken or missing config file must
-    /// never block them — they get a lenient (unvalidated) load instead.
+    /// never block them — they get a lenient (unvalidated) load instead. Cache
+    /// management is likewise config-independent (it only touches the on-disk
+    /// cache) and must stay usable for recovery even with a broken config.
     const fn consumes_config(&self) -> bool {
+        // Cache management is config-independent (it only touches the on-disk
+        // cache) and must stay usable for recovery even with a broken config.
+        #[cfg(feature = "enrichment")]
+        if matches!(self, Self::Cache { .. }) {
+            return false;
+        }
         !matches!(
             self,
             Self::Config { .. } | Self::Completions { .. } | Self::ConfigSchema { .. } | Self::Man
@@ -1348,6 +1374,15 @@ fn main() -> Result<()> {
         EffectiveConfig::load_lenient(cli.config.as_deref(), cli.no_config)
     };
     let app = effective.into_app_config();
+
+    // Resolve offline mode once: the global --offline flag (or
+    // SBOM_TOOLS_OFFLINE), OR the config file's enrichment.offline. Setting the
+    // process-wide switch here makes every code path — including the cache
+    // subcommand and watch loop — refuse network calls and serve stale cache.
+    let offline = cli.offline || app.enrichment.as_ref().is_some_and(|e| e.offline);
+    #[cfg(feature = "enrichment")]
+    sbom_tools::enrichment::source::set_offline(offline);
+
     // Per-subcommand argument matches, used to detect which CLI flags were set
     // explicitly (vs. left at their clap default).
     let sub_matches = matches.subcommand().map(|(_, m)| m);
@@ -1357,7 +1392,7 @@ fn main() -> Result<()> {
         Commands::Diff(args) => {
             let sm = sub_matches;
             let fail_on_kev = resolve_bool(args.fail_on_kev, app.behavior.fail_on_kev);
-            let mut enrichment = seed_enrichment(&args.enrichment, sm, &app);
+            let mut enrichment = seed_enrichment(&args.enrichment, sm, &app, offline);
             // --fail-on-kev is meaningless without KEV data, so it implies --kev.
             if fail_on_kev {
                 enrichment.enable_kev = true;
@@ -1466,7 +1501,7 @@ fn main() -> Result<()> {
 
         Commands::View(args) => {
             let sm = sub_matches;
-            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app, offline);
 
             let config = ViewConfig {
                 sbom_path: args.sbom,
@@ -1521,7 +1556,7 @@ fn main() -> Result<()> {
 
         Commands::DiffMulti(args) => {
             let sm = sub_matches;
-            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app, offline);
             let config = MultiDiffConfig {
                 baseline: args.baseline,
                 targets: args.targets,
@@ -1599,7 +1634,7 @@ fn main() -> Result<()> {
 
         Commands::Timeline(args) => {
             let sm = sub_matches;
-            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app, offline);
             let config = TimelineConfig {
                 sbom_paths: args.sboms,
                 output: OutputConfig {
@@ -1673,7 +1708,7 @@ fn main() -> Result<()> {
 
         Commands::Matrix(args) => {
             let sm = sub_matches;
-            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app, offline);
             let config = MatrixConfig {
                 sbom_paths: args.sboms,
                 output: OutputConfig {
@@ -1753,7 +1788,7 @@ fn main() -> Result<()> {
                 arg_was_set_sub(sm, "output"),
                 Some(app.output.format),
             );
-            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app, offline);
             let exit_code = cli::run_quality(
                 args.sbom,
                 args.profile,
@@ -1888,7 +1923,7 @@ fn main() -> Result<()> {
 
         Commands::Watch(args) => {
             let sm = sub_matches;
-            let enrichment = seed_enrichment(&args.enrichment, sm, &app);
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app, offline);
 
             let config = WatchConfig {
                 watch_dirs: args.dirs,
@@ -2048,6 +2083,15 @@ fn main() -> Result<()> {
             Ok(())
         }
 
+        #[cfg(feature = "enrichment")]
+        Commands::Cache { action } => {
+            let exit_code = cli::run_cache(action, cli.quiet)?;
+            if exit_code != 0 {
+                std::process::exit(exit_code);
+            }
+            Ok(())
+        }
+
         Commands::LicenseCheck(args) => {
             let exit_code = cli::run_license_check(
                 &args.file,
@@ -2065,7 +2109,8 @@ fn main() -> Result<()> {
 
         #[cfg(feature = "enrichment")]
         Commands::Enrich(args) => {
-            let enrichment = args.enrichment.to_enrichment_config();
+            let mut enrichment = args.enrichment.to_enrichment_config();
+            enrichment.offline = offline || enrichment.offline;
 
             let exit_code =
                 cli::run_enrich(&args.file, args.output_file.as_ref(), enrichment, cli.quiet)?;

--- a/src/pipeline/enrich.rs
+++ b/src/pipeline/enrich.rs
@@ -70,6 +70,17 @@ pub fn enrich_sbom_full(
 ) -> AggregatedEnrichmentStats {
     let mut stats = AggregatedEnrichmentStats::default();
 
+    // Honor offline mode regardless of entry point: the process-wide switch
+    // gates every source's network layer and flips cache reads to
+    // stale-if-offline. `main` already sets this for the CLI; setting it here
+    // makes library callers (and tests) offline-correct too.
+    crate::enrichment::source::set_offline(config.offline);
+    if config.offline && !quiet {
+        stats
+            .warnings
+            .push("Offline mode: enrichment served from cache only (no network)".into());
+    }
+
     // 1. OSV vulnerability enrichment
     if config.enabled {
         let osv_config = super::build_enrichment_config(config);

--- a/src/pipeline/parse.rs
+++ b/src/pipeline/parse.rs
@@ -214,7 +214,10 @@ pub fn enrich_sbom(
 
     match OsvEnricher::new(config.clone()) {
         Ok(enricher) => {
-            if !enricher.is_available() {
+            // The availability probe is a live network call. In offline mode it
+            // would always fail and wrongly skip cache-served enrichment, so it
+            // is bypassed: enrichment proceeds straight to the cache.
+            if !crate::enrichment::source::is_offline() && !enricher.is_available() {
                 eprintln!("Warning: OSV API unavailable, skipping vulnerability enrichment");
                 return None;
             }

--- a/tests/offline_cache_tests.rs
+++ b/tests/offline_cache_tests.rs
@@ -1,0 +1,499 @@
+//! Integration tests for offline mode + the `cache` subcommand.
+//!
+//! Covers:
+//! - a warm OSV cache serving an offline `enrich_sbom_full` with **zero**
+//!   network requests (httpmock asserts no extra hits in offline mode),
+//! - a TTL-expired cache entry being served *stale* (not evicted) when offline,
+//!   while the online path still evicts it,
+//! - the CLI `cache` subcommand: `status`, `warm`, and an `export` + `import`
+//!   round-trip, plus an end-to-end offline KEV run served purely from cache.
+//!
+//! Offline mode is a process-wide switch ([`set_offline`]), so the tests that
+//! toggle it are serialized through a single mutex to keep parallel test threads
+//! from racing on the global flag. The CLI tests run in their own subprocess and
+//! need no such guard.
+
+#![cfg(feature = "enrichment")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Mutex;
+use std::time::Duration;
+
+use httpmock::prelude::*;
+use sbom_tools::config::EnrichmentConfig;
+use sbom_tools::enrichment::source::{JsonCache, is_offline, set_offline};
+use sbom_tools::enrichment::{CacheKey, FileCache};
+use sbom_tools::model::{
+    Component, NormalizedSbom, Severity, VulnerabilityRef, VulnerabilitySource,
+};
+use sbom_tools::pipeline::enrich_sbom_full;
+
+/// Serializes every test that flips the process-wide offline switch.
+static OFFLINE_LOCK: Mutex<()> = Mutex::new(());
+
+/// Lock the offline serialization mutex, recovering from a prior panic's poison
+/// so one failing test does not cascade into the others.
+fn offline_lock() -> std::sync::MutexGuard<'static, ()> {
+    OFFLINE_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+const VULN_ID: &str = "GHSA-jf85-cpcp-j695";
+
+fn querybatch_stub_body(ids: &[&str]) -> serde_json::Value {
+    let vulns: Vec<serde_json::Value> = ids
+        .iter()
+        .map(|id| serde_json::json!({"id": id, "modified": "2026-01-10T00:00:00Z"}))
+        .collect();
+    serde_json::json!({ "results": [ { "vulns": vulns } ] })
+}
+
+fn full_vuln_body(id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "id": id,
+        "summary": "Prototype pollution in lodash",
+        "modified": "2026-01-10T00:00:00Z",
+        "severity": [
+            {"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}
+        ],
+        "affected": [{
+            "package": {"name": "lodash", "ecosystem": "npm", "purl": "pkg:npm/lodash"},
+            "ranges": [{"type": "SEMVER", "events": [{"introduced": "0"}, {"fixed": "4.17.21"}]}]
+        }],
+        "database_specific": {"severity": "CRITICAL"}
+    })
+}
+
+fn lodash_sbom() -> NormalizedSbom {
+    let mut sbom = NormalizedSbom::default();
+    sbom.add_component(
+        Component::new("lodash".to_string(), "lodash@4.17.20".to_string())
+            .with_purl("pkg:npm/lodash@4.17.20".to_string())
+            .with_version("4.17.20".to_string()),
+    );
+    sbom
+}
+
+/// A warm OSV cache must serve an offline run without any network request.
+#[test]
+fn offline_run_serves_warm_cache_without_network() {
+    let _guard = offline_lock();
+    set_offline(false);
+
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(200).json_body(querybatch_stub_body(&[VULN_ID]));
+    });
+    let vuln_mock = server.mock(|when, then| {
+        when.method(GET).path(format!("/v1/vulns/{VULN_ID}"));
+        then.status(200).json_body(full_vuln_body(VULN_ID));
+    });
+
+    // 1. Online warm-up populates the cache.
+    let online = EnrichmentConfig::osv()
+        .with_api_base(server.base_url())
+        .with_cache_dir(cache_dir.path().to_path_buf());
+    let mut sbom = lodash_sbom();
+    let stats = enrich_sbom_full(&mut sbom, &online, true);
+    assert!(stats.osv.is_some(), "online enrichment should run");
+    batch_mock.assert_hits(1);
+    vuln_mock.assert_hits(1);
+
+    // 2. Offline run is served entirely from the warm cache: ZERO new requests.
+    let offline = EnrichmentConfig::osv()
+        .with_api_base(server.base_url())
+        .with_cache_dir(cache_dir.path().to_path_buf())
+        .with_offline();
+    let mut sbom2 = lodash_sbom();
+    let stats2 = enrich_sbom_full(&mut sbom2, &offline, true);
+
+    // The mocks must not have been hit again.
+    batch_mock.assert_hits(1);
+    vuln_mock.assert_hits(1);
+
+    let osv = stats2.osv.expect("offline OSV stats present");
+    assert_eq!(osv.api_calls, 0, "offline mode must make no API calls");
+    let comp = sbom2.components.values().next().unwrap();
+    assert_eq!(
+        comp.vulnerabilities[0].severity,
+        Some(Severity::Critical),
+        "the cached, enriched vulnerability is served offline"
+    );
+
+    set_offline(false);
+}
+
+/// In offline mode a TTL-expired entry is served stale (not evicted); the online
+/// path still evicts it.
+#[test]
+fn expired_entry_served_stale_when_offline() {
+    let _guard = offline_lock();
+    set_offline(false);
+
+    let tmp = tempfile::tempdir().unwrap();
+    let ttl = Duration::from_millis(50);
+    let cache: JsonCache<String> = JsonCache::new(tmp.path().to_path_buf(), ttl).unwrap();
+    cache.set_named("entry", &"payload".to_string()).unwrap();
+
+    // Let the entry age past its TTL.
+    std::thread::sleep(Duration::from_millis(150));
+
+    // Offline: the expired entry is RETURNED with a staleness signal and kept.
+    set_offline(true);
+    let (value, stale_by) = cache
+        .get_named_allow_stale("entry")
+        .expect("stale entry must be served offline");
+    assert_eq!(value, "payload");
+    assert!(
+        stale_by.is_some(),
+        "an expired-but-served entry reports how far past TTL it is"
+    );
+    assert!(
+        cache.path_for("entry").exists(),
+        "offline must NOT evict the stale entry"
+    );
+
+    // Online: the same expired entry is a miss and gets evicted.
+    set_offline(false);
+    assert!(
+        cache.get_named("entry").is_none(),
+        "online path treats an expired entry as a miss"
+    );
+    assert!(
+        !cache.path_for("entry").exists(),
+        "online path evicts the expired entry"
+    );
+
+    set_offline(false);
+}
+
+/// The offline HTTP guard refuses a fresh fetch (cache miss) with a clear error
+/// rather than attempting a network call.
+#[test]
+fn offline_cache_miss_makes_no_request() {
+    let _guard = offline_lock();
+    set_offline(false);
+
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(200).json_body(querybatch_stub_body(&[VULN_ID]));
+    });
+
+    // Offline with an EMPTY cache: nothing is served and nothing is fetched.
+    let offline = EnrichmentConfig::osv()
+        .with_api_base(server.base_url())
+        .with_cache_dir(cache_dir.path().to_path_buf())
+        .with_offline();
+    let mut sbom = lodash_sbom();
+    let _stats = enrich_sbom_full(&mut sbom, &offline, true);
+
+    // The offline guard refused the fetch: the OSV mock saw no request at all.
+    batch_mock.assert_hits(0);
+    assert!(
+        is_offline(),
+        "enrich_sbom_full sets the process-wide offline flag"
+    );
+    let comp = sbom.components.values().next().unwrap();
+    assert!(
+        comp.vulnerabilities.is_empty(),
+        "an offline cache miss yields no enrichment"
+    );
+
+    set_offline(false);
+}
+
+// ============================================================================
+// CLI `cache` subcommand
+// ============================================================================
+
+fn bin_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_sbom-tools"))
+}
+
+fn write_sbom(dir: &Path, name: &str, components: &str) -> PathBuf {
+    let path = dir.join(name);
+    let body = format!(
+        r#"{{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {{ "timestamp": "2026-01-04T12:00:00Z" }},
+  {components}
+}}"#
+    );
+    std::fs::write(&path, body).unwrap();
+    path
+}
+
+/// Seed a cache directory tree with one fake OSV entry so `status`/`export`
+/// have something to report without any network access.
+fn seed_osv_cache(sbom_tools_root: &Path) -> CacheKey {
+    let osv_dir = sbom_tools_root.join("osv");
+    let cache = FileCache::new(osv_dir, Duration::from_secs(3600)).unwrap();
+    let key = CacheKey::new(
+        Some("pkg:npm/lodash@4.17.20".to_string()),
+        "lodash".to_string(),
+        Some("npm".to_string()),
+        Some("4.17.20".to_string()),
+    );
+    let mut vuln = VulnerabilityRef::new(VULN_ID.to_string(), VulnerabilitySource::Osv);
+    vuln.severity = Some(Severity::Critical);
+    cache.set(&key, std::slice::from_ref(&vuln)).unwrap();
+    key
+}
+
+/// The `sbom-tools` cache root the binary resolves to for a given env base,
+/// matching `enrichment::source::cache_dir` precedence.
+fn resolved_root(base: &Path) -> PathBuf {
+    if cfg!(target_os = "macos") {
+        base.join("home")
+            .join("Library")
+            .join("Caches")
+            .join("sbom-tools")
+    } else {
+        base.join("sbom-tools")
+    }
+}
+
+#[test]
+fn cli_cache_status_reports_seeded_entries() {
+    let base = tempfile::tempdir().unwrap();
+    seed_osv_cache(&resolved_root(base.path()));
+
+    let output = Command::new(bin_path())
+        .arg("cache")
+        .arg("status")
+        .envs(cache_env(base.path()))
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("cache status should run");
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("osv"),
+        "status lists the osv source: {stdout}"
+    );
+    assert!(
+        stdout.contains("ENTRIES"),
+        "status prints a header: {stdout}"
+    );
+}
+
+#[test]
+fn cli_cache_warm_succeeds_without_queryable_components() {
+    // An SBOM whose components have no PURL/ecosystem produces no OSV queries,
+    // so `cache warm` completes with no network access — exercising the warm
+    // command path end-to-end through the binary.
+    let work = tempfile::tempdir().unwrap();
+    let base = tempfile::tempdir().unwrap();
+    let sbom = write_sbom(
+        work.path(),
+        "sbom.cdx.json",
+        r#""components": [
+    { "type": "library", "bom-ref": "internal-thing", "name": "internal-thing" }
+  ]"#,
+    );
+
+    let output = Command::new(bin_path())
+        .args(["cache", "warm"])
+        .arg(&sbom)
+        .envs(cache_env(base.path()))
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("cache warm should run");
+
+    assert!(
+        output.status.success(),
+        "warm stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Warmed cache"),
+        "warm prints a summary: {stdout}"
+    );
+}
+
+#[test]
+fn cli_cache_warm_rejects_offline() {
+    // Warming requires the network, so it must refuse to run in offline mode.
+    let work = tempfile::tempdir().unwrap();
+    let base = tempfile::tempdir().unwrap();
+    let sbom = write_sbom(
+        work.path(),
+        "sbom.cdx.json",
+        r#""components": [
+    { "type": "library", "bom-ref": "x", "name": "x" }
+  ]"#,
+    );
+
+    let output = Command::new(bin_path())
+        .arg("--offline")
+        .args(["cache", "warm"])
+        .arg(&sbom)
+        .envs(cache_env(base.path()))
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("cache warm should run");
+
+    assert!(
+        !output.status.success(),
+        "offline warm must fail; stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("offline"),
+        "error explains the offline conflict: {stderr}"
+    );
+}
+
+#[test]
+fn cli_cache_export_import_roundtrip() {
+    let base = tempfile::tempdir().unwrap();
+    seed_osv_cache(&resolved_root(base.path()));
+    let export_dir = tempfile::tempdir().unwrap();
+
+    // Export the seeded cache to a portable directory bundle.
+    let export = Command::new(bin_path())
+        .args(["cache", "export"])
+        .arg(export_dir.path())
+        .envs(cache_env(base.path()))
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("cache export should run");
+    assert!(
+        export.status.success(),
+        "export stderr: {}",
+        String::from_utf8_lossy(&export.stderr)
+    );
+    assert!(
+        export_dir.path().join("osv").exists(),
+        "export copies the osv namespace dir"
+    );
+
+    // Import into a fresh, empty cache root.
+    let import_base = tempfile::tempdir().unwrap();
+    let import = Command::new(bin_path())
+        .args(["cache", "import"])
+        .arg(export_dir.path())
+        .envs(cache_env(import_base.path()))
+        .env("RUST_LOG", "error")
+        .output()
+        .expect("cache import should run");
+    assert!(
+        import.status.success(),
+        "import stderr: {}",
+        String::from_utf8_lossy(&import.stderr)
+    );
+
+    // The imported tree mirrors the original: the osv entry is present.
+    let imported_osv = resolved_root(import_base.path()).join("osv");
+    assert!(
+        imported_osv.exists() && std::fs::read_dir(&imported_osv).unwrap().count() >= 1,
+        "imported cache contains the osv entry"
+    );
+}
+
+/// An end-to-end offline run served purely from a warm KEV cache: the KEV mock
+/// is hit once during the online warm-up and ZERO times during the offline run.
+#[test]
+fn cli_offline_kev_served_from_warm_cache() {
+    let server = MockServer::start();
+    let kev_mock = server.mock(|when, then| {
+        when.method(GET).path("/kev.json");
+        then.status(200).json_body(serde_json::json!({
+            "title": "CISA KEV",
+            "catalogVersion": "2026.06.01",
+            "dateReleased": "2026-06-01T12:00:00.000Z",
+            "count": 1,
+            "vulnerabilities": [{
+                "cveID": "CVE-2021-44228",
+                "vendorProject": "Apache",
+                "product": "Log4j2",
+                "vulnerabilityName": "Log4Shell",
+                "dateAdded": "2021-12-10",
+                "shortDescription": "RCE",
+                "requiredAction": "Patch",
+                "dueDate": "2021-12-24",
+                "knownRansomwareCampaignUse": "Known",
+                "notes": ""
+            }]
+        }));
+    });
+    let cache_dir = tempfile::tempdir().unwrap();
+    let work = tempfile::tempdir().unwrap();
+
+    let sbom = write_sbom(
+        work.path(),
+        "sbom.cdx.json",
+        r#""components": [
+    { "type": "library", "bom-ref": "log4j@2.14.0", "name": "log4j", "version": "2.14.0", "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.0" }
+  ],
+  "vulnerabilities": [
+    { "id": "CVE-2021-44228", "source": { "name": "NVD" }, "affects": [ { "ref": "log4j@2.14.0" } ] }
+  ]"#,
+    );
+
+    let kev_url = format!("{}/kev.json", server.base_url());
+
+    // 1. Online warm-up: fetch + cache the KEV catalog.
+    let warm = Command::new(bin_path())
+        .arg("--no-color")
+        .env("RUST_LOG", "error")
+        .env("SBOM_TOOLS_KEV_URL", &kev_url)
+        .args(["view", &sbom.to_string_lossy(), "-o", "summary", "--kev"])
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .output()
+        .expect("warm view should run");
+    assert!(
+        warm.status.success() || warm.status.code() == Some(0),
+        "warm stderr: {}",
+        String::from_utf8_lossy(&warm.stderr)
+    );
+    kev_mock.assert_hits(1);
+
+    // 2. Offline run: KEV is served from the warm cache, no new request.
+    let offline = Command::new(bin_path())
+        .arg("--no-color")
+        .arg("--offline")
+        .env("RUST_LOG", "error")
+        .env("SBOM_TOOLS_KEV_URL", &kev_url)
+        .args(["view", &sbom.to_string_lossy(), "-o", "summary", "--kev"])
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .output()
+        .expect("offline view should run");
+    assert!(
+        offline.status.success(),
+        "offline stderr: {}",
+        String::from_utf8_lossy(&offline.stderr)
+    );
+    // The KEV mock must NOT have been hit a second time.
+    kev_mock.assert_hits(1);
+}
+
+/// Set the platform cache-dir env var so `root_cache_dir()` resolves under
+/// `resolved_root(base)`. Mirrors the precedence in
+/// `enrichment::source::cache_dir`.
+fn cache_env(base: &Path) -> Vec<(String, String)> {
+    let base = base.to_string_lossy().into_owned();
+    if cfg!(target_os = "macos") {
+        vec![("HOME".to_string(), format!("{base}/home"))]
+    } else if cfg!(target_os = "windows") {
+        vec![("LOCALAPPDATA".to_string(), base)]
+    } else {
+        vec![("XDG_CACHE_HOME".to_string(), base)]
+    }
+}


### PR DESCRIPTION
## Summary

Makes sbom-tools usable in air-gapped (CRA / FDA / defense) environments by adding a global offline mode and a `cache` management subcommand.

- **Global `--offline` flag + `SBOM_TOOLS_OFFLINE` env.** Resolved once in `main.rs` (CLI flag OR config-file `enrichment.offline`) into a process-wide switch (`enrichment::source::set_offline`). `EnrichmentConfig` gains an `offline` field threaded through `seed_enrichment`.
- **The HTTP layer refuses network calls when offline.** `get_with_retry` and every source's direct `.send()` call a new `offline_guard()` that returns a clear `offline: not in cache` error (`EnrichmentErrorKind::Offline` / `EnrichmentError::Offline`) before any socket is opened. The OSV `is_available()` health probe is bypassed offline so cache-served enrichment proceeds straight to the cache.
- **Stale-if-offline cache.** `JsonCache::get_named_allow_stale` returns a TTL-expired entry with an age signal instead of evicting it when offline; `get_named` logs a `N day(s) past TTL` warning. **The online path is byte-identical** — it still evicts on read, so the E1 cache tests pass unchanged.
- **`EolEnricher` builds offline.** A missing product list is served from cache, or it falls back to an empty list (skip) instead of failing at construction.
- **New `cache` subcommand:** `status` (sources, entry counts, ages, total size), `warm <sbom> [--all-sources]` (pre-fetch so a later `--offline` run is fully served), `clear`, and `export <path>` / `import <path>` for sneakernet transfer. Export/import use a portable recursive **directory copy** — no new dependency (the cache is already a tree of small JSON files), which keeps cargo-deny green.

### Notes / deviations
- Export/import format: chose a plain recursive directory copy over adding `tar`/`zip` — zero new deps, and the cache is already small JSON files, so the bundle is directly consumable by an `--offline` reader.
- The `cache` command is gated behind the `enrichment` feature (mirroring `enrich`), since the cache only exists when enrichment is compiled in.
- The offline-mode "served from cache only" report warning is emitted by `enrich_sbom_full` (used by `quality`/`multi`); the `diff` handler inlines its own enrichment so it does not surface that one cosmetic warning, but offline behavior itself is fully enforced via the global switch. Per-entry staleness is surfaced as a `tracing::warn` log (the spec's "at minimum").

## Test plan

`tests/offline_cache_tests.rs` (all via httpmock / `CARGO_BIN_EXE`):
- a warm OSV cache serves an offline `enrich_sbom_full` with **zero** new HTTP hits;
- an offline cache miss makes **no** request (guard fires);
- a TTL-expired entry is served *stale* when offline and **not** evicted, while the online path still evicts it;
- CLI `cache status`, `cache warm` (success + offline-rejection), and `cache export` + `import` round-trip.

Also verified: `cargo fmt --check` clean; `rustup run 1.88 cargo clippy` 0 new warnings vs HEAD (production code); full `cargo test --features enrichment` green (42 binaries); builds with and without the `enrichment` feature; the E1 cache eviction tests and OSV HTTP tests still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)