### PR TITLE
fix(enrichment): official EPSS endpoint, cache namespace coverage, response size bound

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +723,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1144,6 +1159,16 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2035,6 +2060,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -3015,6 +3050,7 @@ dependencies = [
  "crossterm",
  "ctrlc",
  "dirs",
+ "flate2",
  "httpmock",
  "indexmap",
  "insta",
@@ -3264,6 +3300,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ clap_mangen = { version = "0.3", optional = true }
 
 # HTTP Client for enrichment
 reqwest = { version = "0.13", features = ["blocking", "json", "rustls"], default-features = false, optional = true }
+# gzip decompression for the FIRST EPSS bulk dataset (served as .csv.gz)
+flate2 = { version = "1.0", optional = true }
 sha2 = "0.11"
 
 # Utilities
@@ -80,7 +82,7 @@ schemars = "1.2"
 
 [features]
 default = ["enrichment", "cli", "tui"]
-enrichment = ["dep:reqwest"]
+enrichment = ["dep:reqwest", "dep:flate2"]
 # Interactive terminal UI (ratatui + crossterm). ~60K LOC of render/event code.
 tui = ["dep:ratatui", "dep:crossterm"]
 # Command handlers + binary support. The `cli` module calls into `crate::tui`,

--- a/src/cli/cache.rs
+++ b/src/cli/cache.rs
@@ -33,7 +33,7 @@ pub enum CacheAction {
     Warm {
         /// SBOM file to warm the cache for
         sbom: PathBuf,
-        /// Warm every source (OSV, EOL, KEV, staleness), not just OSV
+        /// Warm every source (OSV, EOL, KEV, EPSS, staleness, HuggingFace), not just OSV
         #[arg(long)]
         all_sources: bool,
     },
@@ -63,7 +63,12 @@ pub fn run_cache(action: CacheAction, quiet: bool) -> Result<i32> {
 }
 
 /// The enrichment source namespaces that live under the root cache directory.
-const SOURCE_NAMESPACES: &[&str] = &["osv", "eol", "kev", "staleness"];
+///
+/// Must list every namespace any client writes under (see each
+/// `namespaced_cache_dir(...)` call) so `cache status`/`cache clear` cover them
+/// all; EPSS and HuggingFace were previously omitted, so their caches were never
+/// purged or reported.
+const SOURCE_NAMESPACES: &[&str] = &["osv", "eol", "kev", "epss", "staleness", "huggingface"];
 
 /// Aggregate counts for one source's cache directory.
 struct SourceStatus {
@@ -179,6 +184,7 @@ fn cache_warm(sbom_path: &Path, all_sources: bool, quiet: bool) -> Result<i32> {
     let mut config = EnrichmentConfig::osv();
     config.enable_eol = all_sources;
     config.enable_kev = all_sources;
+    config.enable_epss = all_sources;
     config.enable_staleness = all_sources;
     config.enable_huggingface = all_sources;
     // Force fresh fetches so every queryable component lands in the cache.
@@ -196,7 +202,7 @@ fn cache_warm(sbom_path: &Path, all_sources: bool, quiet: bool) -> Result<i32> {
             "Warmed cache for {n} component(s) from {} ({}).",
             sbom_path.display(),
             if all_sources {
-                "OSV, EOL, KEV, staleness, HuggingFace"
+                "OSV, EOL, KEV, EPSS, staleness, HuggingFace"
             } else {
                 "OSV"
             }
@@ -361,5 +367,75 @@ mod tests {
         assert_eq!(copied, 2);
         assert!(dst.path().join("osv").join("a.json").exists());
         assert!(dst.path().join("osv").join("b.json").exists());
+    }
+
+    /// Regression: `cache status`/`cache clear` enumerate a fixed namespace
+    /// list. EPSS and HuggingFace clients write under their own namespaces, so
+    /// those must appear in the list or their caches are silently never purged
+    /// or reported.
+    #[test]
+    fn source_namespaces_cover_epss_and_huggingface() {
+        assert!(
+            SOURCE_NAMESPACES.contains(&"epss"),
+            "epss namespace must be covered by cache status/clear"
+        );
+        assert!(
+            SOURCE_NAMESPACES.contains(&"huggingface"),
+            "huggingface namespace must be covered by cache status/clear"
+        );
+
+        // The default cache dirs of the EPSS/HF clients must end in exactly the
+        // namespace strings the const enumerates, tying this test to the real
+        // write locations.
+        let epss_dir = crate::enrichment::epss::EpssClientConfig::default().cache_dir;
+        assert!(
+            epss_dir.ends_with("epss"),
+            "EPSS client writes under the 'epss' namespace"
+        );
+        let hf_dir = crate::enrichment::huggingface::HuggingFaceConfig::default().cache_dir;
+        assert!(
+            hf_dir.ends_with("huggingface"),
+            "HuggingFace client writes under the 'huggingface' namespace"
+        );
+    }
+
+    /// Regression: clearing the cache root removes EPSS and HuggingFace JSON
+    /// entries, not just the original four namespaces.
+    #[test]
+    fn clear_logic_removes_all_namespaces() {
+        let root = tempfile::tempdir().unwrap();
+        let mut expected_removed = 0usize;
+        for ns in SOURCE_NAMESPACES {
+            let dir = root.path().join(ns);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(dir.join("entry.json"), "{}").unwrap();
+            expected_removed += 1;
+        }
+
+        // Mirror cache_clear's per-namespace removal against the temp root.
+        let mut removed = 0usize;
+        for ns in SOURCE_NAMESPACES {
+            let dir = root.path().join(ns);
+            if let Ok(read_dir) = fs::read_dir(&dir) {
+                for entry in read_dir.flatten() {
+                    let path = entry.path();
+                    if path.extension().is_some_and(|e| e == "json")
+                        && fs::remove_file(&path).is_ok()
+                    {
+                        removed += 1;
+                    }
+                }
+            }
+        }
+
+        assert_eq!(removed, expected_removed);
+        assert!(
+            !root.path().join("epss").join("entry.json").exists(),
+            "epss entry must be cleared"
+        );
+        assert!(
+            !root.path().join("huggingface").join("entry.json").exists(),
+            "huggingface entry must be cleared"
+        );
     }
 }

--- a/src/enrichment/epss/client.rs
+++ b/src/enrichment/epss/client.rs
@@ -12,9 +12,23 @@ const EPSS_CACHE_FILE: &str = "epss_scores.json";
 
 /// Default FIRST EPSS bulk-scores URL.
 ///
-/// FIRST also serves a gzip-compressed `…/epss_scores-current.csv.gz`; the
-/// uncompressed endpoint is used here so no gzip dependency is required.
-pub const EPSS_SCORES_URL: &str = "https://epss.cybersecurity.fr/epss_scores-current.csv";
+/// This is the official FIRST-operated endpoint (run by Empirical Security, who
+/// maintain EPSS for FIRST). It 302-redirects to the dated
+/// `epss_scores-YYYY-MM-DD.csv.gz`; `reqwest` follows redirects by default. The
+/// payload is gzip-compressed, so [`EpssClient::fetch_from_api`] detects the
+/// gzip magic bytes (`0x1f 0x8b`) and decompresses before CSV parsing.
+///
+/// The previous default pointed at a non-FIRST third-party mirror
+/// (`epss.cybersecurity.fr`); fetching exploit-risk gating data from a
+/// non-official host is a supply-chain risk, so the default is pinned here and
+/// asserted by [`tests::default_url_uses_official_first_host`].
+pub const EPSS_SCORES_URL: &str = "https://epss.empiricalsecurity.com/epss_scores-current.csv.gz";
+
+/// Host the default [`EPSS_SCORES_URL`] must resolve to.
+///
+/// Pinned so the default endpoint cannot silently drift back to an unofficial
+/// mirror; see the regression test of the same name.
+pub const EPSS_OFFICIAL_HOST: &str = "epss.empiricalsecurity.com";
 
 /// EPSS client configuration.
 #[derive(Debug, Clone)]
@@ -131,9 +145,15 @@ impl EpssClient {
             )));
         }
 
-        let body = response
-            .text()
-            .map_err(|e| EnrichmentError::ParseError(e.to_string()))?;
+        // Bound the body so a malicious/MITM endpoint cannot OOM us; the full
+        // daily EPSS dataset is well under the cap.
+        let raw = crate::enrichment::source::read_bounded(response)
+            .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
+
+        // The official `…current.csv.gz` endpoint serves gzip; the test seam
+        // serves plain CSV. Decompress only when the gzip magic is present so
+        // both work without a separate code path.
+        let body = decode_maybe_gzip(&raw)?;
 
         Ok(EpssScores::from_csv(&body))
     }
