### PR TITLE
fix(cli): route enrich/watch/query through the unified enrichment orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -778,6 +778,7 @@ jobs:
 | `3` | Error |
 | `4` | VEX coverage gaps found (`--fail-on-vex-gap`) |
 | `5` | License policy violations found (`license-check`) |
+| `6` | Actively exploited (KEV) vulnerability introduced (`--fail-on-kev`) |
 
 ## Configuration
 

--- a/src/cli/enrich.rs
+++ b/src/cli/enrich.rs
@@ -25,34 +25,15 @@ pub fn run_enrich(
     let raw_json = std::fs::read_to_string(file)?;
     let mut sbom = parse_sbom(file)?;
 
-    // Enrich with OSV vulnerability data
-    if enrichment.enabled {
-        let osv_config = crate::pipeline::build_enrichment_config(&enrichment);
-        if crate::pipeline::enrich_sbom(&mut sbom, &osv_config, quiet).is_none() && !quiet {
-            eprintln!("Warning: OSV vulnerability enrichment failed");
+    // Route through the unified orchestrator so every advertised source
+    // (OSV / KEV / EPSS / EOL / staleness / HuggingFace / VEX) and the config
+    // file's `enrichment:` block are honored. Hand-rolling individual sources
+    // here silently dropped --kev/--epss/--enrich-staleness/--huggingface.
+    let stats = crate::pipeline::enrich_sbom_full(&mut sbom, &enrichment, quiet);
+    if !quiet {
+        for warning in &stats.warnings {
+            eprintln!("Warning: {warning}");
         }
-    }
-
-    // Enrich with EOL data
-    if enrichment.enable_eol {
-        let eol_config = crate::enrichment::EolClientConfig {
-            cache_dir: enrichment
-                .cache_dir
-                .clone()
-                .unwrap_or_else(crate::pipeline::dirs::eol_cache_dir),
-            cache_ttl: std::time::Duration::from_secs(enrichment.cache_ttl_hours * 3600),
-            bypass_cache: enrichment.bypass_cache,
-            timeout: std::time::Duration::from_secs(enrichment.timeout_secs),
-            ..Default::default()
-        };
-        if crate::pipeline::enrich_eol(&mut sbom, &eol_config, quiet).is_none() && !quiet {
-            eprintln!("Warning: EOL enrichment failed");
-        }
-    }
-
-    // Apply VEX overlays
-    if !enrichment.vex_paths.is_empty() {
-        crate::pipeline::enrich_vex(&mut sbom, &enrichment.vex_paths, quiet);
     }
 
     let enriched_json = enrich_sbom_json(&raw_json, &sbom)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1874,6 +1874,7 @@ fn main() -> Result<()> {
         }
 
         Commands::Query(args) => {
+            let sm = sub_matches;
             // Split positional args: first arg is pattern if it doesn't look like a file,
             // otherwise all args are file paths
             let (pattern, sbom_paths) = split_query_args(&args.args);
@@ -1882,7 +1883,11 @@ fn main() -> Result<()> {
                 anyhow::bail!("No SBOM files specified. Usage: sbom-tools query [PATTERN] FILE...");
             }
 
-            let enrichment = args.enrichment.to_enrichment_config();
+            // Route through the shared seeder so the config file's `enrichment:`
+            // block applies (ValueSource precedence) and the global --offline
+            // flag is carried into the config. seed_enrichment already folds
+            // `offline` in, so no double-setting is needed below.
+            let enrichment = seed_enrichment(&args.enrichment, sm, &app, offline);
 
             let quantum_safe_filter = if args.quantum_safe {
                 Some(true)
@@ -1909,10 +1914,14 @@ fn main() -> Result<()> {
             let config = QueryConfig {
                 sbom_paths,
                 output: OutputConfig {
-                    format: args.output,
+                    format: resolve(
+                        args.output,
+                        arg_was_set_sub(sm, "output"),
+                        Some(app.output.format),
+                    ),
                     file: args.output_file,
                     report_types: ReportType::All,
-                    no_color: cli.no_color,
+                    no_color: resolve_bool(cli.no_color, app.output.no_color),
                     streaming: sbom_tools::config::StreamingConfig::default(),
                     export_template: None,
                 },

--- a/src/pipeline/enrich.rs
+++ b/src/pipeline/enrich.rs
@@ -78,7 +78,13 @@ pub fn enrich_sbom_full(
     // gates every source's network layer and flips cache reads to
     // stale-if-offline. `main` already sets this for the CLI; setting it here
     // makes library callers (and tests) offline-correct too.
-    crate::enrichment::source::set_offline(config.offline);
+    //
+    // OR with the current process-wide flag so this can NEVER re-enable network
+    // egress that a global `--offline` (set in `main`) already disabled — a
+    // per-call `config.offline == false` must not override an air-gapped run.
+    crate::enrichment::source::set_offline(
+        crate::enrichment::source::is_offline() || config.offline,
+    );
     if config.offline && !quiet {
         stats
             .warnings

--- a/src/serialization/enricher.rs
+++ b/src/serialization/enricher.rs
@@ -74,6 +74,33 @@ fn inject_cyclonedx_vulns(doc: &mut Value, sbom: &NormalizedSbom) {
                 });
             }
 
+            // Surface KEV / EPSS overlays as vulnerability properties so the
+            // enriched output SBOM actually carries the data the `--kev` /
+            // `--epss` flags produced (it would otherwise be dropped on
+            // serialization).
+            let mut props = Vec::new();
+            if vuln.is_kev {
+                props.push(serde_json::json!({
+                    "name": "sbom-tools:kev",
+                    "value": "true",
+                }));
+                if let Some(kev) = &vuln.kev_info {
+                    props.push(serde_json::json!({
+                        "name": "sbom-tools:kev:ransomware",
+                        "value": kev.known_ransomware_use.to_string(),
+                    }));
+                }
+            }
+            if let Some(score) = vuln.epss_score {
+                props.push(serde_json::json!({
+                    "name": "sbom-tools:epss:score",
+                    "value": score.to_string(),
+                }));
+            }
+            if !props.is_empty() {
+                vuln_obj["properties"] = Value::Array(props);
+            }
+
             vulns.push(vuln_obj);
         }
     }

--- a/src/watch/loop_impl.rs
+++ b/src/watch/loop_impl.rs
@@ -178,10 +178,11 @@ pub fn run_watch_loop(config: &WatchConfig) -> anyhow::Result<()> {
     }
 }
 
-/// Enrich an SBOM in place with OSV/EOL/VEX data per the watch config.
+/// Enrich an SBOM in place with OSV/KEV/EPSS/EOL/staleness/HuggingFace/VEX data
+/// per the watch config.
 ///
-/// `bypass_cache` forces fresh OSV/EOL data (used by periodic enrichment
-/// cycles); otherwise the configured cache behavior applies.
+/// `bypass_cache` forces fresh data (used by periodic enrichment cycles);
+/// otherwise the configured cache behavior applies.
 #[cfg(feature = "enrichment")]
 fn enrich_watched_sbom(sbom: &mut NormalizedSbom, config: &WatchConfig, bypass_cache: bool) {
     let mut osv_config = crate::pipeline::build_enrichment_config(&config.enrichment);
@@ -252,6 +253,24 @@ fn enrich_watched_sbom(sbom: &mut NormalizedSbom, config: &WatchConfig, bypass_c
             ..Default::default()
         };
         crate::pipeline::enrich_staleness(sbom, &staleness_config, true);
+    }
+
+    if config.enrichment.enable_huggingface {
+        let mut hf_config = crate::enrichment::HuggingFaceConfig {
+            cache_dir: config
+                .enrichment
+                .cache_dir
+                .clone()
+                .unwrap_or_else(crate::pipeline::dirs::huggingface_cache_dir),
+            cache_ttl: std::time::Duration::from_secs(config.enrichment.cache_ttl_hours * 3600),
+            bypass_cache,
+            timeout: std::time::Duration::from_secs(config.enrichment.timeout_secs),
+            ..Default::default()
+        };
+        if let Some(ref url) = config.enrichment.huggingface_url {
+            hf_config.api_url = url.clone();
+        }
+        crate::pipeline::enrich_huggingface(sbom, &hf_config, true);
     }
 
     if !config.enrichment.vex_paths.is_empty() {
@@ -595,6 +614,92 @@ fn count_vulns(sbom: &NormalizedSbom) -> usize {
 
 fn count_eol(sbom: &NormalizedSbom) -> usize {
     sbom.components.values().filter(|c| c.eol.is_some()).count()
+}
+
+#[cfg(all(test, feature = "enrichment"))]
+mod tests {
+    use super::*;
+    use crate::config::{EnrichmentConfig, OutputConfig};
+    use crate::model::{Component, ComponentType, MlModelInfo};
+    use httpmock::prelude::*;
+    use std::time::Duration;
+
+    fn hf_model_body() -> serde_json::Value {
+        serde_json::json!({
+            "id": "google-bert/bert-base-uncased",
+            "pipeline_tag": "fill-mask",
+            "lastModified": "2020-02-19T11:06:12.000Z",
+            "license": "apache-2.0",
+            "siblings": [
+                { "rfilename": "model.safetensors", "lfs": { "sha256": "AAAA1111", "size": 1 } }
+            ]
+        })
+    }
+
+    fn watch_config(enrichment: EnrichmentConfig) -> WatchConfig {
+        WatchConfig {
+            watch_dirs: vec![],
+            poll_interval: Duration::from_secs(1),
+            enrich_interval: Duration::from_secs(1),
+            debounce: Duration::ZERO,
+            output: OutputConfig::default(),
+            enrichment,
+            webhook_url: None,
+            exit_on_change: false,
+            max_snapshots: 10,
+            quiet: true,
+            dry_run: false,
+            cra_standards_enabled: false,
+            cra_standards_interval: Duration::from_secs(1),
+            cra_standards_timeout: Duration::from_secs(1),
+        }
+    }
+
+    /// Regression: `watch --huggingface` (enable_huggingface) was accepted but
+    /// `enrich_watched_sbom` had no HuggingFace dispatch, so ML-model weight
+    /// hashes were never injected during watch cycles. With the HF block added,
+    /// the mocked Hub IS queried and the sha256 weight hash lands on the model.
+    #[test]
+    fn enrich_watched_sbom_runs_huggingface() {
+        let server = MockServer::start();
+        let cache_dir = tempfile::tempdir().unwrap();
+
+        let hf_mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/api/models/google-bert/bert-base-uncased");
+            then.status(200).json_body(hf_model_body());
+        });
+
+        let mut model = Component::new("bert-base-uncased".to_string(), "ml-1".to_string())
+            .with_purl("pkg:huggingface/google-bert/bert-base-uncased@1.0.0".to_string())
+            .with_version("1.0.0".to_string());
+        model.component_type = ComponentType::MachineLearningModel;
+        model.ml_model = Some(MlModelInfo::default());
+
+        let mut sbom = NormalizedSbom::default();
+        sbom.add_component(model);
+
+        let enrichment = EnrichmentConfig::default()
+            .with_huggingface()
+            .with_huggingface_url(server.base_url())
+            .with_cache_dir(cache_dir.path().to_path_buf());
+        let config = watch_config(enrichment);
+
+        // bypass_cache=true so the mock is hit deterministically.
+        enrich_watched_sbom(&mut sbom, &config, true);
+
+        hf_mock.assert();
+        let enriched = sbom
+            .components
+            .values()
+            .find(|c| c.name == "bert-base-uncased")
+            .expect("model present");
+        let hashes: Vec<&str> = enriched.hashes.iter().map(|h| h.value.as_str()).collect();
+        assert!(
+            hashes.contains(&"aaaa1111"),
+            "watch HF enrichment must inject the sha256 weight hash; got {hashes:?}"
+        );
+    }
 }
 
 /// Probe the curated CRA-standards catalogue and emit

--- a/tests/enrichment_orchestration_tests.rs
+++ b/tests/enrichment_orchestration_tests.rs
@@ -1,0 +1,348 @@
+//! Regression tests for routing every enrichment entry point through the
+//! unified [`enrich_sbom_full`] orchestrator.
+//!
+//! Pre-fix defects these tests lock down:
+//! - `enrich --kev` parsed `--kev` but never ran it, so KEV data was silently
+//!   dropped from the output SBOM. We assert the mocked KEV catalog IS fetched
+//!   and the enriched output carries the KEV marker.
+//! - `query --offline` reset the process-wide offline flag (the orchestrator's
+//!   unconditional `set_offline(config.offline=false)` overwrote the global
+//!   `--offline=true`), permitting network egress. This is the BLOCKER: we
+//!   assert `query --offline` makes ZERO network requests.
+//! - `query` ignored the global `--config` file's `enrichment:`/`offline:`
+//!   block (no ValueSource precedence). We assert a config-file `offline: true`
+//!   suppresses all network access for `query`.
+//! - DEFENSIVE: a library `enrich_sbom_full` call with `config.offline=false`
+//!   must NEVER re-enable egress once the process is globally offline.
+
+#![cfg(feature = "enrichment")]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Mutex;
+
+use httpmock::prelude::*;
+use sbom_tools::config::EnrichmentConfig;
+use sbom_tools::enrichment::source::{is_offline, set_offline};
+use sbom_tools::model::{Component, NormalizedSbom};
+use sbom_tools::pipeline::enrich_sbom_full;
+
+/// Serializes every test that flips the process-wide offline switch so parallel
+/// threads don't race on the global flag. Recovers from a poisoned lock.
+static OFFLINE_LOCK: Mutex<()> = Mutex::new(());
+fn offline_lock() -> std::sync::MutexGuard<'static, ()> {
+    OFFLINE_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+const CVE: &str = "CVE-2021-44228";
+
+fn bin_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_sbom-tools"))
+}
+
+/// Point the platform cache-dir env var at `base` so the binary's cache root
+/// resolves under a temp dir without using the `--cache-dir` CLI flag (which
+/// `seed_enrichment` treats as "CLI touched enrichment", discarding the config
+/// file's `enrichment:` block). Mirrors `enrichment::source::cache_dir`.
+fn cache_env(base: &Path) -> Vec<(String, String)> {
+    let base = base.to_string_lossy().into_owned();
+    if cfg!(target_os = "macos") {
+        vec![("HOME".to_string(), format!("{base}/home"))]
+    } else if cfg!(target_os = "windows") {
+        vec![("LOCALAPPDATA".to_string(), base)]
+    } else {
+        vec![("XDG_CACHE_HOME".to_string(), base)]
+    }
+}
+
+/// A CISA KEV catalog body containing a single entry for `cve`.
+fn kev_catalog_body(cve: &str) -> serde_json::Value {
+    serde_json::json!({
+        "title": "CISA Catalog of Known Exploited Vulnerabilities",
+        "catalogVersion": "2026.06.01",
+        "dateReleased": "2026-06-01T12:00:00.000Z",
+        "count": 1,
+        "vulnerabilities": [{
+            "cveID": cve,
+            "vendorProject": "Apache",
+            "product": "Log4j2",
+            "vulnerabilityName": "Apache Log4j2 RCE",
+            "dateAdded": "2021-12-10",
+            "shortDescription": "RCE in Log4j2.",
+            "requiredAction": "Apply updates per vendor instructions.",
+            "dueDate": "2021-12-24",
+            "knownRansomwareCampaignUse": "Known",
+            "notes": ""
+        }]
+    })
+}
+
+/// A CycloneDX SBOM with one component already carrying `CVE` so KEV can flag it
+/// without needing OSV. Written to `dir/name`.
+fn write_vuln_sbom(dir: &Path, name: &str) -> PathBuf {
+    let path = dir.join(name);
+    let body = format!(
+        r#"{{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "metadata": {{ "timestamp": "2026-01-04T12:00:00Z" }},
+  "components": [
+    {{ "type": "library", "bom-ref": "log4j@2.14.0", "name": "log4j", "version": "2.14.0",
+       "purl": "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.0" }}
+  ],
+  "vulnerabilities": [
+    {{ "id": "{CVE}", "source": {{ "name": "NVD" }}, "affects": [ {{ "ref": "log4j@2.14.0" }} ] }}
+  ]
+}}"#
+    );
+    std::fs::write(&path, body).unwrap();
+    path
+}
+
+// ============================================================================
+// FIX #1 — `enrich --kev` actually runs KEV and writes it into the output SBOM
+// ============================================================================
+
+/// The old `run_enrich` parsed `--kev` but only applied OSV/EOL/VEX, dropping
+/// KEV entirely. Now it routes through `enrich_sbom_full`: the mocked KEV
+/// catalog IS fetched and the enriched output SBOM carries the KEV marker.
+#[test]
+fn enrich_kev_writes_kev_data_into_output() {
+    let server = MockServer::start();
+    let kev_mock = server.mock(|when, then| {
+        when.method(GET).path("/kev.json");
+        then.status(200).json_body(kev_catalog_body(CVE));
+    });
+
+    let work = tempfile::tempdir().unwrap();
+    let cache_dir = tempfile::tempdir().unwrap();
+    let sbom = write_vuln_sbom(work.path(), "in.cdx.json");
+    let out = work.path().join("out.cdx.json");
+    let kev_url = format!("{}/kev.json", server.base_url());
+
+    let output = Command::new(bin_path())
+        .arg("--no-color")
+        .env("RUST_LOG", "error")
+        .env("SBOM_TOOLS_KEV_URL", &kev_url)
+        .args(["enrich", &sbom.to_string_lossy(), "--kev"])
+        .arg("-O")
+        .arg(&out)
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .output()
+        .expect("enrich --kev should run");
+
+    assert!(
+        output.status.success(),
+        "enrich --kev failed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The KEV catalog was fetched (proves --kev is wired through enrich now).
+    kev_mock.assert_hits(1);
+
+    // The enriched output SBOM carries the KEV marker injected by the serializer.
+    let enriched = std::fs::read_to_string(&out).expect("output SBOM written");
+    let doc: serde_json::Value = serde_json::from_str(&enriched).unwrap();
+    let vulns = doc["vulnerabilities"]
+        .as_array()
+        .expect("vulnerabilities[]");
+    let kev_prop = vulns
+        .iter()
+        .flat_map(|v| v["properties"].as_array().into_iter().flatten())
+        .any(|p| p["name"] == "sbom-tools:kev" && p["value"] == "true");
+    assert!(
+        kev_prop,
+        "enriched output SBOM must carry the sbom-tools:kev property:\n{enriched}"
+    );
+}
+
+// ============================================================================
+// FIX #3 — `query --offline` makes ZERO network calls (the BLOCKER)
+// ============================================================================
+
+/// With `--offline`, `query --kev` must serve nothing from the network: the
+/// pre-fix bug let the orchestrator reset the global offline flag, so the KEV
+/// mock would be hit. Now the mock must see ZERO requests.
+#[test]
+fn query_offline_makes_zero_network_calls() {
+    let server = MockServer::start();
+    let kev_mock = server.mock(|when, then| {
+        when.method(GET).path("/kev.json");
+        then.status(200).json_body(kev_catalog_body(CVE));
+    });
+
+    let work = tempfile::tempdir().unwrap();
+    let cache_dir = tempfile::tempdir().unwrap();
+    let sbom = write_vuln_sbom(work.path(), "in.cdx.json");
+    let kev_url = format!("{}/kev.json", server.base_url());
+
+    let output = Command::new(bin_path())
+        .arg("--no-color")
+        .arg("--offline")
+        .env("RUST_LOG", "error")
+        .env("SBOM_TOOLS_KEV_URL", &kev_url)
+        // Pattern "log4j" + the SBOM path; --kev would normally fetch the catalog.
+        .args(["query", "log4j", &sbom.to_string_lossy(), "--kev"])
+        .arg("--cache-dir")
+        .arg(cache_dir.path())
+        .output()
+        .expect("query --offline should run");
+
+    assert!(
+        output.status.success(),
+        "query --offline failed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // THE BLOCKER ASSERTION: offline mode must make no network requests at all.
+    kev_mock.assert_hits(0);
+}
+
+// ============================================================================
+// FIX #4 — `query` honors the global --config file's enrichment/offline block
+// ============================================================================
+
+/// A config file's `enrichment:` block must take effect for `query`, even when
+/// no enrichment flag is passed on the CLI. Pre-fix, the Query arm built
+/// enrichment from raw `args.enrichment` and ignored the config file, so the
+/// file's `enable_kev` was a no-op. Here the config enables KEV (no `--kev` on
+/// the CLI) and points at the mock: the catalog MUST be fetched.
+#[test]
+fn query_honors_config_file_enrichment() {
+    let server = MockServer::start();
+    let kev_mock = server.mock(|when, then| {
+        when.method(GET).path("/kev.json");
+        then.status(200).json_body(kev_catalog_body(CVE));
+    });
+
+    let work = tempfile::tempdir().unwrap();
+    let cache_dir = tempfile::tempdir().unwrap();
+    let sbom = write_vuln_sbom(work.path(), "in.cdx.json");
+    let kev_url = format!("{}/kev.json", server.base_url());
+
+    // Config file enables KEV and points it at the mock; offline is false.
+    let cfg = work.path().join("cfg.yaml");
+    std::fs::write(
+        &cfg,
+        format!("enrichment:\n  enabled: false\n  enable_kev: true\n  kev_url: {kev_url}\n"),
+    )
+    .unwrap();
+
+    let output = Command::new(bin_path())
+        .arg("--no-color")
+        .args(["--config", &cfg.to_string_lossy()])
+        .env("RUST_LOG", "error")
+        .envs(cache_env(cache_dir.path()))
+        // NOTE: no --kev here; the config file must supply it.
+        .args(["query", "log4j", &sbom.to_string_lossy()])
+        .output()
+        .expect("query with config should run");
+
+    assert!(
+        output.status.success(),
+        "query with config failed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The config file's enable_kev must have driven a KEV fetch.
+    kev_mock.assert_hits(1);
+}
+
+/// A config file with `enrichment.offline: true` must suppress all network
+/// access for `query`, even though `--offline` was not passed on the CLI.
+#[test]
+fn query_honors_config_file_offline() {
+    let server = MockServer::start();
+    let kev_mock = server.mock(|when, then| {
+        when.method(GET).path("/kev.json");
+        then.status(200).json_body(kev_catalog_body(CVE));
+    });
+
+    let work = tempfile::tempdir().unwrap();
+    let cache_dir = tempfile::tempdir().unwrap();
+    let sbom = write_vuln_sbom(work.path(), "in.cdx.json");
+    let kev_url = format!("{}/kev.json", server.base_url());
+
+    // Config file enables KEV + offline; KEV would fetch the catalog if online.
+    let cfg = work.path().join("cfg.yaml");
+    std::fs::write(
+        &cfg,
+        format!(
+            "enrichment:\n  enabled: false\n  enable_kev: true\n  offline: true\n  kev_url: {kev_url}\n",
+        ),
+    )
+    .unwrap();
+
+    let output = Command::new(bin_path())
+        .arg("--no-color")
+        .args(["--config", &cfg.to_string_lossy()])
+        .env("RUST_LOG", "error")
+        .envs(cache_env(cache_dir.path()))
+        .args(["query", "log4j", &sbom.to_string_lossy()])
+        .output()
+        .expect("query with config should run");
+
+    assert!(
+        output.status.success(),
+        "query with offline config failed; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The config file's offline:true must have suppressed the KEV fetch.
+    kev_mock.assert_hits(0);
+}
+
+// ============================================================================
+// FIX #3 (defensive) — enrich_sbom_full can never re-enable a global offline
+// ============================================================================
+
+fn lodash_sbom() -> NormalizedSbom {
+    let mut sbom = NormalizedSbom::default();
+    sbom.add_component(
+        Component::new("lodash".to_string(), "lodash@4.17.20".to_string())
+            .with_purl("pkg:npm/lodash@4.17.20".to_string())
+            .with_version("4.17.20".to_string()),
+    );
+    sbom
+}
+
+/// Once the process is globally offline, a later `enrich_sbom_full` call whose
+/// own `config.offline` is false must NOT flip the process back online. This
+/// hardens the whole class so no future caller can accidentally re-enable
+/// egress.
+#[test]
+fn enrich_sbom_full_cannot_disable_global_offline() {
+    let _guard = offline_lock();
+
+    // Simulate `main` having set the global offline flag from --offline.
+    set_offline(true);
+    assert!(is_offline());
+
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+    let osv_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        then.status(200)
+            .json_body(serde_json::json!({ "results": [] }));
+    });
+
+    // A per-call config with offline=false (the dangerous case).
+    let config = EnrichmentConfig::osv()
+        .with_api_base(server.base_url())
+        .with_cache_dir(cache_dir.path().to_path_buf());
+    assert!(!config.offline, "this call's config is online");
+
+    let mut sbom = lodash_sbom();
+    let _ = enrich_sbom_full(&mut sbom, &config, true);
+
+    // The global offline flag survived, and no OSV request was attempted.
+    assert!(
+        is_offline(),
+        "enrich_sbom_full must not re-enable network egress when globally offline"
+    );
+    osv_mock.assert_hits(0);
+
+    set_offline(false);
+}


### PR DESCRIPTION
## Summary

Several enrichment entry points hand-rolled their own enrichment instead of going through the canonical `pipeline::enrich_sbom_full` orchestrator, so flags added by parallel PRs (KEV/EPSS/HuggingFace/staleness) silently no-op'd — and one path could re-enable network egress in an air-gapped run.

- **`enrich`** silently dropped `--kev`/`--epss`/`--enrich-staleness`/`--huggingface` (parsed but never read). Now routes through `enrich_sbom_full`, which also makes `enrich` honor the config file's `enrichment:` block.
- **`watch --huggingface`** was accepted but never ran HF — `enrich_watched_sbom` had no HuggingFace dispatch. Added an `enable_huggingface` block (lower-risk than delegating, which would lose watch's per-source `bypass_cache` override for periodic cycles).
- **`query --offline` (BLOCKER)** re-enabled network egress: the Query arm built enrichment via `to_enrichment_config()` (never set `.offline`), and `enrich_sbom_full`'s unconditional `set_offline(config.offline=false)` overwrote the global `offline=true` set in `main`. Fixed both layers: the Query arm now routes through `seed_enrichment`, and **defensively** `enrich_sbom_full` now uses `set_offline(is_offline() || config.offline)` so no caller can ever clear a globally-set offline.
- **`query` ignored the global `--config` file** (no ValueSource precedence — PR #227 migrated every other command but not Query). Now builds enrichment via `seed_enrichment` and resolves output format + `no_color` through the same `resolve()`/`arg_was_set_sub` machinery as Diff/View.
- **`enrich_sbom_json`** dropped KEV/EPSS overlays on serialization, so even a wired-up `enrich --kev` wrote nothing observable. Now emits `sbom-tools:kev` / `sbom-tools:epss:score` CycloneDX vulnerability properties.
- **README** exit-code table omitted code `6` (`KEV_INTRODUCED`), contradicting the CLI help — added.

## Test plan

New regression tests (`tests/enrichment_orchestration_tests.rs` plus an in-crate watch unit test) — each was confirmed to **fail on the pre-fix code** and pass after the fix:

- `enrich --kev` fetches the mocked KEV catalog (via the `--kev-url` seam) and the output SBOM carries the `sbom-tools:kev` property.
- `query --offline` makes **ZERO** network requests (the blocker; httpmock asserts 0 hits).
- A config-file `enrichment.enable_kev` drives a KEV fetch for `query` with no CLI flag; a config-file `offline: true` suppresses all network access.
- `enrich_sbom_full` cannot re-enable a globally-set offline.
- `enrich_watched_sbom` runs HuggingFace and injects the weight hash.

Verification:
- `cargo fmt`
- `rustup run 1.88 cargo clippy` — 0 new warnings vs same-toolchain HEAD (pre-existing TUI warnings unchanged; the locally-installed clippy is newer than the CI-pinned one).
- `cargo check --no-default-features --features ffi` and `cargo build` — both pass (exercises the `#[cfg(not(feature = "enrichment"))]` path).
- Full `cargo test --features enrichment` — 952 lib tests + all integration tests pass, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
