### PR TITLE
feat(enrichment): scope OSV exploitability enrichment to ML components (HuggingFace)

### DIFF
--- a/src/enrichment/huggingface/client.rs
+++ b/src/enrichment/huggingface/client.rs
@@ -77,6 +77,10 @@ pub struct HuggingFaceEnrichmentStats {
     pub hashes_added: usize,
     /// Components that received a `task` from `pipeline_tag`.
     pub tasks_added: usize,
+    /// Components that received a synthesized `pkg:huggingface` PURL (resolved
+    /// via a model-card URL but lacking a PURL), making them resolvable to
+    /// `Ecosystem::HuggingFace` for vulnerability enrichment.
+    pub purls_added: usize,
     /// Components that received a license (only when none was declared).
     pub licenses_added: usize,
     /// API calls performed (cache misses).
@@ -210,6 +214,15 @@ impl HuggingFaceClient {
             };
             stats.models_resolved += 1;
 
+            // Ensure a `pkg:huggingface/...` PURL is present so the component is
+            // resolvable to `Ecosystem::HuggingFace` and routed through the
+            // vulnerability/exploitability enrichment stack (OSV PURL query +
+            // KEV/advisory linkage). When the model was resolved only via a
+            // model-card URL it has no PURL; synthesize one from the model id.
+            if ensure_huggingface_purl(component, &model_id) {
+                stats.purls_added += 1;
+            }
+
             let info = match self.resolve(&model_id, &mut stats) {
                 Ok(Some(info)) => info,
                 Ok(None) => continue,
@@ -255,6 +268,20 @@ pub fn resolve_model_id(component: &Component) -> Option<String> {
         .external_refs
         .iter()
         .find_map(|r| model_id_from_hf_url(&r.url))
+}
+
+/// Ensure the component carries a `pkg:huggingface/{model_id}` PURL.
+///
+/// Returns `true` if a PURL was synthesized. A component already carrying any
+/// PURL is left untouched (we never overwrite an existing identifier). The
+/// synthesized PURL makes the component resolvable to `Ecosystem::HuggingFace`,
+/// routing it through the OSV/KEV exploitability enrichment stack.
+fn ensure_huggingface_purl(component: &mut Component, model_id: &str) -> bool {
+    if component.identifiers.purl.is_some() {
+        return false;
+    }
+    component.set_purl(format!("pkg:huggingface/{model_id}"));
+    true
 }
 
 /// Extract `{org}/{name}` from a `pkg:huggingface/...` PURL.
@@ -506,6 +533,40 @@ mod tests {
         assert_eq!(c.ml_model.as_ref().unwrap().task.as_deref(), Some("nlp"));
         assert_eq!(stats.licenses_added, 0);
         assert_eq!(stats.tasks_added, 0);
+    }
+
+    #[test]
+    fn ensure_purl_synthesizes_from_model_card_url() {
+        use crate::model::Ecosystem;
+        // Model resolved via a model-card URL, no PURL.
+        let mut c = ml_component(None);
+        c.ml_model = Some(MlModelInfo {
+            model_card_url: Some(
+                "https://huggingface.co/google-bert/bert-base-uncased".to_string(),
+            ),
+            ..MlModelInfo::default()
+        });
+        let model_id = resolve_model_id(&c).expect("resolvable via URL");
+
+        assert!(ensure_huggingface_purl(&mut c, &model_id));
+        assert_eq!(
+            c.identifiers.purl.as_deref(),
+            Some("pkg:huggingface/google-bert/bert-base-uncased")
+        );
+        // The synthesized PURL must resolve to the HuggingFace ecosystem so the
+        // component is routed through vulnerability enrichment.
+        assert_eq!(c.ecosystem, Some(Ecosystem::HuggingFace));
+    }
+
+    #[test]
+    fn ensure_purl_never_overwrites_existing() {
+        let mut c = ml_component(Some("pkg:huggingface/org/name@v1"));
+        assert!(!ensure_huggingface_purl(&mut c, "org/name"));
+        assert_eq!(
+            c.identifiers.purl.as_deref(),
+            Some("pkg:huggingface/org/name@v1"),
+            "an existing PURL must be preserved verbatim"
+        );
     }
 
     #[test]

--- a/src/enrichment/osv/mod.rs
+++ b/src/enrichment/osv/mod.rs
@@ -92,14 +92,24 @@ impl OsvEnricher {
             component.version.clone(),
         );
 
-        // Prefer PURL if available
+        // Prefer PURL if available. A `pkg:huggingface` PURL is forwarded as-is:
+        // OSV does not index the HuggingFace ecosystem, so it simply returns no
+        // vulns (harmless), but routing the query keeps the component in the
+        // pipeline rather than counting it as skipped, and exploitability for
+        // ML models is supplied downstream by KEV/advisory linkage on any
+        // identifier-referenced CVEs (see `merge_vulnerabilities` consumers).
         if let Some(ref purl) = component.identifiers.purl {
             return Some((cache_key, OsvQuery::from_purl(purl.clone())));
         }
 
-        // Fallback to name + ecosystem + version
+        // Fallback to name + ecosystem + version. Skip ecosystems OSV cannot
+        // resolve (empty string) — e.g. HuggingFace — so we never send a query
+        // that OSV would reject or, worse, silently mis-key.
         if let (Some(ecosystem), Some(version)) = (&component.ecosystem, &component.version) {
             let osv_ecosystem = ecosystem_to_osv_string(ecosystem);
+            if osv_ecosystem.is_empty() {
+                return None;
+            }
             return Some((
                 cache_key,
                 OsvQuery::from_package(component.name.clone(), osv_ecosystem, version.clone()),
@@ -297,6 +307,13 @@ fn ecosystem_to_osv_string(ecosystem: &Ecosystem) -> String {
         Ecosystem::Deb => "Debian".to_string(),
         Ecosystem::Rpm => "AlmaLinux".to_string(), // Or could be other RPM-based
         Ecosystem::Apk => "Alpine".to_string(),
+        // OSV (osv.dev) has NO ecosystem for HuggingFace / ML models. Returning
+        // an empty string is the honest signal "OSV cannot resolve this by
+        // name+ecosystem". A `pkg:huggingface` PURL query is still forwarded
+        // (OSV returns nothing for it), and real exploitability data for ML
+        // components comes from KEV/advisory linkage on CVE identifiers the
+        // model already carries — not from an OSV ecosystem lookup.
+        Ecosystem::HuggingFace => String::new(),
         Ecosystem::Generic => "OSS-Fuzz".to_string(),
         Ecosystem::Unknown(s) => s.clone(),
     }
@@ -311,5 +328,59 @@ mod tests {
         assert_eq!(ecosystem_to_osv_string(&Ecosystem::Npm), "npm");
         assert_eq!(ecosystem_to_osv_string(&Ecosystem::PyPi), "PyPI");
         assert_eq!(ecosystem_to_osv_string(&Ecosystem::Cargo), "crates.io");
+    }
+
+    #[test]
+    fn huggingface_has_no_osv_ecosystem_string() {
+        // OSV does not index HuggingFace; the honest mapping is an empty string
+        // so `build_query` never sends a name+ecosystem query OSV would reject.
+        assert!(ecosystem_to_osv_string(&Ecosystem::HuggingFace).is_empty());
+    }
+
+    fn test_enricher() -> OsvEnricher {
+        let dir = std::env::temp_dir().join(format!("osv-test-{}", std::process::id()));
+        OsvEnricher::new(OsvEnricherConfig {
+            cache_dir: dir,
+            ..Default::default()
+        })
+        .expect("enricher")
+    }
+
+    #[test]
+    fn build_query_forwards_huggingface_purl() {
+        use crate::model::{Component, ComponentType};
+        let enricher = test_enricher();
+
+        let mut comp = Component::new("bert".to_string(), "ml-1".to_string())
+            .with_purl("pkg:huggingface/google-bert/bert-base-uncased".to_string());
+        comp.component_type = ComponentType::MachineLearningModel;
+
+        // The HuggingFace PURL resolves to Ecosystem::HuggingFace...
+        assert_eq!(comp.ecosystem, Some(Ecosystem::HuggingFace));
+        // ...and OSV enrichment is still ATTEMPTED via the PURL query (not skipped),
+        // so the model participates in the exploitability pipeline.
+        let query = enricher.build_query(&comp);
+        assert!(
+            matches!(query, Some((_, OsvQuery::Purl { .. }))),
+            "HuggingFace model with a PURL must be queried by PURL"
+        );
+    }
+
+    #[test]
+    fn build_query_skips_huggingface_name_fallback() {
+        use crate::model::{Component, ComponentType, Ecosystem};
+        let enricher = test_enricher();
+
+        // No PURL — only ecosystem + version. OSV cannot resolve HuggingFace by
+        // name+ecosystem, so we must NOT fabricate a garbage query.
+        let mut comp = Component::new("bert".to_string(), "ml-2".to_string());
+        comp.component_type = ComponentType::MachineLearningModel;
+        comp.ecosystem = Some(Ecosystem::HuggingFace);
+        comp.version = Some("v1".to_string());
+
+        assert!(
+            enricher.build_query(&comp).is_none(),
+            "HuggingFace without a PURL must not emit a name+ecosystem OSV query"
+        );
     }
 }

--- a/src/matching/rules.rs
+++ b/src/matching/rules.rs
@@ -534,6 +534,7 @@ impl EcosystemRules {
             Ecosystem::Deb => "deb".to_string(),
             Ecosystem::Rpm => "rpm".to_string(),
             Ecosystem::Apk => "apk".to_string(),
+            Ecosystem::HuggingFace => "huggingface".to_string(),
             Ecosystem::Generic => "generic".to_string(),
             Ecosystem::Unknown(s) => s.to_lowercase(),
         }

--- a/src/model/identifiers.rs
+++ b/src/model/identifiers.rs
@@ -669,6 +669,11 @@ pub enum Ecosystem {
     Deb,
     Rpm,
     Apk,
+    /// HuggingFace Hub ML model (`pkg:huggingface/...`). Not a classical
+    /// package ecosystem; surfaced so ML components are routed through the
+    /// vulnerability/exploitability enrichment stack rather than silently
+    /// treated as `Unknown`.
+    HuggingFace,
     Generic,
     Unknown(String),
 }
@@ -698,6 +703,7 @@ impl Ecosystem {
             "deb" => Self::Deb,
             "rpm" => Self::Rpm,
             "apk" => Self::Apk,
+            "huggingface" => Self::HuggingFace,
             "generic" => Self::Generic,
             other => Self::Unknown(other.to_string()),
         }
@@ -727,6 +733,7 @@ impl fmt::Display for Ecosystem {
             Self::Deb => write!(f, "deb"),
             Self::Rpm => write!(f, "rpm"),
             Self::Apk => write!(f, "apk"),
+            Self::HuggingFace => write!(f, "huggingface"),
             Self::Generic => write!(f, "generic"),
             Self::Unknown(s) => write!(f, "{s}"),
         }

--- a/src/model/sbom.rs
+++ b/src/model/sbom.rs
@@ -706,6 +706,14 @@ impl Component {
     /// Set the PURL and update canonical ID
     #[must_use]
     pub fn with_purl(mut self, purl: String) -> Self {
+        self.set_purl(purl);
+        self
+    }
+
+    /// Set the PURL in place, refreshing the canonical ID and deriving the
+    /// ecosystem from the PURL type. Mirrors [`Self::with_purl`] for callers
+    /// holding a `&mut Component` (e.g. enrichment that synthesizes a PURL).
+    pub fn set_purl(&mut self, purl: String) {
         self.identifiers.purl = Some(purl);
         self.canonical_id = self.identifiers.canonical_id();
 
@@ -717,8 +725,6 @@ impl Component {
         {
             self.ecosystem = Some(Ecosystem::from_purl_type(purl_type));
         }
-
-        self
     }
 
     /// Set the version and try to parse as semver

--- a/src/pipeline/parse.rs
+++ b/src/pipeline/parse.rs
@@ -486,12 +486,13 @@ pub fn enrich_huggingface(
         Ok(stats) => {
             if !quiet {
                 eprintln!(
-                    "HuggingFace enrichment: {} models resolved, {} enriched, {} weight hashes, {} tasks, {} licenses",
+                    "HuggingFace enrichment: {} models resolved, {} enriched, {} weight hashes, {} tasks, {} licenses, {} PURLs added",
                     stats.models_resolved,
                     stats.models_enriched,
                     stats.hashes_added,
                     stats.tasks_added,
                     stats.licenses_added,
+                    stats.purls_added,
                 );
             }
             Some(stats)

--- a/src/quality/scorer.rs
+++ b/src/quality/scorer.rs
@@ -33,6 +33,27 @@ fn has_non_empty_pointer(raw: Option<&Value>, pointers: &[&str]) -> bool {
         })
 }
 
+/// Returns true if a component is connected to the vulnerability/exploitability
+/// tooling stack: it carries at least one vulnerability reference (which
+/// OSV/KEV/EPSS/VEX enrichment acts on) OR a security/advisory external
+/// reference an analyst can pivot on. This realizes the BSI thesis that an AI
+/// SBOM is only useful when linked to cybersecurity tooling.
+fn ml_has_exploitability_reference(component: &crate::model::Component) -> bool {
+    use crate::model::ExternalRefType;
+    if !component.vulnerabilities.is_empty() {
+        return true;
+    }
+    component.external_refs.iter().any(|r| {
+        matches!(
+            r.ref_type,
+            ExternalRefType::Advisories
+                | ExternalRefType::SecurityContact
+                | ExternalRefType::VulnerabilityAssertion
+                | ExternalRefType::ExploitabilityStatement
+        )
+    })
+}
+
 /// Scoring profile determines weights and thresholds
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
@@ -654,8 +675,10 @@ impl QualityScorer {
 
     /// Score ML model-card completeness for the AI-readiness profile.
     ///
-    /// Filters to `MachineLearningModel` components and evaluates ten model-card
-    /// checks (AI-001..AI-010, the last being a weight-hash integrity check). The
+    /// Filters to `MachineLearningModel` components and evaluates eleven checks
+    /// (AI-001..AI-011): AI-001..AI-009 cover model-card transparency, AI-010 is
+    /// a weight-hash integrity check, and AI-011 verifies the component is
+    /// connected to the vulnerability/exploitability tooling stack. The
     /// returned `QualityReport` has all standard category scores zeroed/`None`;
     /// the rich data lives in `ai_readiness_metrics`.
     /// When the SBOM has no ML components the report is marked not-applicable.
@@ -731,7 +754,7 @@ impl QualityScorer {
         // carries weight comparable to the transparency checks. The literals are
         // chosen for readability; they no longer sum to exactly 1.0 once AI-010 is
         // added, so they are renormalized below to keep the total at 1.0.
-        const CHECK_DEFS: [(&str, &str, f32); 10] = [
+        const CHECK_DEFS: [(&str, &str, f32); 11] = [
             ("AI-001", "Model card URL present", 0.15),
             ("AI-002", "Architecture family declared", 0.12),
             ("AI-003", "Training datasets referenced", 0.12),
@@ -742,6 +765,11 @@ impl QualityScorer {
             ("AI-008", "Known limitations stated", 0.09),
             ("AI-009", "Ethical considerations present", 0.09),
             ("AI-010", "Model weight hashes present", 0.12),
+            // AI-011 closes the BSI "vulnerability/exploitability referencing"
+            // gap for AI clusters: a model is only connected to the security
+            // tooling stack if it carries a CVE/advisory reference that OSV/KEV
+            // /EPSS/VEX can act on. Weighted like the integrity check (AI-010).
+            ("AI-011", "Exploitability/advisory reference present", 0.12),
         ];
 
         // Renormalize the per-check weights so they sum to exactly 1.0. Without
@@ -759,7 +787,7 @@ impl QualityScorer {
             let ml = component.ml_model.as_ref();
             let raw = component.extensions.raw.as_ref();
 
-            let results: [bool; 10] = [
+            let results: [bool; 11] = [
                 // AI-001: model card URL
                 ml.and_then(|m| m.model_card_url.as_ref()).is_some(),
                 // AI-002: architecture family
@@ -820,6 +848,11 @@ impl QualityScorer {
                 // its weights can be verified against tampering. Hashes typically
                 // arrive via HuggingFace enrichment (siblings[].lfs.sha256).
                 !component.hashes.is_empty(),
+                // AI-011: exploitability/advisory reference present. The model is
+                // only connected to the cybersecurity tooling stack (OSV/KEV/EPSS
+                // /VEX) when it carries at least one vulnerability reference OR a
+                // security/advisory external reference an analyst can pivot on.
+                ml_has_exploitability_reference(component),
             ];
 
             if results.iter().all(|&p| p) {
@@ -1462,6 +1495,13 @@ mod tests {
             crate::model::HashAlgorithm::Sha256,
             "a".repeat(64),
         ));
+        // A vulnerability reference makes the AI-011 exploitability check pass.
+        component
+            .vulnerabilities
+            .push(crate::model::VulnerabilityRef::new(
+                "CVE-2024-0001".to_string(),
+                crate::model::VulnerabilitySource::Cve,
+            ));
         sbom.add_component(component);
 
         let report = QualityScorer::new(ScoringProfile::AiReadiness).score(&sbom);
@@ -1469,11 +1509,11 @@ mod tests {
             .ai_readiness_metrics
             .expect("AI readiness metrics should be present");
         assert!(!metrics.is_not_applicable());
-        // All ten checks should pass → fully documented, perfect score.
+        // All eleven checks should pass → fully documented, perfect score.
         for check in &metrics.checks {
             assert!(check.passed, "expected {} to pass", check.id);
         }
-        assert_eq!(metrics.checks.len(), 10, "AI-001..AI-010 are all reported");
+        assert_eq!(metrics.checks.len(), 11, "AI-001..AI-011 are all reported");
         // The renormalized per-check weights must still sum to 1.0.
         let weight_total: f32 = metrics.checks.iter().map(|c| c.weight).sum();
         assert!(
@@ -1599,6 +1639,74 @@ mod tests {
                 .unwrap_or_default()
                 .contains("1/2 components passed"),
             "AI-010 detail should report 1/2 models passing"
+        );
+    }
+
+    #[test]
+    fn test_ai_011_exploitability_reference_check() {
+        use crate::model::{
+            ExternalRefType, ExternalReference, VulnerabilityRef, VulnerabilitySource,
+        };
+
+        let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
+
+        // Model 1: carries a vulnerability reference → AI-011 passes.
+        let mut with_vuln = ml_component("ml-1", "with-vuln", MlModelInfo::default(), json!({}));
+        with_vuln.vulnerabilities.push(VulnerabilityRef::new(
+            "CVE-2024-1234".to_string(),
+            VulnerabilitySource::Cve,
+        ));
+        sbom.add_component(with_vuln);
+
+        // Model 2: carries a security advisory external reference → AI-011 passes.
+        let mut with_advisory =
+            ml_component("ml-2", "with-advisory", MlModelInfo::default(), json!({}));
+        with_advisory.external_refs.push(ExternalReference {
+            ref_type: ExternalRefType::Advisories,
+            url: "https://example.test/advisory".to_string(),
+            comment: None,
+            hashes: Vec::new(),
+        });
+        sbom.add_component(with_advisory);
+
+        let report = QualityScorer::new(ScoringProfile::AiReadiness).score(&sbom);
+        let metrics = report
+            .ai_readiness_metrics
+            .expect("AI readiness metrics should be present");
+        let ai011 = metrics
+            .checks
+            .iter()
+            .find(|c| c.id == "AI-011")
+            .expect("AI-011 should be present");
+        assert!(
+            ai011.passed,
+            "AI-011 should pass when every model carries a vuln or advisory reference"
+        );
+    }
+
+    #[test]
+    fn test_ai_011_fails_without_exploitability_reference() {
+        let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
+        // A model with neither a vuln ref nor an advisory external reference.
+        sbom.add_component(ml_component(
+            "ml-1",
+            "no-refs",
+            MlModelInfo::default(),
+            json!({}),
+        ));
+
+        let report = QualityScorer::new(ScoringProfile::AiReadiness).score(&sbom);
+        let metrics = report
+            .ai_readiness_metrics
+            .expect("AI readiness metrics should be present");
+        let ai011 = metrics
+            .checks
+            .iter()
+            .find(|c| c.id == "AI-011")
+            .expect("AI-011 should be present");
+        assert!(
+            !ai011.passed,
+            "AI-011 should fail when a model has no exploitability/advisory reference"
         );
     }
 }

--- a/src/reports/sarif.rs
+++ b/src/reports/sarif.rs
@@ -350,7 +350,7 @@ impl ReportGenerator for SarifReporter {
     }
 }
 
-/// Map an AI-readiness check ID (`AI-001`..`AI-010`) to its SARIF rule ID.
+/// Map an AI-readiness check ID (`AI-001`..`AI-011`) to its SARIF rule ID.
 /// Unknown IDs fall back to the `SBOM-AIBOM-GENERAL` rule so a future check
 /// never silently drops (`AiCheck`/`AiReadinessMetrics` are `#[non_exhaustive]`).
 fn ai_check_to_rule_id(check_id: &str) -> &'static str {
@@ -365,6 +365,7 @@ fn ai_check_to_rule_id(check_id: &str) -> &'static str {
         "AI-008" => "SBOM-AIBOM-008",
         "AI-009" => "SBOM-AIBOM-009",
         "AI-010" => "SBOM-AIBOM-010",
+        "AI-011" => "SBOM-AIBOM-011",
         _ => "SBOM-AIBOM-GENERAL",
     }
 }
@@ -375,10 +376,14 @@ fn ai_check_to_rule_id(check_id: &str) -> &'static str {
 /// This is the single source of truth shared by the rule table and the results.
 fn aibom_level(check_id: &str) -> SarifLevel {
     match check_id {
-        // AI-010 is the weight-hash integrity check: a missing weight hash
-        // defeats tamper verification, so it is a `warning` like the other
-        // load-bearing transparency checks (not a soft `note`).
-        "AI-001" | "AI-002" | "AI-003" | "AI-005" | "AI-009" | "AI-010" => SarifLevel::Warning,
+        // AI-010 is the weight-hash integrity check and AI-011 the
+        // exploitability/advisory-reference check: both are load-bearing
+        // security signals (tamper verification and vulnerability tooling
+        // linkage), so they are `warning` like the other load-bearing checks
+        // rather than a soft `note`.
+        "AI-001" | "AI-002" | "AI-003" | "AI-005" | "AI-009" | "AI-010" | "AI-011" => {
+            SarifLevel::Warning
+        }
         _ => SarifLevel::Note,
     }
 }
@@ -448,6 +453,12 @@ fn get_sarif_aibom_rules() -> Vec<SarifRule> {
             "AI-010",
             "AibomModelWeightHashes",
             "Model weight hashes present",
+        ),
+        (
+            "SBOM-AIBOM-011",
+            "AI-011",
+            "AibomExploitabilityReference",
+            "Exploitability/advisory reference present",
         ),
         (
             "SBOM-AIBOM-GENERAL",

--- a/tests/fixtures/cyclonedx/aibom-complete.cdx.json
+++ b/tests/fixtures/cyclonedx/aibom-complete.cdx.json
@@ -97,6 +97,10 @@
         {
           "type": "model-card",
           "url": "https://example.test/model-cards/sentiment-classifier"
+        },
+        {
+          "type": "advisories",
+          "url": "https://example.test/security/sentiment-classifier-advisories"
         }
       ]
     },

--- a/tests/fixtures/spdx3/ai-dataset.spdx3.json
+++ b/tests/fixtures/spdx3/ai-dataset.spdx3.json
@@ -56,6 +56,10 @@
         {
           "externalRefType": "documentation",
           "locator": ["https://huggingface.co/google-bert/bert-base-uncased"]
+        },
+        {
+          "externalRefType": "securityAdvisory",
+          "locator": ["https://example.test/security/bert-base-advisories"]
         }
       ]
     },

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -883,8 +883,8 @@ mod parser_tests {
         for id in ["AI-004", "AI-005", "AI-007", "AI-009"] {
             assert!(passed(id), "expected {id} to pass for CycloneDX ML-BOM");
         }
-        // Fully documented (including a weight hash for AI-010) → all ten pass,
-        // grade A.
+        // Fully documented (a weight hash for AI-010 and a security-advisory
+        // external reference for AI-011) → all eleven pass, grade A.
         for check in &metrics.checks {
             assert!(check.passed, "expected {} to pass", check.id);
         }

--- a/tests/ml_component_vuln_enrichment_tests.rs
+++ b/tests/ml_component_vuln_enrichment_tests.rs
@@ -1,0 +1,159 @@
+//! Integration tests for scoping the exploitability enrichment stack to ML
+//! (HuggingFace) components — PR-C.
+//!
+//! Realizes the BSI thesis that an AI SBOM is only useful when connected to
+//! cybersecurity tooling:
+//! - a `pkg:huggingface` model component is routed through OSV enrichment (the
+//!   OSV PURL query is attempted, not skipped), and
+//! - KEV/advisory linkage by CVE identifier flags an exploited vulnerability a
+//!   model already carries — independent of OSV's (absent) HuggingFace coverage.
+//!
+//! Honesty note: OSV (osv.dev) has NO ecosystem for HuggingFace models, so OSV
+//! returns no vulns for a `pkg:huggingface` PURL. These tests therefore assert
+//! that (a) the query is still ATTEMPTED and (b) exploitability data arrives via
+//! the KEV path on identifier-referenced CVEs.
+
+#![cfg(feature = "enrichment")]
+
+use httpmock::prelude::*;
+use sbom_tools::config::EnrichmentConfig;
+use sbom_tools::enrichment::{OsvEnricher, OsvEnricherConfig, VulnerabilityEnricher};
+use sbom_tools::model::{
+    Component, ComponentType, Ecosystem, NormalizedSbom, VulnerabilityRef, VulnerabilitySource,
+};
+use sbom_tools::pipeline::enrich_sbom_full;
+use std::time::Duration;
+
+/// A `MachineLearningModel` component identified by a `pkg:huggingface` PURL.
+fn hf_model(model_id: &str, bom_ref: &str) -> Component {
+    let mut comp = Component::new(model_id.to_string(), bom_ref.to_string())
+        .with_purl(format!("pkg:huggingface/{model_id}"));
+    comp.component_type = ComponentType::MachineLearningModel;
+    comp
+}
+
+/// A CISA KEV catalog body containing a single entry for the given CVE.
+fn kev_catalog_body(cve_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "title": "CISA Catalog of Known Exploited Vulnerabilities",
+        "catalogVersion": "2026.06.01",
+        "dateReleased": "2026-06-01T12:00:00.000Z",
+        "count": 1,
+        "vulnerabilities": [
+            {
+                "cveID": cve_id,
+                "vendorProject": "HuggingFace",
+                "product": "transformers",
+                "vulnerabilityName": "Unsafe model deserialization",
+                "dateAdded": "2026-01-10",
+                "shortDescription": "Loading an untrusted model executes code.",
+                "requiredAction": "Apply updates per vendor instructions.",
+                "dueDate": "2026-01-24",
+                "knownRansomwareCampaignUse": "Unknown",
+                "notes": ""
+            }
+        ]
+    })
+}
+
+#[test]
+fn huggingface_model_resolves_to_huggingface_ecosystem() {
+    let comp = hf_model("google-bert/bert-base-uncased", "ml-1");
+    assert_eq!(
+        comp.ecosystem,
+        Some(Ecosystem::HuggingFace),
+        "a pkg:huggingface PURL must resolve to Ecosystem::HuggingFace"
+    );
+}
+
+#[test]
+fn osv_enrichment_is_attempted_for_huggingface_model() {
+    // OSV does not index HuggingFace, so it returns no vulns — but the query
+    // MUST be attempted (the component is not skipped). We assert the OSV
+    // querybatch endpoint is hit with the model in the pipeline.
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+
+    let batch_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/querybatch");
+        // OSV's honest answer for a HuggingFace PURL: an empty result set.
+        then.status(200)
+            .json_body(serde_json::json!({ "results": [{ "vulns": [] }] }));
+    });
+
+    let enricher = OsvEnricher::new(OsvEnricherConfig {
+        cache_dir: cache_dir.path().to_path_buf(),
+        cache_ttl: Duration::from_secs(3600),
+        bypass_cache: false,
+        timeout: Duration::from_secs(5),
+        api_base: server.base_url(),
+        max_retries: 0,
+    })
+    .unwrap();
+
+    let mut components = vec![hf_model("google-bert/bert-base-uncased", "ml-1")];
+    let stats = enricher.enrich(&mut components).unwrap();
+
+    // The HuggingFace model was queried (by PURL), not skipped.
+    batch_mock.assert();
+    assert_eq!(
+        stats.components_queried, 1,
+        "the HuggingFace model must be queried by PURL"
+    );
+    assert_eq!(
+        stats.components_skipped, 0,
+        "the HuggingFace model must not be skipped"
+    );
+    // OSV genuinely has nothing for it — that is correct and honest.
+    assert_eq!(stats.total_vulns_found, 0);
+}
+
+#[test]
+fn kev_linkage_flags_exploited_cve_on_huggingface_model() {
+    // The exploitability signal for ML models arrives via KEV linkage on a CVE
+    // the model already carries (e.g. from a SECURITY external ref or a prior
+    // enrichment), NOT from OSV's HuggingFace coverage (which does not exist).
+    let server = MockServer::start();
+    let cache_dir = tempfile::tempdir().unwrap();
+
+    let kev_mock = server.mock(|when, then| {
+        when.method(GET).path("/kev.json");
+        then.status(200)
+            .json_body(kev_catalog_body("CVE-2026-12345"));
+    });
+
+    let mut sbom = NormalizedSbom::default();
+    let mut model = hf_model("evil-org/backdoored-model", "ml-1");
+    // The model carries a CVE reference an analyst can pivot on.
+    model.vulnerabilities.push(VulnerabilityRef::new(
+        "CVE-2026-12345".to_string(),
+        VulnerabilitySource::Cve,
+    ));
+    sbom.add_component(model);
+
+    let config = EnrichmentConfig::default()
+        .with_kev()
+        .with_kev_url(format!("{}/kev.json", server.base_url()))
+        .with_cache_dir(cache_dir.path().to_path_buf())
+        .with_bypass_cache();
+
+    let stats = enrich_sbom_full(&mut sbom, &config, true);
+
+    kev_mock.assert();
+    let kev_stats = stats.kev.expect("KEV stats should be produced");
+    assert_eq!(
+        kev_stats.kev_matches, 1,
+        "the model's CVE must be flagged as actively exploited"
+    );
+
+    // The flag landed on the ML component's vulnerability.
+    let model = sbom
+        .components
+        .values()
+        .find(|c| c.component_type == ComponentType::MachineLearningModel)
+        .expect("ML component present");
+    assert!(
+        model.vulnerabilities.iter().any(|v| v.is_kev),
+        "the ML model's CVE must be marked is_kev after KEV linkage"
+    );
+}

--- a/tests/sarif_aibom_tests.rs
+++ b/tests/sarif_aibom_tests.rs
@@ -65,7 +65,7 @@ fn result_rule_ids(value: &serde_json::Value) -> Vec<String> {
 fn aibom_rule_table_is_complete_with_help_uris() {
     let value = render_sarif(&NormalizedSbom::new(DocumentMetadata::default()));
     let ids = rule_ids(&value);
-    for n in 1..=10 {
+    for n in 1..=11 {
         assert!(
             ids.contains(&format!("SBOM-AIBOM-{n:03}")),
             "missing SBOM-AIBOM-{n:03}"
@@ -101,7 +101,7 @@ fn aibom_not_applicable_emits_table_no_results() {
 #[test]
 fn aibom_emits_result_per_failing_check() {
     // A model documenting only the URL + architecture family: AI-001/002 pass,
-    // the rest fail → seven findings with the matching rule IDs.
+    // the remaining nine checks (AI-003..AI-011) fail with matching rule IDs.
     let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
     sbom.add_component(ml_component(|ml, _comp| {
         ml.architecture_family = Some("transformer".to_string());
@@ -118,9 +118,10 @@ fn aibom_emits_result_per_failing_check() {
     // AI-001 (URL) and AI-002 (family) pass → no result for them.
     assert!(!ids.contains(&"SBOM-AIBOM-001".to_string()));
     assert!(!ids.contains(&"SBOM-AIBOM-002".to_string()));
-    // The remaining eight checks fail (AI-003..AI-010, the last being the
-    // weight-hash integrity check — this model carries no hashes).
-    for n in 3..=10 {
+    // The remaining nine checks fail (AI-003..AI-011): AI-010 is the weight-hash
+    // integrity check (no hashes) and AI-011 the exploitability/advisory-reference
+    // check (no vuln or advisory ref on this model).
+    for n in 3..=11 {
         assert!(
             ids.contains(&format!("SBOM-AIBOM-{n:03}")),
             "expected a finding for SBOM-AIBOM-{n:03}"
@@ -150,9 +151,10 @@ fn aibom_emits_result_per_failing_check() {
 #[test]
 fn aibom_passing_checks_produce_no_result() {
     // Document everything except training datasets (AI-003): the typed checks
-    // AI-001/002/006/008, the raw-pointer checks AI-004/005/007/009, and the
-    // weight-hash integrity check AI-010 all pass, so the ONLY finding is
-    // SBOM-AIBOM-003. Confirms passing checks are skipped.
+    // AI-001/002/006/008, the raw-pointer checks AI-004/005/007/009, the
+    // weight-hash integrity check AI-010, and the exploitability-reference check
+    // AI-011 all pass, so the ONLY finding is SBOM-AIBOM-003. Confirms passing
+    // checks are skipped.
     let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
     sbom.add_component(ml_component(|ml, comp| {
         ml.architecture_family = Some("transformer".to_string());
@@ -164,6 +166,12 @@ fn aibom_passing_checks_produce_no_result() {
             sbom_tools::model::HashAlgorithm::Sha256,
             "c".repeat(64),
         ));
+        // A vulnerability reference satisfies the AI-011 exploitability check.
+        comp.vulnerabilities
+            .push(sbom_tools::model::VulnerabilityRef::new(
+                "CVE-2024-9999".to_string(),
+                sbom_tools::model::VulnerabilitySource::Cve,
+            ));
         comp.extensions.raw = Some(serde_json::json!({
             "mlModel": { "modelCard": {
                 "quantitativeAnalysis": { "performanceMetrics": [{ "type": "accuracy", "value": 0.97 }] },
@@ -182,5 +190,51 @@ fn aibom_passing_checks_produce_no_result() {
         ids,
         vec!["SBOM-AIBOM-003".to_string()],
         "only the training-datasets gap should be reported"
+    );
+}
+
+#[test]
+fn aibom_011_emitted_when_no_exploitability_reference() {
+    // A model with no vuln/advisory reference must yield an SBOM-AIBOM-011
+    // finding at `warning` level — the BSI exploitability-referencing gap.
+    let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
+    sbom.add_component(ml_component(|_ml, _comp| {}));
+
+    let value = render_sarif(&sbom);
+    let finding = value["runs"][0]["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|r| r["ruleId"] == serde_json::json!("SBOM-AIBOM-011"))
+        .expect("SBOM-AIBOM-011 finding for a model lacking an exploitability reference");
+    assert_eq!(finding["level"], serde_json::json!("warning"));
+    assert!(
+        finding["message"]["text"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("AI-011")
+    );
+}
+
+#[test]
+fn aibom_011_satisfied_by_security_advisory_external_ref() {
+    // A model carrying a security-advisory external reference satisfies AI-011
+    // even without an enriched vulnerability list, so no SBOM-AIBOM-011 finding.
+    let mut sbom = NormalizedSbom::new(DocumentMetadata::default());
+    sbom.add_component(ml_component(|_ml, comp| {
+        comp.external_refs
+            .push(sbom_tools::model::ExternalReference {
+                ref_type: sbom_tools::model::ExternalRefType::Advisories,
+                url: "https://example.test/advisory".to_string(),
+                comment: None,
+                hashes: Vec::new(),
+            });
+    }));
+
+    let value = render_sarif(&sbom);
+    let ids = result_rule_ids(&value);
+    assert!(
+        !ids.contains(&"SBOM-AIBOM-011".to_string()),
+        "an advisory external reference must satisfy AI-011"
     );
 }


### PR DESCRIPTION
## Summary

Realizes the BSI core thesis — *an AI SBOM is insufficient unless connected to cybersecurity tools* — by pointing the existing OSV/KEV/EPSS/VEX exploitability stack at `pkg:huggingface` ML model components, which were previously skipped because there was no HuggingFace ecosystem mapping.

- **`Ecosystem::HuggingFace`** added with `from_purl_type` / `Display` / matching-rule mappings so `pkg:huggingface` resolves to it (`src/model/identifiers.rs`, `src/matching/rules.rs`).
- **`Component::set_purl(&mut self)`** mirrors `with_purl` so enrichment can synthesize a PURL in place (`src/model/sbom.rs`).
- **HuggingFace enricher** now synthesizes a `pkg:huggingface/{model_id}` PURL when a model was resolved only via a model-card URL and lacks one, making it resolvable to `Ecosystem::HuggingFace` and routing it through vuln enrichment. Tracked via a new `purls_added` stat (`src/enrichment/huggingface/client.rs`).
- **AI-011** scorer check *"Exploitability/advisory reference present"* added to the `AiReadiness` profile: passes when a `MachineLearningModel` carries ≥1 `VulnerabilityRef` **or** an `Advisories` / `SecurityContact` / `VulnerabilityAssertion` / `ExploitabilityStatement` external reference. Weights renormalize to 1.0 via the existing `weight_sum` pattern (`src/quality/scorer.rs`).
- **`SBOM-AIBOM-011`** SARIF rule added at `warning` tier with `ai_check_to_rule_id` mapping (`src/reports/sarif.rs`).

### What OSV does / does NOT cover for ML (honest)

OSV (osv.dev) has **no ecosystem for HuggingFace / ML models**. This PR does **not** fabricate a garbage ecosystem string:

- `ecosystem_to_osv_string(Ecosystem::HuggingFace)` returns `""` — the honest "OSV cannot resolve this by name+ecosystem" signal. `build_query` therefore **skips** the name+ecosystem fallback for HuggingFace (OSV would reject it).
- A `pkg:huggingface` PURL query is still **forwarded** to OSV. OSV returns no vulns for it (correct), but the component stays *in* the pipeline (counted as queried, not skipped) rather than being silently dropped.
- The exploitability element for ML clusters is satisfied by **KEV/advisory linkage on CVE identifiers the model already carries** (e.g. from a security external ref or prior enrichment), independent of OSV's absent HuggingFace coverage. This is partial-but-correct coverage, exactly matching the BSI "exploitability referencing" element.

`AiReadiness` FFI conformance remains **deferred (#205)** — unchanged by this PR.

## Test plan

- `cargo test --features enrichment` — full suite green (967 lib + all integration suites, 0 failures).
- New unit tests: OSV `build_query` forwards the HF PURL / skips the name fallback; HF PURL synthesis (and never overwrites an existing PURL); scorer AI-011 pass (vuln ref **and** advisory ref) / fail (no ref).
- New integration tests (`tests/ml_component_vuln_enrichment_tests.rs`, httpmock): a `pkg:huggingface` model is OSV-queried (not skipped); KEV linkage flags an exploited CVE the model carries.
- `tests/sarif_aibom_tests.rs`: `SBOM-AIBOM-011` in the rule table, emitted when no exploitability ref, suppressed when an advisory external ref is present.
- Fixtures (`aibom-complete.cdx.json`, `ai-dataset.spdx3.json`) gain a security-advisory external ref so the fully-documented AI BOMs still pass all checks and keep cross-format score parity.
- `cargo fmt` clean; `cargo clippy --all-targets --all-features -- -D warnings` clean on pinned 1.88 (0 new). Golden report snapshots unaffected (AI-readiness SARIF is a separate generator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)