### PR TITLE
fix(convert): preserve typed AI fields on emit; harden verify --model-dir paths

### DIFF
--- a/src/serialization/emit/cyclonedx.rs
+++ b/src/serialization/emit/cyclonedx.rs
@@ -348,7 +348,10 @@ fn emit_model_card(component: &Component, report: &mut FidelityReport) -> Option
             model_card.insert("modelParameters".to_string(), Value::Object(params));
         }
 
-        // considerations from typed limitations + energy.
+        // considerations from typed limitations + energy + the AI-readiness
+        // fields (fairness / ethics / use-cases). These mirror the exact spec
+        // field names + shapes the CycloneDX parser reads so an AI-BOM round-trips
+        // without regressing AI-005/007/009 scoring.
         let mut considerations = model_card
             .get("considerations")
             .and_then(Value::as_object)
@@ -368,8 +371,86 @@ fn emit_model_card(component: &Component, report: &mut FidelityReport) -> Option
                 }),
             );
         }
+        // considerations.fairnessAssessments[] — spec object shape
+        // { groupAtRisk, benefits, harms, mitigationStrategy } (camelCase, the
+        // parser's CdxFairnessObj). Only non-null fields are emitted.
+        if !ml.fairness.is_empty() {
+            let assessments: Vec<Value> = ml
+                .fairness
+                .iter()
+                .map(|f| {
+                    let mut o = Map::new();
+                    if let Some(group) = &f.group_at_risk {
+                        o.insert("groupAtRisk".to_string(), json!(group));
+                    }
+                    if let Some(benefits) = &f.benefits {
+                        o.insert("benefits".to_string(), json!(benefits));
+                    }
+                    if let Some(harms) = &f.harms {
+                        o.insert("harms".to_string(), json!(harms));
+                    }
+                    if let Some(mitigation) = &f.mitigation_strategy {
+                        o.insert("mitigationStrategy".to_string(), json!(mitigation));
+                    }
+                    Value::Object(o)
+                })
+                .collect();
+            considerations.insert("fairnessAssessments".to_string(), Value::Array(assessments));
+        }
+        // considerations.ethicalConsiderations[] — spec object shape
+        // { name, mitigationStrategy } (the parser's CdxEthicalObj).
+        if !ml.ethical_considerations.is_empty() {
+            let ethics: Vec<Value> = ml
+                .ethical_considerations
+                .iter()
+                .map(|e| {
+                    let mut o = Map::new();
+                    if let Some(name) = &e.name {
+                        o.insert("name".to_string(), json!(name));
+                    }
+                    if let Some(mitigation) = &e.mitigation_strategy {
+                        o.insert("mitigationStrategy".to_string(), json!(mitigation));
+                    }
+                    Value::Object(o)
+                })
+                .collect();
+            considerations.insert("ethicalConsiderations".to_string(), Value::Array(ethics));
+        }
+        // considerations.useCases — spec string array.
+        if !ml.use_cases.is_empty() {
+            considerations.insert("useCases".to_string(), json!(ml.use_cases));
+        }
         if !considerations.is_empty() {
             model_card.insert("considerations".to_string(), Value::Object(considerations));
+        }
+
+        // modelCard.quantitativeAnalysis.performanceMetrics[] — spec object shape
+        // { type, value, slice } (the parser's CdxPerformanceMetric).
+        if !ml.performance_metrics.is_empty() {
+            let metrics: Vec<Value> = ml
+                .performance_metrics
+                .iter()
+                .map(|m| {
+                    let mut o = Map::new();
+                    if let Some(metric_type) = &m.metric_type {
+                        o.insert("type".to_string(), json!(metric_type));
+                    }
+                    if let Some(value) = &m.value {
+                        o.insert("value".to_string(), json!(value));
+                    }
+                    if let Some(slice) = &m.slice {
+                        o.insert("slice".to_string(), json!(slice));
+                    }
+                    Value::Object(o)
+                })
+                .collect();
+            let mut quant = model_card
+                .get("quantitativeAnalysis")
+                .and_then(Value::as_object)
+                .cloned()
+                .unwrap_or_default();
+            quant.insert("performanceMetrics".to_string(), Value::Array(metrics));
+            model_card.insert("quantitativeAnalysis".to_string(), Value::Object(quant));
         }
         report.synthesized("modelCard from ml_model");
     }

