### PR TITLE
feat(diff): semantic ML model and dataset diffing

### DIFF
--- a/src/diff/changes/components.rs
+++ b/src/diff/changes/components.rs
@@ -2,7 +2,10 @@
 
 use crate::diff::traits::{ChangeComputer, ComponentChangeSet, ComponentMatches};
 use crate::diff::{ComponentChange, CostModel, FieldChange};
-use crate::model::{Component, CryptoAssetType, CryptoProperties, NormalizedSbom};
+use crate::model::{
+    Component, CryptoAssetType, CryptoProperties, DatasetInfo, DatasetRef, MlModelInfo,
+    NormalizedSbom,
+};
 use std::collections::HashSet;
 
 /// Computes component-level changes between SBOMs.
@@ -15,30 +18,6 @@ impl ComponentChangeComputer {
     #[must_use]
     pub const fn new(cost_model: CostModel) -> Self {
         Self { cost_model }
-    }
-
-    fn serialize_optional<T: serde::Serialize>(value: &Option<T>) -> Option<String> {
-        value.as_ref().map(|value| {
-            serde_json::to_string(value).expect("serializing diff value should be infallible")
-        })
-    }
-
-    fn push_structured_change<T: serde::Serialize + PartialEq>(
-        changes: &mut Vec<FieldChange>,
-        field: &str,
-        old: &Option<T>,
-        new: &Option<T>,
-        total_cost: &mut u32,
-        field_cost: u32,
-    ) {
-        if old != new {
-            changes.push(FieldChange {
-                field: field.to_string(),
-                old_value: Self::serialize_optional(old),
-                new_value: Self::serialize_optional(new),
-            });
-            *total_cost += field_cost;
-        }
     }
 
     /// Compute individual field changes between two components.
@@ -128,22 +107,15 @@ impl ComponentChangeComputer {
             }
         }
 
