### PR TITLE
fix(aibom): cross-format AI-readiness parity via typed model-card fields

### DIFF
--- a/src/model/metadata.rs
+++ b/src/model/metadata.rs
@@ -542,6 +542,60 @@ pub struct MlModelInfo {
     pub energy_kwh_training: Option<f64>,
     /// URL to detailed model card (from ExternalRefType::ModelCard)
     pub model_card_url: Option<String>,
+    /// Fairness assessments (CycloneDX 1.5+ `considerations.fairnessAssessments`).
+    /// SPDX 3.0 has no direct analogue; the nearest AI-profile signals are
+    /// normalized into this shape so cross-format scoring is symmetric.
+    pub fairness: Vec<FairnessAssessment>,
+    /// Ethical considerations. CycloneDX emits structured objects
+    /// (`considerations.ethicalConsiderations[]`); SPDX emits free strings.
+    /// Both are normalized into this single shape.
+    pub ethical_considerations: Vec<EthicalConsideration>,
+    /// Intended use-cases (CycloneDX `considerations.useCases`, SPDX `ai_domain` /
+    /// `ai_informationAboutApplication`).
+    pub use_cases: Vec<String>,
+    /// Quantitative performance metrics (CycloneDX
+    /// `modelCard.quantitativeAnalysis.performanceMetrics`, SPDX `ai_metric`).
+    pub performance_metrics: Vec<MetricEntry>,
+}
+
+/// A fairness assessment for an ML model (CycloneDX 1.5+
+/// `considerations.fairnessAssessments[]`).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct FairnessAssessment {
+    /// The group(s) potentially at risk for the identified fairness concern.
+    pub group_at_risk: Option<String>,
+    /// Expected benefits to the group at risk.
+    pub benefits: Option<String>,
+    /// Potential harms to the group at risk.
+    pub harms: Option<String>,
+    /// Strategy used to mitigate the identified harms.
+    pub mitigation_strategy: Option<String>,
+}
+
+/// An ethical consideration for an ML model. Normalized from CycloneDX structured
+/// objects (`{ name, mitigationStrategy }`) and SPDX free-text strings alike.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct EthicalConsideration {
+    /// Name / description of the ethical risk.
+    pub name: Option<String>,
+    /// Strategy used to mitigate the ethical risk (CycloneDX only).
+    pub mitigation_strategy: Option<String>,
+}
+
+/// A single quantitative performance metric (CycloneDX
+/// `quantitativeAnalysis.performanceMetrics[]`).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct MetricEntry {
+    /// Metric type (e.g. "accuracy", "F1", "precision").
+    pub metric_type: Option<String>,
+    /// Metric value, retained verbatim (string form is spec-conformant and
+    /// preserves precision / non-numeric values such as confidence intervals).
+    pub value: Option<String>,
+    /// Data slice the metric was computed over (CycloneDX `slice`).
+    pub slice: Option<String>,
 }
 
 /// Reference to a dataset used for training or evaluation

--- a/src/parsers/cyclonedx.rs
+++ b/src/parsers/cyclonedx.rs
@@ -534,6 +534,26 @@ impl CycloneDxParser {
                         ml_info.energy_kwh_training = Some(total_training_energy);
                     }
                 }
+
+                ml_info.fairness = considerations
+                    .fairness_assessments
+                    .iter()
+                    .map(CdxFairnessAssessment::to_model)
+                    .collect();
+                ml_info.ethical_considerations = considerations
+                    .ethical_considerations
+                    .iter()
+                    .map(CdxEthicalConsideration::to_model)
+                    .collect();
+                ml_info.use_cases.clone_from(&considerations.use_cases);
+            }
+
+            if let Some(quant) = &model_card.quantitative_analysis {
+                ml_info.performance_metrics = quant
+                    .performance_metrics
+                    .iter()
+                    .map(CdxPerformanceMetric::to_model)
+                    .collect();
             }
 
             // Extract model card URL from external references