@@ -144,6 +164,16 @@ impl EpssClient {
         Err(EnrichmentError::ApiError(
             "Enrichment feature not enabled".to_string(),
         ))
+    }
+
+    /// Convert the EPSS bulk dataset bytes (gzip or plain) to a CSV string.
+    ///
+    /// Exposed at the type level for the gzip round-trip test; see
+    /// [`decode_maybe_gzip`].
+    #[cfg(test)]
+    #[cfg(feature = "enrichment")]
+    fn decode_body(raw: &[u8]) -> Result<String, EnrichmentError> {
+        decode_maybe_gzip(raw)
     }
 
     /// Load the EPSS dataset (from cache or API).
@@ -214,6 +244,29 @@ impl EpssClient {
     }
 }
 
+/// Decode an EPSS body, decompressing only when it is gzip-framed.
+///
+/// The official `epss_scores-current.csv.gz` endpoint serves gzip; the
+/// `--epss-url`/`SBOM_TOOLS_EPSS_URL` test seam serves plain CSV. Detecting the
+/// gzip magic bytes (`0x1f 0x8b`) keeps a single fetch path working for both
+/// without depending on the URL extension or a `Content-Encoding` header.
+#[cfg(feature = "enrichment")]
+fn decode_maybe_gzip(raw: &[u8]) -> Result<String, EnrichmentError> {
+    use std::io::Read;
+
+    if raw.starts_with(&[0x1f, 0x8b]) {
+        let mut decoder = flate2::read::GzDecoder::new(raw);
+        let mut out = String::new();
+        decoder
+            .read_to_string(&mut out)
+            .map_err(|e| EnrichmentError::ParseError(format!("gzip decode failed: {e}")))?;
+        Ok(out)
+    } else {
+        String::from_utf8(raw.to_vec())
+            .map_err(|e| EnrichmentError::ParseError(format!("EPSS body is not valid UTF-8: {e}")))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -232,6 +285,58 @@ mod tests {
     fn test_epss_client_creation() {
         let client = EpssClient::with_defaults();
         assert!(client.scores.is_none());
+    }
+
+    /// Regression: the default EPSS endpoint must be the official FIRST host,
+    /// never an unofficial third-party mirror.
+    #[test]
+    fn default_url_uses_official_first_host() {
+        let cfg = EpssClientConfig::default();
+        let host = cfg
+            .epss_url
+            .strip_prefix("https://")
+            .and_then(|rest| rest.split('/').next())
+            .expect("default EPSS URL must be an https URL");
+        assert_eq!(
+            host, EPSS_OFFICIAL_HOST,
+            "default EPSS endpoint must point at the official FIRST host"
+        );
+        assert!(
+            EPSS_SCORES_URL.starts_with("https://"),
+            "default EPSS URL must use https"
+        );
+    }
+
+    /// Regression: a gzip-framed body (the official `.csv.gz` endpoint) round-
+    /// trips through decoding to the original CSV, while a plain body (the test
+    /// seam) is passed through unchanged.
+    #[cfg(feature = "enrichment")]
+    #[test]
+    fn decodes_gzip_and_plain_bodies() {
+        use flate2::Compression;
+        use flate2::write::GzEncoder;
+        use std::io::Write;
+
+        let csv = "#model_version:v1,score_date:2026-06-01\n\
+                   cve,epss,percentile\n\
+                   CVE-2024-9999,0.87654,0.95432\n";
+
+        // Plain body passes through unchanged.
+        let plain = EpssClient::decode_body(csv.as_bytes()).unwrap();
+        assert_eq!(plain, csv);
+
+        // Gzip body decompresses back to the original CSV, and parses.
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(csv.as_bytes()).unwrap();
+        let gz = encoder.finish().unwrap();
+        assert_eq!(&gz[..2], &[0x1f, 0x8b], "gzip magic must be present");
+
+        let decoded = EpssClient::decode_body(&gz).unwrap();
+        assert_eq!(decoded, csv);
+
+        let scores = EpssScores::from_csv(&decoded);
+        let entry = scores.get("CVE-2024-9999").expect("score parsed");
+        assert!((entry.score - 0.87654).abs() < 1e-9);
     }
 
     #[test]

--- a/src/enrichment/epss/mod.rs
+++ b/src/enrichment/epss/mod.rs
@@ -21,5 +21,7 @@
 mod client;
 mod scores;
 
-pub use client::{EPSS_SCORES_URL, EpssClient, EpssClientConfig, EpssEnrichmentStats};
+pub use client::{
+    EPSS_OFFICIAL_HOST, EPSS_SCORES_URL, EpssClient, EpssClientConfig, EpssEnrichmentStats,
+};
 pub use scores::{EpssEntry, EpssScores};

--- a/src/enrichment/huggingface/client.rs
+++ b/src/enrichment/huggingface/client.rs
@@ -153,8 +153,11 @@ impl HuggingFaceClient {
             )));
         }
 