-        Self::push_structured_change(
-            &mut changes,
-            "ml_model",
-            &old.ml_model,
-            &new.ml_model,
-            &mut total_cost,
-            self.cost_model.ml_model_changed,
-        );
-        Self::push_structured_change(
-            &mut changes,
-            "dataset",
-            &old.dataset,
-            &new.dataset,
-            &mut total_cost,
-            self.cost_model.dataset_changed,
-        );
+        // ML model metadata changes (granular, prefixed per-field)
+        if old.ml_model != new.ml_model {
+            total_cost += Self::compute_ml_changes(&self.cost_model, old, new, &mut changes);
+        }
+
+        // Dataset metadata changes (granular, prefixed per-field)
+        if old.dataset != new.dataset {
+            total_cost += Self::compute_dataset_changes(&self.cost_model, old, new, &mut changes);
+        }
 
         // Cryptographic property changes
         if old.crypto_properties != new.crypto_properties {
@@ -151,6 +123,298 @@ impl ComponentChangeComputer {
         }
 
         (changes, total_cost)
+    }
+
+    /// Push a scalar `Option<String>` field change when the values differ.
+    fn push_scalar_change(
+        changes: &mut Vec<FieldChange>,
+        field: &str,
+        old: &Option<String>,
+        new: &Option<String>,
+        cost: &mut u32,
+        field_cost: u32,
+    ) {
+        if old != new {
+            changes.push(FieldChange {
+                field: field.to_string(),
+                old_value: old.clone(),
+                new_value: new.clone(),
+            });
+            *cost += field_cost;
+        }
+    }
+
+    /// Stable identity key for a training-dataset reference: prefer the BOM-ref,
+    /// then the name, then the PURL. Used to detect added/removed datasets across
+    /// two model revisions.
+    fn dataset_ref_key(reference: &DatasetRef) -> Option<&str> {
+        reference
+            .reference
+            .as_deref()
+            .or(reference.name.as_deref())
+            .or(reference.purl.as_deref())
+    }
+
+    /// Compute ML-model-specific field changes between two components.
+    ///
+    /// Emits granular, prefixed `ml_*` field changes (approach, architecture, task,
+    /// quantization, model card) plus per-dataset `ml_training_dataset` add/remove
+    /// entries, rather than one opaque serialized blob. This surfaces model-swap
+    /// signals such as `fp32 -> int4` re-quantization or training-data provenance loss.
+    fn compute_ml_changes(
+        cost_model: &CostModel,
+        old: &Component,
+        new: &Component,
+        changes: &mut Vec<FieldChange>,
+    ) -> u32 {
+        let mut cost = 0u32;
+
+        match (&old.ml_model, &new.ml_model) {
+            (Some(old_ml), Some(new_ml)) => {
+                cost += Self::compute_ml_sub_changes(cost_model, old_ml, new_ml, changes);
+            }
+            (None, Some(_)) | (Some(_), None) => {
+                // Model metadata appeared or disappeared wholesale.
+                changes.push(FieldChange {
+                    field: "ml_model".to_string(),
+                    old_value: old.ml_model.as_ref().map(|_| "present".to_string()),
+                    new_value: new.ml_model.as_ref().map(|_| "present".to_string()),
+                });
+                cost += cost_model.ml_model_changed;
+            }
+            (None, None) => {}
+        }
+
+        cost
+    }
+
+    fn compute_ml_sub_changes(
+        cost_model: &CostModel,
+        old: &MlModelInfo,
+        new: &MlModelInfo,
+        changes: &mut Vec<FieldChange>,
+    ) -> u32 {
+        let mut cost = 0u32;
+
+        Self::push_scalar_change(
+            changes,
+            "ml_approach",
+            &old.approach,
+            &new.approach,
+            &mut cost,
+            cost_model.ml_approach_changed,
+        );
+
+        // Architecture family and name are reported under a single prefixed field
+        // so a "resnet -> bert" or "cnn -> transformer" swap reads as one signal.
+        let old_arch = Self::join_architecture(old);
+        let new_arch = Self::join_architecture(new);
+        Self::push_scalar_change(
+            changes,
+            "ml_architecture",
+            &old_arch,
+            &new_arch,
+            &mut cost,
+            cost_model.ml_architecture_changed,
+        );
+
+        Self::push_scalar_change(
+            changes,
+            "ml_task",
+            &old.task,
+            &new.task,
+            &mut cost,
+            cost_model.ml_task_changed,
+        );
+        Self::push_scalar_change(
+            changes,
+            "ml_quantization",
+            &old.quantization,
+            &new.quantization,
+            &mut cost,
+            cost_model.ml_quantization_changed,
+        );
+        Self::push_scalar_change(
+            changes,
+            "ml_model_card",
+            &old.model_card_url,
+            &new.model_card_url,
+            &mut cost,
+            cost_model.ml_model_card_changed,
+        );
+
+        cost += Self::compute_training_dataset_changes(cost_model, old, new, changes);
+
+        cost
+    }
+
+    /// Combine architecture family and name into a single display value.
+    fn join_architecture(ml: &MlModelInfo) -> Option<String> {
+        match (&ml.architecture_family, &ml.architecture_name) {
+            (Some(family), Some(name)) => Some(format!("{family}/{name}")),
+            (Some(value), None) | (None, Some(value)) => Some(value.clone()),
+            (None, None) => None,
+        }
+    }
+
+    /// Emit per-dataset `ml_training_dataset` add/remove changes keyed by
+    /// `DatasetRef.reference`-or-`name`. Training-dataset removal is treated as a
+    /// provenance-loss signal and carries a high cost.
+    fn compute_training_dataset_changes(
+        cost_model: &CostModel,
+        old: &MlModelInfo,
+        new: &MlModelInfo,
+        changes: &mut Vec<FieldChange>,
+    ) -> u32 {
+        let mut cost = 0u32;
+
+        let old_keys: HashSet<&str> = old
+            .training_datasets
+            .iter()
+            .filter_map(Self::dataset_ref_key)
+            .collect();
+        let new_keys: HashSet<&str> = new
+            .training_datasets
+            .iter()
+            .filter_map(Self::dataset_ref_key)
+            .collect();
+
+        // Removed training datasets (present in old, absent in new). Sorted for
+        // deterministic output.
+        let mut removed: Vec<&str> = old_keys.difference(&new_keys).copied().collect();
+        removed.sort_unstable();
+        for key in removed {
+            changes.push(FieldChange {
+                field: "ml_training_dataset".to_string(),
+                old_value: Some(key.to_string()),
+                new_value: None,
+            });
+            cost += cost_model.ml_training_dataset_removed;
+        }
+
+        // Added training datasets (absent in old, present in new).
+        let mut added: Vec<&str> = new_keys.difference(&old_keys).copied().collect();
+        added.sort_unstable();
+        for key in added {
+            changes.push(FieldChange {
+                field: "ml_training_dataset".to_string(),
+                old_value: None,
+                new_value: Some(key.to_string()),
+            });
+            cost += cost_model.ml_training_dataset_added;
+        }
+
+        cost
+    }
+
+    /// Compute dataset-component-specific field changes between two components.
+    ///
+    /// Emits granular, prefixed `dataset_*` field changes: type, per-classification
+    /// sensitivity add/remove, and governance. Gaining a sensitivity classification
+    /// (e.g. a dataset newly tagged `pii`) is a data-governance signal and carries
+    /// a high cost.
+    fn compute_dataset_changes(
+        cost_model: &CostModel,
+        old: &Component,
+        new: &Component,
+        changes: &mut Vec<FieldChange>,
+    ) -> u32 {
+        let mut cost = 0u32;
+
+        match (&old.dataset, &new.dataset) {
+            (Some(old_ds), Some(new_ds)) => {
+                cost += Self::compute_dataset_sub_changes(cost_model, old_ds, new_ds, changes);
+            }
+            (None, Some(_)) | (Some(_), None) => {
+                changes.push(FieldChange {
+                    field: "dataset".to_string(),
+                    old_value: old.dataset.as_ref().map(|_| "present".to_string()),
+                    new_value: new.dataset.as_ref().map(|_| "present".to_string()),
+                });
+                cost += cost_model.dataset_changed;
+            }
+            (None, None) => {}
+        }
+
+        cost
+    }
+
+    fn compute_dataset_sub_changes(
+        cost_model: &CostModel,
+        old: &DatasetInfo,
+        new: &DatasetInfo,
+        changes: &mut Vec<FieldChange>,
+    ) -> u32 {
+        let mut cost = 0u32;
+
+        Self::push_scalar_change(
+            changes,
+            "dataset_type",
+            &old.dataset_type,
+            &new.dataset_type,
+            &mut cost,
+            cost_model.dataset_type_changed,
+        );
+
+        // Sensitivity classifications: emit per-classification add/remove so a
+        // dataset newly gaining "pii" is visible and costly.
+        let old_sens: HashSet<&str> = old
+            .sensitivity_classifications
+            .iter()
+            .map(String::as_str)
+            .collect();
+        let new_sens: HashSet<&str> = new
+            .sensitivity_classifications
+            .iter()
+            .map(String::as_str)
+            .collect();
+
+        let mut added: Vec<&str> = new_sens.difference(&old_sens).copied().collect();
+        added.sort_unstable();
+        for class in added {
+            changes.push(FieldChange {
+                field: "dataset_sensitivity".to_string(),
+                old_value: None,
+                new_value: Some(class.to_string()),
+            });
+            cost += cost_model.dataset_sensitivity_added;
+        }
+
+        let mut removed: Vec<&str> = old_sens.difference(&new_sens).copied().collect();
+        removed.sort_unstable();
+        for class in removed {
+            changes.push(FieldChange {
+                field: "dataset_sensitivity".to_string(),
+                old_value: Some(class.to_string()),
+                new_value: None,
+            });
+            cost += cost_model.dataset_sensitivity_removed;
+        }
+
+        // Governance owners: report a single change when the owner set differs.
+        let old_gov: HashSet<&str> = old.governance_owners.iter().map(String::as_str).collect();
+        let new_gov: HashSet<&str> = new.governance_owners.iter().map(String::as_str).collect();
+        if old_gov != new_gov {
+            changes.push(FieldChange {
+                field: "dataset_governance".to_string(),
+                old_value: Self::join_sorted(&old.governance_owners),
+                new_value: Self::join_sorted(&new.governance_owners),
+            });
+            cost += cost_model.dataset_governance_changed;
+        }
+
+        cost
+    }
+
+    /// Join a list of strings into a deterministic, comma-separated display value,
+    /// or `None` when empty.
+    fn join_sorted(values: &[String]) -> Option<String> {
+        if values.is_empty() {
+            return None;
+        }
+        let mut sorted: Vec<&str> = values.iter().map(String::as_str).collect();
+        sorted.sort_unstable();
+        Some(sorted.join(", "))
     }
 
     /// Compute crypto-specific field changes between two components.