@@ -1500,6 +1520,8 @@ struct CdxProperty {
 struct CdxMlModelCard {
     model_parameters: Option<CdxModelParameters>,
     considerations: Option<CdxConsiderations>,
+    /// Spec: `modelCard.quantitativeAnalysis` (performance metrics, graphics).
+    quantitative_analysis: Option<CdxQuantitativeAnalysis>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1572,6 +1594,142 @@ struct CdxConsiderations {
     #[serde(default)]
     technical_limitations: Vec<String>,
     environmental_considerations: Option<CdxEnvironmentalConsiderations>,
+    /// Spec (CDX 1.5+): `considerations.fairnessAssessments` is an array of objects.
+    /// The non-spec `fairnessConsiderations` (a string array used by some emitters)
+    /// is accepted via alias and coerced into the structured form.
+    #[serde(
+        rename = "fairnessAssessments",
+        alias = "fairnessConsiderations",
+        default,
+        deserialize_with = "deserialize_fairness"
+    )]
+    fairness_assessments: Vec<CdxFairnessAssessment>,
+    /// Spec: `considerations.ethicalConsiderations` is an array of objects
+    /// `{ name, mitigationStrategy }`; a bare string is accepted for non-spec emitters.
+    #[serde(default)]
+    ethical_considerations: Vec<CdxEthicalConsideration>,
+    /// Spec: `considerations.useCases` is a string array.
+    #[serde(default)]
+    use_cases: Vec<String>,
+}
+
+/// One `considerations.fairnessAssessments` entry. Per spec these are objects;
+/// a bare string (non-spec `fairnessConsiderations`) is accepted and lands in
+/// `group_at_risk` so it is still surfaced.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum CdxFairnessAssessment {
+    Text(String),
+    Structured(CdxFairnessObj),
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct CdxFairnessObj {
+    group_at_risk: Option<String>,
+    benefits: Option<String>,
+    harms: Option<String>,
+    mitigation_strategy: Option<String>,
+}
+
+impl CdxFairnessAssessment {
+    fn to_model(&self) -> crate::model::FairnessAssessment {
+        match self {
+            Self::Text(text) => crate::model::FairnessAssessment {
+                group_at_risk: Some(text.clone()),
+                ..Default::default()
+            },
+            Self::Structured(obj) => crate::model::FairnessAssessment {
+                group_at_risk: obj.group_at_risk.clone(),
+                benefits: obj.benefits.clone(),
+                harms: obj.harms.clone(),
+                mitigation_strategy: obj.mitigation_strategy.clone(),
+            },
+        }
+    }
+}
+
+/// Accept `fairnessAssessments` as either the spec object array or a non-spec string array.
+fn deserialize_fairness<'de, D>(deserializer: D) -> Result<Vec<CdxFairnessAssessment>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<Vec<CdxFairnessAssessment>>::deserialize(deserializer)?.unwrap_or_default())
+}
+
+/// One `considerations.ethicalConsiderations` entry: the spec object
+/// `{ name, mitigationStrategy }`, or a bare string for non-spec emitters.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum CdxEthicalConsideration {
+    Text(String),
+    Structured(CdxEthicalObj),
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct CdxEthicalObj {
+    name: Option<String>,
+    mitigation_strategy: Option<String>,
+}
+
+impl CdxEthicalConsideration {
+    fn to_model(&self) -> crate::model::EthicalConsideration {
+        match self {
+            Self::Text(text) => crate::model::EthicalConsideration {
+                name: Some(text.clone()),
+                mitigation_strategy: None,
+            },
+            Self::Structured(obj) => crate::model::EthicalConsideration {
+                name: obj.name.clone(),
+                mitigation_strategy: obj.mitigation_strategy.clone(),
+            },
+        }
+    }
+}
+
+/// `modelCard.quantitativeAnalysis` — performance metrics for the model.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct CdxQuantitativeAnalysis {
+    #[serde(default)]
+    performance_metrics: Vec<CdxPerformanceMetric>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct CdxPerformanceMetric {
+    #[serde(rename = "type")]
+    metric_type: Option<String>,
+    /// Spec `value` is a string; a JSON number is also accepted and stringified.
+    #[serde(default, deserialize_with = "de_metric_value")]
+    value: Option<String>,
+    slice: Option<String>,
+}
+
+impl CdxPerformanceMetric {
+    fn to_model(&self) -> crate::model::MetricEntry {
+        crate::model::MetricEntry {
+            metric_type: self.metric_type.clone(),
+            value: self.value.clone(),
+            slice: self.slice.clone(),
+        }
+    }
+}
+
+/// A performance-metric `value` per spec is a string, but numbers appear in the
+/// wild; accept both and normalize to the string form.
+fn de_metric_value<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match Option::<serde_json::Value>::deserialize(deserializer)? {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(text)) => Ok(Some(text)),
+        Some(serde_json::Value::Number(number)) => Ok(Some(number.to_string())),
+        Some(serde_json::Value::Bool(flag)) => Ok(Some(flag.to_string())),
+        Some(other) => Ok(Some(other.to_string())),
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -2517,5 +2675,102 @@ mod tests {
         assert_eq!(vuln.severity, Some(Severity::Critical));
         assert_eq!(vuln.affected_versions, vec!["2.14.1".to_string()]);
         assert_eq!(sbom.vulnerability_counts().critical, 1);
+    }
+
+    fn parse_json(json: &str) -> NormalizedSbom {
+        CycloneDxParser::new()
+            .parse_str(json)
+            .expect("JSON should parse")
+    }
+
+    #[test]
+    fn test_json_ml_model_card_typed_fields() {
+        // Uses the SPEC field names: considerations.fairnessAssessments (objects),
+        // ethicalConsiderations (objects), useCases, and
+        // modelCard.quantitativeAnalysis.performanceMetrics.
+        let sbom = parse_json(
+            r#"{
+              "bomFormat": "CycloneDX",
+              "specVersion": "1.6",
+              "version": 1,
+              "components": [{
+                "bom-ref": "m1",
+                "type": "machine-learning-model",
+                "name": "m1",
+                "modelCard": {
+                  "quantitativeAnalysis": {
+                    "performanceMetrics": [
+                      { "type": "accuracy", "value": "0.97", "slice": "overall" },
+                      { "type": "F1", "value": 0.95 }
+                    ]
+                  },
+                  "considerations": {
+                    "useCases": ["triage", "moderation"],
+                    "ethicalConsiderations": [
+                      { "name": "bias risk", "mitigationStrategy": "human review" }
+                    ],
+                    "fairnessAssessments": [
+                      { "groupAtRisk": "minors", "mitigationStrategy": "age gating" }
+                    ]
+                  }
+                }
+              }]
+            }"#,
+        );
+
+        let ml = component(&sbom, "m1")
+            .ml_model
+            .as_ref()
+            .expect("ml_model missing");
+        assert_eq!(ml.performance_metrics.len(), 2);
+        assert_eq!(
+            ml.performance_metrics[0].metric_type.as_deref(),
+            Some("accuracy")
+        );
+        assert_eq!(ml.performance_metrics[0].value.as_deref(), Some("0.97"));
+        assert_eq!(ml.performance_metrics[0].slice.as_deref(), Some("overall"));
+        // Numeric `value` is normalized to its string form.
+        assert_eq!(ml.performance_metrics[1].value.as_deref(), Some("0.95"));
+        assert_eq!(ml.use_cases, vec!["triage", "moderation"]);
+        assert_eq!(ml.ethical_considerations.len(), 1);
+        assert_eq!(
+            ml.ethical_considerations[0].mitigation_strategy.as_deref(),
+            Some("human review")
+        );
+        assert_eq!(ml.fairness.len(), 1);
+        assert_eq!(ml.fairness[0].group_at_risk.as_deref(), Some("minors"));
+    }
+
+    #[test]
+    fn test_json_ml_fairness_non_spec_string_alias() {
+        // The non-spec `fairnessConsiderations` string-array variant is accepted
+        // via serde alias and coerced into the structured form.
+        let sbom = parse_json(
+            r#"{
+              "bomFormat": "CycloneDX",
+              "specVersion": "1.5",
+              "version": 1,
+              "components": [{
+                "bom-ref": "m1",
+                "type": "machine-learning-model",
+                "name": "m1",
+                "modelCard": {
+                  "considerations": {
+                    "fairnessConsiderations": ["assessed for demographic parity"]
+                  }
+                }
+              }]
+            }"#,
+        );
+
+        let ml = component(&sbom, "m1")
+            .ml_model
+            .as_ref()
+            .expect("ml_model missing");
+        assert_eq!(ml.fairness.len(), 1);
+        assert_eq!(
+            ml.fairness[0].group_at_risk.as_deref(),
+            Some("assessed for demographic parity")
+        );
     }
 }