-        let info: HfModelInfo = response
-            .json()
+        // Bound the body before buffering it so a hostile endpoint cannot OOM us.
+        let bytes = crate::enrichment::source::read_bounded(response)
+            .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
+
+        let info: HfModelInfo = serde_json::from_slice(&bytes)
             .map_err(|e| EnrichmentError::ParseError(e.to_string()))?;
         Ok(Some(info))
     }

--- a/src/enrichment/kev/client.rs
+++ b/src/enrichment/kev/client.rs
@@ -135,8 +135,11 @@ impl KevClient {
             )));
         }
 
-        let catalog_response: KevCatalogResponse = response
-            .json()
+        // Bound the body before buffering it so a hostile endpoint cannot OOM us.
+        let bytes = crate::enrichment::source::read_bounded(response)
+            .map_err(|e| EnrichmentError::ApiError(e.to_string()))?;
+
+        let catalog_response: KevCatalogResponse = serde_json::from_slice(&bytes)
             .map_err(|e| EnrichmentError::ParseError(e.to_string()))?;
 
         Ok(KevCatalog::from_response(catalog_response))

--- a/src/enrichment/source.rs
+++ b/src/enrichment/source.rs
@@ -160,6 +160,64 @@ pub fn http_client(timeout: Duration) -> reqwest::Result<reqwest::blocking::Clie
 /// server-provided `Retry-After`.
 const MAX_BACKOFF: Duration = Duration::from_secs(30);
 