--- a/src/verification/model_dir.rs
+++ b/src/verification/model_dir.rs
@@ -103,9 +103,16 @@ const fn is_verifiable(alg: &HashAlgorithm) -> bool {
 /// files found under `model_dir`.
 #[must_use]
 pub fn verify_model_dir(sbom: &NormalizedSbom, model_dir: &Path) -> ModelVerifyReport {
+    // Canonicalize the model-dir root once so symlink-escape detection (below)
+    // compares against a fully-resolved root. If the root itself can't be
+    // canonicalized (e.g. it does not exist), fall back to the path as given;
+    // the walk will simply find nothing.
+    let root = std::fs::canonicalize(model_dir).unwrap_or_else(|_| model_dir.to_path_buf());
+
     // Index files by basename (for direct-filename matches) once, so a large
-    // model directory is walked a single time.
-    let index = FileIndex::build(model_dir);
+    // model directory is walked a single time. Paths that resolve outside the
+    // root (via symlinks) are excluded by the index.
+    let index = FileIndex::build(&root);
 
     let mut report = ModelVerifyReport {
         model_dir: model_dir.display().to_string(),
@@ -123,7 +130,7 @@ pub fn verify_model_dir(sbom: &NormalizedSbom, model_dir: &Path) -> ModelVerifyR
         }
         report.total_models += 1;
 
-        let record = verify_component(component, model_dir, &index);
+        let record = verify_component(component, &root, &index);
         match record.result {
             ModelVerifyResult::Verified => report.verified_count += 1,
             ModelVerifyResult::Mismatch => report.mismatch_count += 1,
@@ -268,30 +275,61 @@ fn filename_candidates(component: &Component) -> Vec<String> {
 /// match both the sha256-named blob and a plain `model.safetensors` regardless
 /// of nesting. When several files share a basename the first seen wins; that is
 /// acceptable because hash verification still rejects a wrong file.
+///
+/// Indexed paths are stored in canonicalized form and are guaranteed to resolve
+/// *inside* the model-dir root: a symlink (or a `..` segment) that escapes the
+/// root is skipped, so `verify --model-dir` can never be tricked into reading a
+/// file outside the tree it was pointed at. HuggingFace's intra-tree
+/// `snapshots → blobs` symlinks still resolve fine because they stay under root.
 struct FileIndex {
     by_name: HashMap<String, PathBuf>,
 }
 
 impl FileIndex {
+    /// Build the index from a *canonicalized* `root`. Every candidate path is
+    /// itself canonicalized (which follows symlinks) and only retained when the
+    /// resolved path is still within `root`; this is the symlink-escape bound.
     fn build(root: &Path) -> Self {
         let mut by_name = HashMap::new();
         let mut stack = vec![root.to_path_buf()];
+        // Directories are canonical here, so a `visited` set makes the walk
+        // robust against symlinked-directory cycles within the tree.
+        let mut visited: std::collections::HashSet<PathBuf> = std::collections::HashSet::new();
 
         while let Some(dir) = stack.pop() {
+            if !visited.insert(dir.clone()) {
+                continue;
+            }
             let Ok(entries) = std::fs::read_dir(&dir) else {
                 continue;
             };
             for entry in entries.flatten() {
                 let path = entry.path();
-                // Resolve symlinks (HF snapshots are symlinks into blobs/).
-                let meta = match std::fs::metadata(&path) {
+                // Resolve the entry fully (follows symlinks, normalizes `..`).
+                // A path that fails to resolve (dangling symlink) is skipped.
+                let Ok(resolved) = std::fs::canonicalize(&path) else {
+                    continue;
+                };
+                // Reject anything that escapes the model-dir root. Without this a
+                // crafted `model.safetensors -> /etc/passwd` (or `../secret`)
+                // symlink would let an attacker have the verifier read an
+                // arbitrary file outside the directory under audit.
+                if !resolved.starts_with(root) {
+                    continue;
+                }
+                let meta = match std::fs::metadata(&resolved) {
                     Ok(m) => m,
                     Err(_) => continue,
                 };
                 if meta.is_dir() {
-                    stack.push(path);
+                    stack.push(resolved);
                 } else if let Some(name) = path.file_name().and_then(|n| n.to_str()) {
-                    by_name.entry(name.to_lowercase()).or_insert(path.clone());
+                    // Key on the on-disk basename (e.g. the human-readable
+                    // snapshot name), but store the bounded, resolved path so the
+                    // subsequent hash read targets the in-tree bytes.
+                    by_name
+                        .entry(name.to_lowercase())
+                        .or_insert_with(|| resolved.clone());
                 }
             }
         }
@@ -409,6 +447,70 @@ mod tests {
         let report = verify_model_dir(&sbom, dir.path());
         assert_eq!(report.no_hash_count, 1);
         assert_eq!(report.components[0].result, ModelVerifyResult::NoHash);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn does_not_follow_symlink_escaping_model_dir() {
+        use std::os::unix::fs::symlink;
+
+        // The real weight bytes live OUTSIDE the model directory.
+        let outside = tempfile::tempdir().unwrap();
+        let weights = b"weights that live outside the model dir";
+        let hex = sha256_hex(weights);
+        let secret = outside.path().join("model.safetensors");
+        fs::write(&secret, weights).unwrap();
+
+        // Inside the model dir, a symlink with a plausible weight name points at
+        // the out-of-tree file. A naive verifier would follow it and report
+        // VERIFIED, leaking the result of reading an arbitrary path.
+        let model_dir = tempfile::tempdir().unwrap();
+        symlink(&secret, model_dir.path().join("model.safetensors")).unwrap();
+
+        let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
+        sbom.add_component(model_component("escape", &hex));
+
+        let report = verify_model_dir(&sbom, model_dir.path());
+        assert_eq!(report.total_models, 1);
+        assert_eq!(
+            report.verified_count, 0,
+            "a symlink escaping the model dir must not be followed/verified"
+        );
+        assert_eq!(
+            report.components[0].result,
+            ModelVerifyResult::Missing,
+            "out-of-tree symlink target is treated as no in-tree file found"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn follows_intra_tree_symlink_like_hf_cache() {
+        use std::os::unix::fs::symlink;
+
+        // HuggingFace layout: blobs/<sha256> with a snapshots/ symlink that stays
+        // WITHIN the model dir. This must still verify (the escape guard only
+        // rejects targets that leave the root).
+        let dir = tempfile::tempdir().unwrap();
+        let weights = b"in-tree hf blob bytes";
+        let hex = sha256_hex(weights);
+
+        let blobs = dir.path().join("blobs");
+        let snapshots = dir.path().join("snapshots").join("main");
+        fs::create_dir_all(&blobs).unwrap();
+        fs::create_dir_all(&snapshots).unwrap();
+        let blob = blobs.join(&hex);
+        fs::write(&blob, weights).unwrap();
+        symlink(&blob, snapshots.join("model.safetensors")).unwrap();
+
+        let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
+        sbom.add_component(model_component("bert", &hex));
+
+        let report = verify_model_dir(&sbom, dir.path());
+        assert_eq!(
+            report.verified_count, 1,
+            "intra-tree HF snapshot→blob symlink must still verify"
+        );
     }
 
     #[test]

--- a/tests/convert_emit_tests.rs
+++ b/tests/convert_emit_tests.rs
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
 use sbom_tools::parsers::parse_sbom_str;
+use sbom_tools::quality::{QualityScorer, ScoringProfile};
 use sbom_tools::serialization::emit::{self, EmitTarget, preserve_source_json};
 
 const FIXTURES_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
@@ -268,6 +269,65 @@ fn ai_bom_convert_preserves_ml_bridge() {
 
     // Pure CycloneDX→CycloneDX of a typed model is not lossy.
     assert!(!report.is_lossy(), "report:\n{}", report.render());
+}
+
+/// Score `sbom_json` with the AiReadiness profile and return
+/// (overall_score, ids of the AI checks that passed).
+fn ai_readiness(sbom_json: &str) -> (f32, Vec<String>) {
+    let sbom = parse_sbom_str(sbom_json).expect("AI-BOM must parse");
+    let report = QualityScorer::new(ScoringProfile::AiReadiness).score(&sbom);
+    let metrics = report
+        .ai_readiness_metrics
+        .expect("AiReadiness profile yields ai_readiness_metrics");
+    assert!(
+        !metrics.is_not_applicable(),
+        "fixture must contain ML components"
+    );
+    let passed: Vec<String> = metrics
+        .checks
+        .iter()
+        .filter(|c| c.passed)
+        .map(|c| c.id.clone())
+        .collect();
+    (report.overall_score, passed)
+}
+
+#[test]
+fn ai_bom_convert_preserves_typed_ai_readiness_score() {
+    // Regression: the CycloneDX emitter previously dropped the typed AI fields
+    // (fairness / ethics / use-cases / performance metrics), so converting a
+    // fully-documented ML-BOM through `convert --to cyclonedx` regressed the
+    // AI-readiness score by ~37pt and flipped AI-004/005/007/009 pass→fail.
+    // No --preserve here: the typed path alone must round-trip.
+    let raw = read_fixture("cyclonedx/aibom-complete.cdx.json");
+    let sbom = parse_sbom_str(&raw).unwrap();
+
+    let (before, passed_before) = ai_readiness(&raw);
+
+    // A fully-documented model must already pass the transparency checks.
+    for id in ["AI-004", "AI-005", "AI-007", "AI-009"] {
+        assert!(
+            passed_before.contains(&id.to_string()),
+            "fixture should pass {id} before conversion: {passed_before:?}"
+        );
+    }
+
+    let (emitted, _report) = emit::emit(&sbom, EmitTarget::CycloneDx).unwrap();
+    let (after, passed_after) = ai_readiness(&emitted);
+
+    // The four typed-field checks must survive the round-trip.
+    for id in ["AI-004", "AI-005", "AI-007", "AI-009"] {
+        assert!(
+            passed_after.contains(&id.to_string()),
+            "{id} must still pass after convert→cyclonedx: {passed_after:?}"
+        );
+    }
+
+    // The overall score must not regress (allow ≤2pt float/normalization noise).
+    assert!(
+        after >= before - 2.0,
+        "AI-readiness regressed on round-trip: before={before:.1} after={after:.1}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Two pre-release defects in the AI-BOM path, with regression tests for each.

**1. MAJOR — `convert --to cyclonedx` dropped typed AI fields (~37.5pt AI-readiness regression).**
`emit_model_card` (`src/serialization/emit/cyclonedx.rs`) re-emitted only `modelParameters` and `considerations.{technicalLimitations, environmentalConsiderations}`. The four typed fields the CycloneDX parser populates — `MlModel.{fairness, ethical_considerations, use_cases, performance_metrics}` — were never re-emitted, so a CycloneDX ML-BOM round-tripped through `convert` lost the data that **AI-004 / AI-005 / AI-007 / AI-009** score, flipping them pass→fail. This violated the module invariant that converting an AI-BOM does not regress AI scoring.

Fix: also synthesize `considerations.fairnessAssessments`, `considerations.ethicalConsiderations`, `considerations.useCases`, and `modelCard.quantitativeAnalysis.performanceMetrics`, using the **exact spec field names/shapes the CycloneDX parser reads** (`groupAtRisk`/`benefits`/`harms`/`mitigationStrategy`; `name`/`mitigationStrategy`; `useCases` string array; `type`/`value`/`slice`) so the typed path round-trips without `--preserve`. The `extensions.raw` bridge fallback is left untouched, as requested.

> **Note / deviation:** the task asked to also fix the equivalent gap in the SPDX emitter ("SPDX 3 AI profile mapping"). The only SPDX emitter in the tree is **SPDX 2.3**, which has no AI/ML profile and already drops *all* `ml_model` metadata honestly via `note_unmappable` — there is no SPDX 3.0 emitter, so there is no equivalent typed-AI gap to fix on the SPDX side. No SPDX change was needed.

**2. SECURITY — `verify --model-dir` followed symlinks out of the model directory.**
`FileIndex::build` (`src/verification/model_dir.rs`) resolved entries with `fs::metadata` (which follows symlinks) and indexed the symlink path, so a crafted `model.safetensors -> /etc/passwd` (or `../secret`) symlink let the verifier read an arbitrary file outside the audited tree.

Fix: canonicalize the model-dir root and each candidate path, skip any whose resolved path escapes the root, and store the bounded resolved path for the hash read. Added a visited-dir set for robustness against intra-tree symlinked-directory cycles. HuggingFace cache layouts (sha256-named blobs, `snapshots → blobs` symlinks that stay under root) keep working.

## Test plan

- `cargo test --test convert_emit_tests` — incl. new `ai_bom_convert_preserves_typed_ai_readiness_score` (parse `aibom-complete.cdx.json` → score AiReadiness → `convert→cyclonedx` → re-parse → re-score; asserts AI-004/005/007/009 still pass and overall score does not drop >2pt). **Verified to FAIL without the emitter fix** (only AI-001/002/003/006/008/010 survived).
- `cargo test --lib model_dir` — 8 pass, incl. new `does_not_follow_symlink_escaping_model_dir` (**verified to FAIL with the escape guard disabled** — escaping symlink got verified) and `follows_intra_tree_symlink_like_hf_cache` (in-tree HF symlink still verifies).
- `cargo fmt --check`: clean. `rustup run 1.88 cargo clippy --all-features`: **0 new** warnings (35 lib baseline unchanged vs HEAD).
- Full `cargo test` on toolchain 1.88: all 46 test binaries pass, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)