@@ -372,8 +636,9 @@ impl ChangeComputer for ComponentChangeComputer {
 
 #[cfg(test)]
 mod tests {
+    // `DatasetInfo`, `DatasetRef`, and `MlModelInfo` are re-exported via the
+    // parent module's `use crate::model::{...}`.
     use super::*;
-    use crate::model::{DatasetInfo, MlModelInfo};
 
     #[test]
     fn test_component_change_computer_default() {
@@ -392,12 +657,17 @@ mod tests {
         assert!(result.is_empty());
     }
 
+    /// Locate the single field change with the given field name, asserting it exists.
+    fn find_change<'a>(changes: &'a [FieldChange], field: &str) -> &'a FieldChange {
+        changes
+            .iter()
+            .find(|c| c.field == field)
+            .unwrap_or_else(|| panic!("expected a `{field}` field change, got {changes:?}"))
+    }
+
     #[test]
-    fn test_ml_model_change_uses_dedicated_cost() {
-        let computer = ComponentChangeComputer::new(CostModel {
-            ml_model_changed: 42,
-            ..CostModel::default()
-        });
+    fn test_ml_quantization_change_is_granular() {
+        let computer = ComponentChangeComputer::default();
         let mut old = Component::new("model".to_string(), "model@1".to_string());
         let mut new = old.clone();
 
@@ -406,39 +676,162 @@ mod tests {
             ..MlModelInfo::default()
         });
         new.ml_model = Some(MlModelInfo {
-            quantization: Some("int8".to_string()),
+            quantization: Some("int4".to_string()),
             ..MlModelInfo::default()
         });
 
         let (changes, total_cost) = computer.compute_field_changes(&old, &new);
 
-        assert_eq!(total_cost, 42);
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].field, "ml_model");
+        // The opaque "ml_model" blob is gone; a prefixed ml_quantization change appears.
+        assert!(changes.iter().all(|c| c.field != "ml_model"));
+        let change = find_change(&changes, "ml_quantization");
+        assert_eq!(change.old_value.as_deref(), Some("fp32"));
+        assert_eq!(change.new_value.as_deref(), Some("int4"));
+        assert_eq!(total_cost, CostModel::default().ml_quantization_changed);
     }
 
     #[test]