+/// Upper bound on a single enrichment response body, in bytes.
+///
+/// Enrichment responses are read fully into memory (the EPSS CSV into a
+/// `HashMap`, the KEV/HuggingFace JSON into structs). Without a cap a malicious
+/// or MITM'd endpoint advertising (or streaming) a huge body could OOM the
+/// process. The largest legitimate payload is the full daily EPSS dataset
+/// (~10-20 MB uncompressed); 256 MiB is a generous-but-finite ceiling that no
+/// real source approaches.
+pub const MAX_RESPONSE_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Read a response body into memory, refusing bodies larger than
+/// [`MAX_RESPONSE_BYTES`].
+///
+/// The cap is enforced twice: first against a declared `Content-Length` (a cheap
+/// up-front reject), then against the actually-buffered length (a defense against
+/// a lying or absent header). The returned bytes are guaranteed `<= MAX`.
+#[cfg(feature = "enrichment")]
+pub fn read_bounded(response: reqwest::blocking::Response) -> Result<Vec<u8>> {
+    read_bounded_with_max(response, MAX_RESPONSE_BYTES)
+}
+
+/// [`read_bounded`] with an explicit cap.
+///
+/// Split out so the cap behavior can be exercised against a real (small)
+/// response without having to transmit a 256 MiB body in tests.
+#[cfg(feature = "enrichment")]
+pub(crate) fn read_bounded_with_max(
+    response: reqwest::blocking::Response,
+    max_bytes: u64,
+) -> Result<Vec<u8>> {
+    if let Some(len) = response.content_length()
+        && len > max_bytes
+    {
+        return Err(oversized_error(len, max_bytes));
+    }
+
+    let bytes = response
+        .bytes()
+        .map_err(|e| network_error("reading response body", &e))?;
+
+    if bytes.len() as u64 > max_bytes {
+        return Err(oversized_error(bytes.len() as u64, max_bytes));
+    }
+
+    Ok(bytes.to_vec())
+}
+
+/// Build the "response too large" enrichment error.
+#[cfg(feature = "enrichment")]
+fn oversized_error(len: u64, max_bytes: u64) -> crate::error::SbomDiffError {
+    crate::error::SbomDiffError::enrichment(
+        "response too large",
+        crate::error::EnrichmentErrorKind::NetworkError(format!(
+            "response body of {len} bytes exceeds the {max_bytes}-byte limit"
+        )),
+    )
+}
+
 /// Compute the backoff delay before retry `attempt` (1-based).
 ///
 /// Honors a server-provided `Retry-After` (seconds) when present, otherwise