--- a/src/parsers/spdx3.rs
+++ b/src/parsers/spdx3.rs
@@ -519,6 +519,57 @@ impl Spdx3Parser {
                     .iter()
                     .find(|r| r.ref_type == ExternalRefType::Documentation)
                     .map(|r| r.url.clone());
+                // Map the closest SPDX 3.0 AI-profile signals into the SAME typed
+                // MlModelInfo fields the CycloneDX parser populates, so AI scoring
+                // is symmetric across formats. Each is an approximation of the
+                // nearest SPDX field; only non-empty values are emitted.
+
+                // AI-005 fairness: explainability + safety-risk assessment narratives.
+                let fairness: Vec<crate::model::FairnessAssessment> = pkg
+                    .ai_model_explainability
+                    .clone()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .chain(pkg.ai_safety_risk_assessment.clone())
+                    .map(|text| crate::model::FairnessAssessment {
+                        group_at_risk: Some(text),
+                        ..Default::default()
+                    })
+                    .collect();
+
+                // AI-007 use-cases: application info + declared domains.
+                let use_cases: Vec<String> = pkg
+                    .ai_information_about_application
+                    .clone()
+                    .into_iter()
+                    .chain(pkg.ai_domain.clone().unwrap_or_default())
+                    .collect();
+
+                // AI-009 ethical: standards compliance + sensitive-PII disclosure.
+                let ethical: Vec<crate::model::EthicalConsideration> = pkg
+                    .ai_standard_compliance
+                    .clone()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .chain(pkg.ai_use_sensitive_personal_information.clone())
+                    .map(|text| crate::model::EthicalConsideration {
+                        name: Some(text),
+                        mitigation_strategy: None,
+                    })
+                    .collect();
+
+                // AI-004 quantitative: ai_metric / ai_metricDecisionThreshold entries.
+                // SPDX `ai_metric` items are objects (often `{ ai_name, ai_value }`);
+                // map name→type and stringify the value, preserving precision.
+                let performance_metrics: Vec<crate::model::MetricEntry> = pkg
+                    .ai_metric
+                    .clone()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .chain(pkg.ai_metric_decision_threshold.clone().unwrap_or_default())
+                    .map(spdx3_metric_to_entry)
+                    .collect();
+
                 comp.ml_model = Some(crate::model::MlModelInfo {
                     // ai_typeOfModel is a free-string list; treat the first as the
                     // family (cross-format approximation — see metadata.rs docs).
@@ -532,76 +583,14 @@ impl Spdx3Parser {
                         .as_ref()
                         .and_then(Spdx3EnergyConsumption::training_energy_kwh),
                     model_card_url,
-                    // training_datasets are linked via Relationships in SPDX, not
-                    // an inline field; relationship-derivation is future work.
+                    fairness,
+                    ethical_considerations: ethical,
+                    use_cases,
+                    performance_metrics,
+                    // training_datasets are linked via TRAINED_ON relationships in
+                    // SPDX (populated in process_relationship), not an inline field.
                     ..Default::default()
                 });
-
-                // Bridge non-typed AI signals into extensions.raw (CycloneDX
-                // modelCard layout) so the AI-readiness raw-pointer checks
-                // (AI-004/005/007/009) can see them. Each is an approximation of
-                // the closest SPDX AI field; only non-empty values are emitted.
-                let quant: Vec<serde_json::Value> = pkg
-                    .ai_metric
-                    .clone()
-                    .unwrap_or_default()
-                    .into_iter()
-                    .chain(pkg.ai_metric_decision_threshold.clone().unwrap_or_default())
-                    .collect();
-                let fairness: Vec<String> = pkg
-                    .ai_model_explainability
-                    .clone()
-                    .unwrap_or_default()
-                    .into_iter()
-                    .chain(pkg.ai_safety_risk_assessment.clone())
-                    .collect();
-                let use_cases: Vec<String> = pkg
-                    .ai_information_about_application
-                    .clone()
-                    .into_iter()
-                    .chain(pkg.ai_domain.clone().unwrap_or_default())
-                    .collect();
-                let ethical: Vec<String> = pkg
-                    .ai_standard_compliance
-                    .clone()
-                    .unwrap_or_default()
-                    .into_iter()
-                    .chain(pkg.ai_use_sensitive_personal_information.clone())
-                    .collect();
-
-                let mut model_card = serde_json::Map::new();
-                if !quant.is_empty() {
-                    model_card.insert(
-                        "quantitativeAnalysis".to_string(),
-                        serde_json::json!({ "performanceMetrics": quant }),
-                    );
-                }
-                let mut considerations = serde_json::Map::new();
-                if !fairness.is_empty() {
-                    considerations.insert(
-                        "fairnessConsiderations".to_string(),
-                        serde_json::json!(fairness),
-                    );
-                }
-                if !use_cases.is_empty() {
-                    considerations.insert("useCases".to_string(), serde_json::json!(use_cases));
-                }
-                if !ethical.is_empty() {
-                    considerations.insert(
-                        "ethicalConsiderations".to_string(),
-                        serde_json::json!(ethical),
-                    );
-                }
-                if !considerations.is_empty() {
-                    model_card.insert(
-                        "considerations".to_string(),
-                        serde_json::Value::Object(considerations),
-                    );
-                }
-                if !model_card.is_empty() {
-                    comp.extensions.raw =
-                        Some(serde_json::json!({ "mlModel": { "modelCard": model_card } }));
-                }
             }
             PackageKind::Dataset => {
                 comp.component_type = ComponentType::Data;
@@ -1026,6 +1015,36 @@ impl Spdx3Parser {
             // VEX assessment relationships — handled via VulnAssessment elements
             "HAS_ASSESSMENT_FOR" => {
                 // These are processed in process_vuln_assessment()
+            }
+
+            // AI profile: an ai_AIPackage TRAINED_ON a dataset. SPDX 3.0 JSON-LD
+            // uppercases the relationship type WITHOUT an underscore ("trainedOn"
+            // → "TRAINEDON"), so the canonical key has no separator. This is the
+            // SPDX equivalent of CycloneDX `modelParameters.datasets`; populate the
+            // model's typed `training_datasets` so AI-003 passes for SPDX too.
+            // `testedOn` is intentionally not treated as a training dataset.
+            "TRAINEDON" | "TRAINED_ON" => {
+                if let Some(from_ref) = &rel.from
+                    && let Some(from_id) = id_map.get(from_ref)
+                    && let Some(to_refs) = &rel.to
+                {
+                    for to_ref in to_refs {
+                        // Prefer the resolved component's name; fall back to the raw ref.
+                        let name = id_map
+                            .get(to_ref)
+                            .and_then(|cid| sbom.components.get(cid))
+                            .map(|c| c.name.clone())
+                            .filter(|n| !n.is_empty());
+                        if let Some(comp) = sbom.components.get_mut(from_id) {
+                            let ml = comp.ml_model.get_or_insert_with(Default::default);
+                            ml.training_datasets.push(crate::model::DatasetRef {
+                                reference: Some(to_ref.clone()),
+                                name,
+                                purl: None,
+                            });
+                        }
+                    }
+                }
             }
 
             _ => {
@@ -1538,6 +1557,41 @@ where
         Some(StrOrNum::Num(n)) => Some(n),
         Some(StrOrNum::Str(s)) => s.trim().parse::<f64>().ok(),
     })
+}
+
+/// Normalize one SPDX 3.0 `ai_metric` value into the typed `MetricEntry`.
+///
+/// SPDX metric entries are commonly objects such as `{ "ai_name": "accuracy",
+/// "ai_value": "0.97" }`, but the property is loosely typed, so plain strings
+/// and numbers are also accepted. `type`/`name`/`key` map to the metric type and
+/// `value` is stringified to preserve precision and non-numeric values.
+fn spdx3_metric_to_entry(value: serde_json::Value) -> crate::model::MetricEntry {
+    let stringify = |v: &serde_json::Value| -> Option<String> {
+        match v {
+            serde_json::Value::Null => None,
+            serde_json::Value::String(text) => Some(text.clone()),
+            other => Some(other.to_string()),
+        }
+    };
+    match value {
+        serde_json::Value::Object(map) => {
+            let pick = |keys: &[&str]| keys.iter().find_map(|k| map.get(*k).and_then(stringify));
+            crate::model::MetricEntry {
+                metric_type: pick(&["ai_name", "name", "type", "ai_type", "key"]),
+                value: pick(&["ai_value", "value", "ai_decisionThreshold"]),
+                slice: pick(&["ai_slice", "slice"]),
+            }
+        }
+        serde_json::Value::String(text) => crate::model::MetricEntry {
+            value: Some(text),
+            ..Default::default()
+        },
+        serde_json::Value::Null => crate::model::MetricEntry::default(),
+        other => crate::model::MetricEntry {
+            value: Some(other.to_string()),
+            ..Default::default()
+        },
+    }
 }
 
 /// SPDX 3.0 File (Software profile)

--- a/src/quality/scorer.rs
+++ b/src/quality/scorer.rs
@@ -755,45 +755,55 @@ impl QualityScorer {
                 ml.and_then(|m| m.architecture_family.as_ref()).is_some(),
                 // AI-003: training datasets
                 ml.is_some_and(|m| !m.training_datasets.is_empty()),
-                // AI-004: quantitative analysis (preserved in raw extensions)
-                has_non_empty_pointer(
-                    raw,
-                    &[
-                        "/modelCard/quantitativeAnalysis",
-                        "/mlModel/modelCard/quantitativeAnalysis",
-                    ],
-                ),
-                // AI-005: fairness assessments
-                has_non_empty_pointer(
-                    raw,
-                    &[
-                        "/modelCard/considerations/fairnessConsiderations",
-                        "/mlModel/modelCard/considerations/fairnessConsiderations",
-                        "/mlModel/considerations/fairnessConsiderations",
-                    ],
-                ),
+                // AI-004: quantitative analysis — typed performance metrics, with
+                // a raw-pointer fallback for SBOMs parsed before typed extraction.
+                ml.is_some_and(|m| !m.performance_metrics.is_empty())
+                    || has_non_empty_pointer(
+                        raw,
+                        &[
+                            "/modelCard/quantitativeAnalysis",
+                            "/mlModel/modelCard/quantitativeAnalysis",
+                        ],
+                    ),
+                // AI-005: fairness assessments. Fallback pointer corrected to the
+                // spec path `fairnessAssessments` (was the non-spec ...Considerations).
+                ml.is_some_and(|m| !m.fairness.is_empty())
+                    || has_non_empty_pointer(
+                        raw,
+                        &[
+                            "/modelCard/considerations/fairnessAssessments",
+                            "/mlModel/modelCard/considerations/fairnessAssessments",
+                            "/mlModel/considerations/fairnessAssessments",
+                            // Legacy non-spec key, retained for back-compat.
+                            "/modelCard/considerations/fairnessConsiderations",
+                            "/mlModel/modelCard/considerations/fairnessConsiderations",
+                            "/mlModel/considerations/fairnessConsiderations",
+                        ],
+                    ),
                 // AI-006: energy consumption
                 ml.and_then(|m| m.energy_kwh_training).is_some(),
                 // AI-007: use-cases
-                has_non_empty_pointer(
-                    raw,
-                    &[
-                        "/modelCard/considerations/useCases",
-                        "/mlModel/modelCard/considerations/useCases",
-                        "/mlModel/considerations/useCases",
-                    ],
-                ),
+                ml.is_some_and(|m| !m.use_cases.is_empty())
+                    || has_non_empty_pointer(
+                        raw,
+                        &[
+                            "/modelCard/considerations/useCases",
+                            "/mlModel/modelCard/considerations/useCases",
+                            "/mlModel/considerations/useCases",
+                        ],
+                    ),
                 // AI-008: limitations
                 ml.and_then(|m| m.limitations.as_ref()).is_some(),
                 // AI-009: ethical considerations
-                has_non_empty_pointer(
-                    raw,
-                    &[
-                        "/modelCard/considerations/ethicalConsiderations",
-                        "/mlModel/modelCard/considerations/ethicalConsiderations",
-                        "/mlModel/considerations/ethicalConsiderations",
-                    ],
-                ),
+                ml.is_some_and(|m| !m.ethical_considerations.is_empty())
+                    || has_non_empty_pointer(
+                        raw,
+                        &[
+                            "/modelCard/considerations/ethicalConsiderations",
+                            "/mlModel/modelCard/considerations/ethicalConsiderations",
+                            "/mlModel/considerations/ethicalConsiderations",
+                        ],
+                    ),
             ];
 
             if results.iter().all(|&p| p) {

--- a/tests/fixtures/cyclonedx/aibom-complete.cdx.json
+++ b/tests/fixtures/cyclonedx/aibom-complete.cdx.json
@@ -1,0 +1,112 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-06-14T00:00:00Z",
+    "tools": [
+      {
+        "vendor": "sbom-tools",
+        "name": "sbom-tools",
+        "version": "0.1.21"
+      }
+    ],
+    "component": {
+      "bom-ref": "root",
+      "type": "application",
+      "name": "aibom-complete-app",
+      "version": "1.0.0"
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "ml-model-1",
+      "type": "machine-learning-model",
+      "name": "sentiment-classifier",
+      "version": "1.0.0",
+      "description": "A fully documented sentiment classification model",
+      "modelCard": {
+        "modelParameters": {
+          "approach": {
+            "type": "supervised"
+          },
+          "task": "nlp",
+          "architectureFamily": "transformer",
+          "modelArchitecture": "bert",
+          "datasets": [
+            {
+              "ref": "data-reviews"
+            }
+          ]
+        },
+        "quantitativeAnalysis": {
+          "performanceMetrics": [
+            {
+              "type": "accuracy",
+              "value": "0.97",
+              "slice": "overall"
+            },
+            {
+              "type": "F1",
+              "value": "0.95"
+            }
+          ]
+        },
+        "considerations": {
+          "useCases": [
+            "Customer review sentiment analysis",
+            "Support-ticket triage"
+          ],
+          "technicalLimitations": [
+            "Optimized for English text; may not generalize to other languages."
+          ],
+          "ethicalConsiderations": [
+            {
+              "name": "May reflect biases present in product-review training data",
+              "mitigationStrategy": "Human review required for moderation decisions"
+            }
+          ],
+          "fairnessAssessments": [
+            {
+              "groupAtRisk": "Non-native English speakers",
+              "benefits": "Faster triage of feedback",
+              "harms": "Potential misclassification of dialectal phrasing",
+              "mitigationStrategy": "Augmented training set with dialectal samples"
+            }
+          ],
+          "environmentalConsiderations": {
+            "energyConsumptions": [
+              {
+                "activity": "training",
+                "activityEnergyCost": {
+                  "value": 1500.0,
+                  "unit": "kWh"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "externalReferences": [
+        {
+          "type": "model-card",
+          "url": "https://example.test/model-cards/sentiment-classifier"
+        }
+      ]
+    },
+    {
+      "bom-ref": "data-reviews",
+      "type": "data",
+      "name": "product-reviews-1M",
+      "data": [
+        {
+          "type": "dataset",
+          "name": "product-reviews",
+          "sensitiveData": [
+            "none"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/spdx3/ai-dataset.spdx3.json
+++ b/tests/fixtures/spdx3/ai-dataset.spdx3.json
@@ -78,6 +78,13 @@
       "relationshipType": "dependsOn",
       "from": "urn:spdx:pkg:bert-base",
       "to": ["urn:spdx:pkg:libtokenizer"]
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "urn:spdx:rel:2",
+      "relationshipType": "trainedOn",
+      "from": "urn:spdx:pkg:bert-base",
+      "to": ["urn:spdx:pkg:training-dataset-v1"]
     }
   ]
 }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -817,15 +817,118 @@ mod parser_tests {
                 .unwrap_or_else(|| panic!("check {id} missing"))
                 .passed
         };
-        // Typed checks (minus AI-003 training datasets, linked via relationships
-        // in SPDX and not derived in v1).
-        for id in ["AI-001", "AI-002", "AI-006", "AI-008"] {
+        // Typed checks. AI-003 (training datasets) is now derived from the
+        // `trainedOn` relationship in the fixture.
+        for id in ["AI-001", "AI-002", "AI-003", "AI-006", "AI-008"] {
             assert!(passed(id), "expected typed check {id} to pass");
         }
-        // Raw-pointer checks satisfied via the extensions.raw bridge.
+        // AI-004/005/007/009 are now satisfied via the typed MlModelInfo fields
+        // (fairness/use_cases/ethical/performance_metrics), not the raw bridge.
         for id in ["AI-004", "AI-005", "AI-007", "AI-009"] {
-            assert!(passed(id), "expected raw-bridge check {id} to pass");
+            assert!(passed(id), "expected typed AI check {id} to pass");
         }
+
+        // The training dataset is linked via the SPDX `trainedOn` relationship.
+        let bert = sbom
+            .components
+            .values()
+            .find(|c| c.name == "bert-base")
+            .expect("bert-base not found");
+        let ml = bert.ml_model.as_ref().expect("ML metadata missing");
+        assert_eq!(ml.training_datasets.len(), 1);
+        assert_eq!(
+            ml.training_datasets[0].name.as_deref(),
+            Some("training-dataset-v1")
+        );
+    }
+
+    /// Regression: a fully-documented CycloneDX 1.6 ML-BOM, scored THROUGH the
+    /// parser (not via hand-built extensions.raw), must pass AI-004/005/007/009.
+    /// Before the typed-field extraction these checks only ever saw SPDX raw data,
+    /// so a complete CycloneDX ML-BOM scored grade F regardless of content.
+    #[test]
+    fn test_cyclonedx_aibom_typed_ai_checks_pass() {
+        use sbom_tools::quality::{QualityGrade, QualityScorer, ScoringProfile};
+
+        let path = fixture_path("cyclonedx/aibom-complete.cdx.json");
+        let sbom = parse_sbom(&path).expect("Failed to parse CycloneDX ML-BOM");
+
+        // The typed fields must be populated directly by the parser.
+        let model = sbom
+            .components
+            .values()
+            .find(|c| c.name == "sentiment-classifier")
+            .expect("ml model not found");
+        let ml = model.ml_model.as_ref().expect("ml_model missing");
+        assert!(!ml.performance_metrics.is_empty(), "AI-004 source");
+        assert!(!ml.fairness.is_empty(), "AI-005 source");
+        assert!(!ml.use_cases.is_empty(), "AI-007 source");
+        assert!(!ml.ethical_considerations.is_empty(), "AI-009 source");
+
+        let report = QualityScorer::new(ScoringProfile::AiReadiness).score(&sbom);
+        let metrics = report
+            .ai_readiness_metrics
+            .as_ref()
+            .expect("AI readiness metrics");
+        assert_eq!(metrics.ml_component_count, 1);
+        let passed = |id: &str| {
+            metrics
+                .checks
+                .iter()
+                .find(|c| c.id == id)
+                .unwrap_or_else(|| panic!("check {id} missing"))
+                .passed
+        };
+        // The previously-broken checks now pass off typed fields.
+        for id in ["AI-004", "AI-005", "AI-007", "AI-009"] {
+            assert!(passed(id), "expected {id} to pass for CycloneDX ML-BOM");
+        }
+        // Fully documented → all nine pass, grade A.
+        for check in &metrics.checks {
+            assert!(check.passed, "expected {} to pass", check.id);
+        }
+        assert!((report.overall_score - 100.0).abs() < 0.01);
+        assert_eq!(report.grade, QualityGrade::A);
+    }
+
+    /// Cross-format parity: equivalent AI content in CycloneDX and SPDX 3.0 must
+    /// yield IDENTICAL AI-readiness scores and per-check pass/fail patterns.
+    #[test]
+    fn test_aibom_cross_format_score_parity() {
+        use sbom_tools::quality::{QualityScorer, ScoringProfile};
+
+        let cdx = parse_sbom(&fixture_path("cyclonedx/aibom-complete.cdx.json"))
+            .expect("Failed to parse CycloneDX ML-BOM");
+        let spdx = parse_sbom(&fixture_path("spdx3/ai-dataset.spdx3.json"))
+            .expect("Failed to parse SPDX 3.0 AI BOM");
+
+        let score = |sbom: &_| {
+            let report = QualityScorer::new(ScoringProfile::AiReadiness).score(sbom);
+            let metrics = report
+                .ai_readiness_metrics
+                .clone()
+                .expect("AI readiness metrics");
+            let mut pattern: Vec<(String, bool)> = metrics
+                .checks
+                .iter()
+                .map(|c| (c.id.clone(), c.passed))
+                .collect();
+            pattern.sort();
+            (report.overall_score, report.grade, pattern)
+        };
+
+        let (cdx_score, cdx_grade, cdx_pattern) = score(&cdx);
+        let (spdx_score, spdx_grade, spdx_pattern) = score(&spdx);
+
+        assert!(
+            (cdx_score - spdx_score).abs() < 0.01,
+            "scores differ: CDX={cdx_score} SPDX={spdx_score}"
+        );
+        assert_eq!(cdx_grade, spdx_grade, "grades differ");
+        assert_eq!(
+            cdx_pattern, spdx_pattern,
+            "per-check pass/fail patterns differ across formats"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

AI-readiness checks AI-004/005/007/009 read JSON pointers from `ComponentExtensions.raw`, which **only the SPDX 3.0 parser populated**. The CycloneDX parser never set `extensions.raw`, and `CdxConsiderations` parsed only `technicalLimitations` + environmental data. As a result a **fully-documented CycloneDX 1.6 ML-BOM scored ~40/100 (grade F) regardless of content**, while equivalent SPDX passed. A mirror gap: SPDX `trainedOn` relationships were unparsed (no arm in `process_relationship`), so **AI-003 failed for SPDX**. The AI-005 raw fallback pointer was also spec-wrong (`fairnessConsiderations` instead of spec `fairnessAssessments`).

This makes CycloneDX ML-BOMs scorable at all and gives identical scores for equivalent content across formats.

### Changes
- **`model/metadata.rs`**: extend `MlModelInfo` with typed `fairness` (`FairnessAssessment{group_at_risk,benefits,harms,mitigation_strategy}`), `ethical_considerations` (`EthicalConsideration{name,mitigation_strategy}`), `use_cases`, and `performance_metrics` (`MetricEntry{metric_type,value,slice}`). One shape normalizes CDX objects and SPDX strings.
- **`parsers/cyclonedx.rs`**: parse the **spec** field `considerations.fairnessAssessments` (objects), serde-aliasing the non-spec `fairnessConsiderations` string form; parse `ethicalConsiderations`, `useCases`, and `modelCard.quantitativeAnalysis.performanceMetrics` into the typed fields.
- **`parsers/spdx3.rs`**: replace the `extensions.raw` shim with mapping of `ai_metric` / `ai_modelExplainability` / `ai_domain` / etc into the **same** typed fields. Add a `TRAINEDON | TRAINED_ON` arm to `process_relationship` (SPDX 3.0 JSON-LD uppercases the relationship type **without** the underscore) that populates `training_datasets` — fixes AI-003 for SPDX. `testedOn` is intentionally not treated as training data.
- **`quality/scorer.rs`**: AI-004/005/007/009 now read the typed fields first, **keeping the raw-pointer fallback** for back-compat; the AI-005 fallback now also targets the spec path `fairnessAssessments`.

## Test plan
- New integration test round-trips a real CycloneDX 1.6 ML-BOM fixture **through the parser** (not hand-built `extensions.raw`) and asserts AI-004/005/007/009 pass + grade A.
- New CDX/SPDX **parity test** asserts identical overall score, grade, and per-check pass/fail pattern for equivalent content.
- New CycloneDX parser unit tests cover typed extraction (spec field names + numeric metric coercion) and the non-spec `fairnessConsiderations` alias.
- Existing `test_spdx3_ai_readiness_scores` updated: AI-003 now passes via `trainedOn`; AI-004/005/007/009 now pass off typed fields.
- Manual CLI check: `quality <fixture> --profile ai-readiness` → CDX and SPDX fixtures both score 100/100 grade A.
- `rustup run 1.88 cargo fmt`; clippy (1.88, all-features): **0 new** warnings vs HEAD on the same toolchain; full `cargo test`: **1389 passed, 0 failed**. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)