-    fn test_dataset_change_uses_dedicated_cost() {
-        let computer = ComponentChangeComputer::new(CostModel {
-            dataset_changed: 17,
-            ..CostModel::default()
+    fn test_ml_architecture_and_task_changes_are_granular() {
+        let computer = ComponentChangeComputer::default();
+        let mut old = Component::new("model".to_string(), "model@1".to_string());
+        let mut new = old.clone();
+
+        old.ml_model = Some(MlModelInfo {
+            architecture_family: Some("cnn".to_string()),
+            architecture_name: Some("resnet".to_string()),
+            task: Some("computer-vision".to_string()),
+            ..MlModelInfo::default()
         });
+        new.ml_model = Some(MlModelInfo {
+            architecture_family: Some("transformer".to_string()),
+            architecture_name: Some("bert".to_string()),
+            task: Some("nlp".to_string()),
+            ..MlModelInfo::default()
+        });
+
+        let (changes, _) = computer.compute_field_changes(&old, &new);
+
+        let arch = find_change(&changes, "ml_architecture");
+        assert_eq!(arch.old_value.as_deref(), Some("cnn/resnet"));
+        assert_eq!(arch.new_value.as_deref(), Some("transformer/bert"));
+        let task = find_change(&changes, "ml_task");
+        assert_eq!(task.old_value.as_deref(), Some("computer-vision"));
+        assert_eq!(task.new_value.as_deref(), Some("nlp"));
+    }
+
+    #[test]
+    fn test_ml_training_dataset_removed_has_high_cost() {
+        let computer = ComponentChangeComputer::default();
+        let mut old = Component::new("model".to_string(), "model@1".to_string());
+        let mut new = old.clone();
+
+        old.ml_model = Some(MlModelInfo {
+            training_datasets: vec![
+                DatasetRef {
+                    reference: Some("ds-imagenet".to_string()),
+                    name: Some("imagenet".to_string()),
+                    purl: None,
+                },
+                DatasetRef {
+                    reference: Some("ds-coco".to_string()),
+                    name: Some("coco".to_string()),
+                    purl: None,
+                },
+            ],
+            ..MlModelInfo::default()
+        });
+        new.ml_model = Some(MlModelInfo {
+            training_datasets: vec![DatasetRef {
+                reference: Some("ds-imagenet".to_string()),
+                name: Some("imagenet".to_string()),
+                purl: None,
+            }],
+            ..MlModelInfo::default()
+        });
+
+        let (changes, total_cost) = computer.compute_field_changes(&old, &new);
+
+        let removed = find_change(&changes, "ml_training_dataset");
+        assert_eq!(removed.old_value.as_deref(), Some("ds-coco"));
+        assert_eq!(removed.new_value, None);
+        assert_eq!(total_cost, CostModel::default().ml_training_dataset_removed);
+    }
+
+    #[test]
+    fn test_dataset_sensitivity_escalation_has_high_cost() {
+        let computer = ComponentChangeComputer::default();
         let mut old = Component::new("dataset".to_string(), "dataset@1".to_string());
         let mut new = old.clone();
 
         old.dataset = Some(DatasetInfo {
             dataset_type: Some("training".to_string()),
+            sensitivity_classifications: vec!["public".to_string()],
             ..DatasetInfo::default()
         });
         new.dataset = Some(DatasetInfo {
-            dataset_type: Some("validation".to_string()),
+            dataset_type: Some("training".to_string()),
+            sensitivity_classifications: vec!["public".to_string(), "pii".to_string()],
             ..DatasetInfo::default()
         });
 
         let (changes, total_cost) = computer.compute_field_changes(&old, &new);
 
-        assert_eq!(total_cost, 17);
-        assert_eq!(changes.len(), 1);
-        assert_eq!(changes[0].field, "dataset");
+        // No opaque "dataset" blob; a prefixed dataset_sensitivity add appears.
+        assert!(changes.iter().all(|c| c.field != "dataset"));
+        let escalation = find_change(&changes, "dataset_sensitivity");
+        assert_eq!(escalation.old_value, None);
+        assert_eq!(escalation.new_value.as_deref(), Some("pii"));
+        assert_eq!(total_cost, CostModel::default().dataset_sensitivity_added);
+    }
+
+    #[test]
+    fn test_dataset_type_and_governance_changes_are_granular() {
+        let computer = ComponentChangeComputer::default();
+        let mut old = Component::new("dataset".to_string(), "dataset@1".to_string());
+        let mut new = old.clone();
+
+        old.dataset = Some(DatasetInfo {
+            dataset_type: Some("training".to_string()),
+            governance_owners: vec!["alice".to_string()],
+            ..DatasetInfo::default()
+        });
+        new.dataset = Some(DatasetInfo {
+            dataset_type: Some("validation".to_string()),
+            governance_owners: vec!["bob".to_string()],
+            ..DatasetInfo::default()
+        });
+
+        let (changes, _) = computer.compute_field_changes(&old, &new);
+
+        let ty = find_change(&changes, "dataset_type");
+        assert_eq!(ty.old_value.as_deref(), Some("training"));
+        assert_eq!(ty.new_value.as_deref(), Some("validation"));
+        let gov = find_change(&changes, "dataset_governance");
+        assert_eq!(gov.old_value.as_deref(), Some("alice"));
+        assert_eq!(gov.new_value.as_deref(), Some("bob"));
+    }
+
+    #[test]
+    fn test_security_focused_escalates_ml_and_dataset_costs() {
+        let secure = ComponentChangeComputer::new(CostModel::security_focused());
+        let default = ComponentChangeComputer::default();
+
+        let mut old = Component::new("dataset".to_string(), "dataset@1".to_string());
+        let mut new = old.clone();
+        old.dataset = Some(DatasetInfo {
+            sensitivity_classifications: vec![],
+            ..DatasetInfo::default()
+        });
+        new.dataset = Some(DatasetInfo {
+            sensitivity_classifications: vec!["pii".to_string()],
+            ..DatasetInfo::default()
+        });
+
+        let (_, secure_cost) = secure.compute_field_changes(&old, &new);
+        let (_, default_cost) = default.compute_field_changes(&old, &new);
+        assert!(
+            secure_cost > default_cost,
+            "security profile should weight PII escalation higher (secure={secure_cost}, default={default_cost})"
+        );
     }
 }

--- a/src/diff/cost.rs
+++ b/src/diff/cost.rs
@@ -26,6 +26,28 @@ pub struct CostModel {
     pub ml_model_changed: u32,
     /// Cost for dataset metadata change
     pub dataset_changed: u32,
+    /// Cost for ML approach change (e.g. supervised -> reinforcement-learning)
+    pub ml_approach_changed: u32,
+    /// Cost for ML architecture change (family or name, e.g. cnn -> transformer)
+    pub ml_architecture_changed: u32,
+    /// Cost for ML task change (e.g. nlp -> computer-vision)
+    pub ml_task_changed: u32,
+    /// Cost for ML quantization change (e.g. fp32 -> int4); a model-swap signal
+    pub ml_quantization_changed: u32,
+    /// Cost for ML model-card URL change
+    pub ml_model_card_changed: u32,
+    /// Cost for adding a training dataset to a model
+    pub ml_training_dataset_added: u32,
+    /// Cost for removing a training dataset from a model (provenance loss; HIGH)
+    pub ml_training_dataset_removed: u32,
+    /// Cost for dataset type change (e.g. training -> validation)
+    pub dataset_type_changed: u32,
+    /// Cost for dataset governance owners change
+    pub dataset_governance_changed: u32,
+    /// Cost for adding a dataset sensitivity classification (e.g. gaining PII; HIGH)
+    pub dataset_sensitivity_added: u32,
+    /// Cost for removing a dataset sensitivity classification
+    pub dataset_sensitivity_removed: u32,
     /// Cost for introducing a vulnerability
     pub vulnerability_introduced: u32,
     /// Reward (negative cost) for resolving a vulnerability
@@ -62,6 +84,17 @@ impl Default for CostModel {
             supplier_changed: 4,
             ml_model_changed: 6,
             dataset_changed: 5,
+            ml_approach_changed: 6,
+            ml_architecture_changed: 6,
+            ml_task_changed: 5,
+            ml_quantization_changed: 8,
+            ml_model_card_changed: 3,
+            ml_training_dataset_added: 5,
+            ml_training_dataset_removed: 12,
+            dataset_type_changed: 5,
+            dataset_governance_changed: 4,
+            dataset_sensitivity_added: 14,
+            dataset_sensitivity_removed: 6,
             vulnerability_introduced: 15,
             vulnerability_resolved: -3,
             dependency_added: 5,
@@ -89,6 +122,12 @@ impl CostModel {
             crypto_downgrade: 30,
             crypto_quantum_level_changed: 15,
             crypto_algorithm_changed: 12,
+            // Model-swap and data-governance escalations are security-relevant:
+            // gaining a sensitivity classification (e.g. PII), losing training-data
+            // provenance, or silently re-quantizing a model all warrant higher cost.
+            dataset_sensitivity_added: 22,
+            ml_training_dataset_removed: 18,
+            ml_quantization_changed: 12,
             ..Default::default()
         }
     }
@@ -171,6 +210,17 @@ mod tests {
         assert_eq!(model.supplier_changed, 4);
         assert_eq!(model.ml_model_changed, 6);
         assert_eq!(model.dataset_changed, 5);
+        assert_eq!(model.ml_approach_changed, 6);
+        assert_eq!(model.ml_architecture_changed, 6);
+        assert_eq!(model.ml_task_changed, 5);
+        assert_eq!(model.ml_quantization_changed, 8);
+        assert_eq!(model.ml_model_card_changed, 3);
+        assert_eq!(model.ml_training_dataset_added, 5);
+        assert_eq!(model.ml_training_dataset_removed, 12);
+        assert_eq!(model.dataset_type_changed, 5);
+        assert_eq!(model.dataset_governance_changed, 4);
+        assert_eq!(model.dataset_sensitivity_added, 14);
+        assert_eq!(model.dataset_sensitivity_removed, 6);
         assert_eq!(model.vulnerability_introduced, 15);
         assert_eq!(model.vulnerability_resolved, -3);
         assert_eq!(model.hash_mismatch, 8);
@@ -191,6 +241,9 @@ mod tests {
         assert!(model.vulnerability_resolved < default.vulnerability_resolved);
         assert!(model.crypto_downgrade > default.crypto_downgrade);
         assert!(model.crypto_quantum_level_changed > default.crypto_quantum_level_changed);
+        assert!(model.dataset_sensitivity_added > default.dataset_sensitivity_added);
+        assert!(model.ml_training_dataset_removed > default.ml_training_dataset_removed);
+        assert!(model.ml_quantization_changed > default.ml_quantization_changed);
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1206,13 +1206,151 @@ mod diff_engine_tests {
             .iter()
             .find(|change| change.name == "bert-base")
             .expect("bert-base change not found");
+        // ML changes are now granular and prefixed: a quantization swap surfaces as
+        // `ml_quantization`, not an opaque `ml_model` blob.
+        assert!(
+            change.field_changes.iter().all(|f| f.field != "ml_model"),
+            "opaque ml_model blob should be gone, got {:?}",
+            change.field_changes
+        );
         assert!(
             change
                 .field_changes
                 .iter()
-                .any(|field| field.field == "ml_model"),
-            "Expected ml_model field change, got {:?}",
+                .any(|field| field.field == "ml_quantization"),
+            "Expected ml_quantization field change, got {:?}",
             change.field_changes
+        );
+    }
+
+    /// End-to-end: a security-relevant ML/dataset revision — model re-quantized,
+    /// a training dataset dropped, and a dataset's sensitivity escalated to PII —
+    /// must surface as granular, prefixed `FieldChange`s carrying high costs, and
+    /// must render through the generic markdown and JSON report paths (no
+    /// AI/ML-specific report code).
+    #[test]
+    fn test_semantic_ml_dataset_diff_end_to_end() {
+        use sbom_tools::diff::CostModel;
+        use sbom_tools::reports::{JsonReporter, MarkdownReporter, ReportConfig, ReportGenerator};
+
+        let path = fixture_path("cyclonedx/minimal-mlbom.cdx.json");
+        let old = parse_sbom(&path).expect("Failed to parse ML BOM fixture");
+        let mut new = old.clone();
+
+        // (1) Re-quantize the model fp32-ish -> int4 and (2) drop the
+        // `data-wikipedia` training dataset, keeping `bookscorpus-800M`.
+        {
+            let model = new
+                .components
+                .values_mut()
+                .find(|c| c.name == "bert-base")
+                .expect("bert-base not found");
+            let ml = model.ml_model.as_mut().expect("ML metadata missing");
+            ml.quantization = Some("int4".to_string());
+            ml.training_datasets
+                .retain(|d| d.reference.as_deref() != Some("data-wikipedia"));
+            assert!(
+                ml.training_datasets
+                    .iter()
+                    .any(|d| d.name.as_deref() == Some("bookscorpus-800M")),
+                "bookscorpus training dataset should survive"
+            );
+            model.calculate_content_hash();
+        }
+
+        // (3) Escalate the wikipedia dataset's sensitivity to include PII.
+        {
+            let data = new
+                .components
+                .values_mut()
+                .find(|c| c.name == "wikipedia-2.5B")
+                .expect("wikipedia dataset not found");
+            let ds = data.dataset.as_mut().expect("dataset metadata missing");
+            ds.sensitivity_classifications.push("pii".to_string());
+            data.calculate_content_hash();
+        }
+
+        new.calculate_content_hash();
+
+        // Use a security-focused cost model so the high-severity signals are bumped.
+        let engine = DiffEngine::new().with_cost_model(CostModel::security_focused());
+        let result = engine.diff(&old, &new).expect("diff should succeed");
+
+        let model_change = result
+            .components
+            .modified
+            .iter()
+            .find(|c| c.name == "bert-base")
+            .expect("bert-base change not found");
+
+        let quant = model_change
+            .field_changes
+            .iter()
+            .find(|f| f.field == "ml_quantization")
+            .expect("ml_quantization change missing");
+        assert_eq!(quant.new_value.as_deref(), Some("int4"));
+
+        let removed_ds = model_change
+            .field_changes
+            .iter()
+            .find(|f| f.field == "ml_training_dataset" && f.new_value.is_none())
+            .expect("ml_training_dataset removal missing");
+        assert_eq!(removed_ds.old_value.as_deref(), Some("data-wikipedia"));
+
+        let data_change = result
+            .components
+            .modified
+            .iter()
+            .find(|c| c.name == "wikipedia-2.5B")
+            .expect("wikipedia dataset change not found");
+        let sensitivity = data_change
+            .field_changes
+            .iter()
+            .find(|f| f.field == "dataset_sensitivity" && f.old_value.is_none())
+            .expect("dataset_sensitivity escalation missing");
+        assert_eq!(sensitivity.new_value.as_deref(), Some("pii"));
+
+        // High-cost assertions: under the security profile the model's per-component
+        // cost must dominate the bumped quantization + dataset-removal weights, and
+        // the dataset's cost must reflect the PII escalation.
+        let secure = CostModel::security_focused();
+        assert!(
+            model_change.cost
+                >= secure.ml_quantization_changed + secure.ml_training_dataset_removed,
+            "model cost {} should cover quantization+dataset-removal weights",
+            model_change.cost
+        );
+        assert!(
+            data_change.cost >= secure.dataset_sensitivity_added,
+            "dataset cost {} should cover the PII-escalation weight",
+            data_change.cost
+        );
+
+        // Generic rendering: the prefixed field names must appear in markdown and the
+        // values must appear in JSON, with no dedicated AI/ML report code involved.
+        let config = ReportConfig::default();
+        let markdown = MarkdownReporter::new()
+            .generate_diff_report(&result, &old, &new, &config)
+            .expect("markdown report");
+        assert!(
+            markdown.contains("ml_quantization"),
+            "markdown should surface ml_quantization via the generic path"
+        );
+        assert!(
+            markdown.contains("dataset_sensitivity"),
+            "markdown should surface dataset_sensitivity via the generic path"
+        );
+
+        let json = JsonReporter::new()
+            .generate_diff_report(&result, &old, &new, &config)
+            .expect("json report");
+        assert!(
+            json.contains("ml_training_dataset") && json.contains("data-wikipedia"),
+            "json should surface the removed training dataset via the generic path"
+        );
+        assert!(
+            json.contains("dataset_sensitivity") && json.contains("pii"),
+            "json should surface the PII escalation via the generic path"
         );
     }
 


### PR DESCRIPTION
## Summary

`ml_model` and `dataset` changes were previously diffed as **opaque whole-struct comparisons** — `push_structured_change` emitted one `ml_model`/`dataset` `FieldChange` containing a serialized JSON blob, costed flatly via `ml_model_changed`/`dataset_changed`. Security-relevant signals (a model re-quantized `fp32 -> int4`, a training dataset removed, a dataset newly classified PII) were invisible and uniformly cheap.

This PR mirrors the established `compute_crypto_changes` precedent in the **same file** to emit granular, prefixed per-field changes.

**`src/diff/changes/components.rs`**
- Replaces the two `push_structured_change` calls with `compute_ml_changes` + `compute_dataset_changes`, gated exactly like the crypto branch.
- ML emits prefixed `ml_approach`, `ml_architecture` (family/name joined), `ml_task`, `ml_quantization`, `ml_model_card`, plus per-dataset `ml_training_dataset` add/remove keyed by `DatasetRef.reference`-or-`name`.
- Datasets emit `dataset_type`, per-classification `dataset_sensitivity` add/remove, and `dataset_governance`.
- Uses AI1's typed `MlModelInfo` fields. `None`/`Some` transitions fall back to a single presence change. Removed the now-dead `push_structured_change`/`serialize_optional` helpers.

**`src/diff/cost.rs`**
- Adds granular `CostModel` fields. Sensitivity-add (14) and training-dataset-removal (12) carry the highest default weights and are bumped in `security_focused()` to 22/18 alongside quantization 12 — mirroring `crypto_downgrade` 20→30.

**No new report code / no new flags** (deliberate): the granular `FieldChange`s flow through the existing generic markdown/JSON rendering (markdown renders `c.field`; JSON serializes `field_changes`), exactly as the crypto precedent did. No `--fail-on-ml-degradation` (no crypto-gate precedent; out of scope).

## Test plan
- 8 unit tests in `components.rs` assert the granular prefixed fields and their costs (quantization, architecture/task, training-dataset removal, sensitivity escalation, type/governance, security-profile escalation).
- Updated the stale opaque-blob assertion in `tests/integration_tests.rs`.
- New `test_semantic_ml_dataset_diff_end_to_end`: a quantization swap + a removed training dataset + a PII sensitivity escalation surfaces the expected high-cost `FieldChange`s and renders through the **generic** markdown/JSON paths.
- `cargo fmt --check` clean; `rustup run 1.88 cargo clippy --all-features --lib --tests` reports 0 warnings in the touched files; full `cargo test` suite: **1424 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)