@@ -687,6 +745,59 @@ mod tests {
             !cache.path_for("entry").exists(),
             "expired entry should be evicted"
         );
+    }
+
+    #[cfg(feature = "enrichment")]
+    #[test]
+    fn read_bounded_rejects_oversized_body() {
+        use httpmock::prelude::*;
+
+        let server = MockServer::start();
+        // A body that comfortably exceeds the tiny test cap below.
+        let body = "x".repeat(1024);
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/big");
+            then.status(200).body(&body);
+        });
+
+        let client = http_client(Duration::from_secs(5)).unwrap();
+        let resp = get_with_retry(&client, &format!("{}/big", server.base_url()), 0).unwrap();
+        mock.assert();
+
+        let err =
+            read_bounded_with_max(resp, 16).expect_err("a body over the cap must be rejected");
+        // The user-facing message names the size-cap; the byte-precise detail
+        // ("exceeds the N-byte limit") is carried on the error's source chain.
+        assert!(
+            err.to_string().contains("too large"),
+            "error must explain the size-cap rejection, got: {err}"
+        );
+        let detail = std::error::Error::source(&err)
+            .map(ToString::to_string)
+            .unwrap_or_default();
+        assert!(
+            detail.contains("exceeds"),
+            "source must carry the byte-precise detail, got: {detail}"
+        );
+    }
+
+    #[cfg(feature = "enrichment")]
+    #[test]
+    fn read_bounded_accepts_body_within_cap() {
+        use httpmock::prelude::*;
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/ok");
+            then.status(200).body("hello");
+        });
+
+        let client = http_client(Duration::from_secs(5)).unwrap();
+        let resp = get_with_retry(&client, &format!("{}/ok", server.base_url()), 0).unwrap();
+        mock.assert();
+
+        let bytes = read_bounded_with_max(resp, MAX_RESPONSE_BYTES).unwrap();
+        assert_eq!(bytes, b"hello");
     }
 
     #[test]

--- a/tests/kev_staleness_tests.rs
+++ b/tests/kev_staleness_tests.rs
@@ -188,6 +188,54 @@ fn enrich_sbom_full_sets_epss_score() {
     );
 }
 
+/// gzip the given bytes (mirrors the official `.csv.gz` EPSS endpoint).
+fn gzip(bytes: &[u8]) -> Vec<u8> {
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use std::io::Write;
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(bytes).unwrap();
+    encoder.finish().unwrap()
+}
+
+#[test]
+fn epss_client_decompresses_gzipped_dataset() {
+    use sbom_tools::enrichment::epss::{EpssClient, EpssClientConfig};
+
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+
+    let csv = epss_csv_body("CVE-2021-44228");
+    let gz = gzip(csv.as_bytes());
+
+    let mock = server.mock(|when, then| {
+        when.method(GET).path("/epss_scores-current.csv.gz");
+        then.status(200)
+            .header("content-type", "application/gzip")
+            .body(gz);
+    });
+
+    let config = EpssClientConfig {
+        cache_dir: cache_dir.path().to_path_buf(),
+        epss_url: format!("{}/epss_scores-current.csv.gz", server.base_url()),
+        bypass_cache: true,
+        ..EpssClientConfig::default()
+    };
+
+    let mut client = EpssClient::new(config);
+    client.load_scores().expect("gzipped dataset must load");
+    mock.assert();
+
+    let scores = client.scores().expect("scores populated");
+    let entry = scores
+        .get("CVE-2021-44228")
+        .expect("CVE present in decompressed dataset");
+    assert!(
+        (entry.score - 0.91234).abs() < 1e-9,
+        "decompressed score must parse"
+    );
+}
+
 #[test]
 fn staleness_enrichment_feeds_lifecycle_metric() {
     // A component carrying staleness data (as the staleness enricher would


### PR DESCRIPTION
## Summary

Four verified pre-release defects in the new enrichment/cache surface:

1. **SECURITY — default EPSS endpoint was an unofficial third-party mirror.** `EPSS_SCORES_URL` hardcoded `https://epss.cybersecurity.fr/...` and `EpssClientConfig::default()` used it, so a default `--epss` run fetched exploit-risk gating data from a non-FIRST host. The default is now the **official FIRST endpoint** `https://epss.empiricalsecurity.com/epss_scores-current.csv.gz` (302-redirects to the dated `.csv.gz`; reqwest follows redirects).
   - The payload is **gzip**: `EpssClient::fetch_from_api` detects the gzip magic bytes (`0x1f 0x8b`) and decompresses; a plain CSV body (the `--epss-url` / `SBOM_TOOLS_EPSS_URL` test seam) is passed through unchanged. One fetch path serves both, so no test mock needs gzipping.
   - Adds the `flate2` crate (MIT/Apache, cargo-deny-clean — pure-Rust `miniz_oxide` backend).
   - Pins the default host via `EPSS_OFFICIAL_HOST` + a regression test so it cannot silently drift again.

2. **`cache clear`/`status` ignored the `epss` + `huggingface` namespaces.** Both clients write under `namespaced_cache_dir("epss")/("huggingface")`, but `SOURCE_NAMESPACES` omitted them, so those caches were never purged or reported. The list now covers all six sources.

3. **`cache warm --all` skipped EPSS.** `cache_warm` set every `enable_*` flag except `enable_epss` (default `false`), so a later `--epss --offline` run could not be served. Now sets `enable_epss = all_sources` and names EPSS in the warm summary.

4. **SECURITY — no response-size bound on EPSS/KEV/HuggingFace reads.** These buffered full bodies (`response.text()` / `.json()`) with no cap, so a malicious/MITM endpoint could OOM the process. Adds `read_bounded` in `source.rs` enforcing `MAX_RESPONSE_BYTES` (256 MiB — the full daily EPSS CSV is ~10-20 MB) against both `Content-Length` and the actually-buffered length; EPSS/KEV/HF decode the bounded buffer.

### Approach note (gzip vs. test seam)
Decompression is **conditional on the gzip magic bytes**, not on the URL extension or a `Content-Encoding` header. The production `.csv.gz` endpoint is gzip-framed and decompresses; the httpmock test seam serves uncompressed CSV and is detected as non-gzip and passed through. This keeps a single code path with no per-environment branching.

## Test plan

- `default_url_uses_official_first_host` — asserts `EpssClientConfig::default()` host is `epss.empiricalsecurity.com` and uses https.
- `decodes_gzip_and_plain_bodies` (unit) + `epss_client_decompresses_gzipped_dataset` (httpmock integration) — gzip round-trip parses; plain body passes through.
- `read_bounded_rejects_oversized_body` / `read_bounded_accepts_body_within_cap` — size cap triggers a clean error on an over-cap body and accepts a within-cap body (real httpmock response, small injectable cap).
- `source_namespaces_cover_epss_and_huggingface` + `clear_logic_removes_all_namespaces` — `cache status`/`clear` now cover `epss`/`huggingface`, tied to each client's real default cache dir.
- Verified under the **true 1.88** clippy (toolchain bin, not the brew-shadowed 1.96): `cargo clippy -- -D warnings` and `cargo clippy --all-features -- -D warnings` both clean. `cargo fmt --check` clean. `cargo check --no-default-features --features ffi` and `cargo build` pass (non-enrichment stubs unaffected). `cargo deny check licenses/bans` ok. Full `cargo test` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)