### PR TITLE
feat(compliance): BSI/G7 SBOM-for-AI minimum-elements readiness profile

### DIFF
--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -120,10 +120,13 @@ pub fn run_validate(
                 }
                 checker.check(parsed.sbom())
             }
+            "bsi-ai" | "bsi_ai" | "bsiai" | "sbom-for-ai" | "ai-bom" => {
+                ComplianceChecker::new(ComplianceLevel::BsiSbomForAi).check(parsed.sbom())
+            }
             _ => {
                 bail!(
                     "Unknown validation standard: {std_name}. \
-                    Valid options: ntia, fda, cra, ssdf, eo14028, cnsa2, pqc, bsi, oss-steward, eucc, ai-act"
+                    Valid options: ntia, fda, cra, ssdf, eo14028, cnsa2, pqc, bsi, oss-steward, eucc, ai-act, bsi-ai"
                 );
             }
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -476,7 +476,7 @@ struct ValidateArgs {
     /// Path to the SBOM file
     sbom: PathBuf,
 
-    /// Compliance standard(s) to validate against (comma-separated: ntia, fda, cra, ssdf, eo14028, ai-act)
+    /// Compliance standard(s) to validate against (comma-separated: ntia, fda, cra, ssdf, eo14028, ai-act, bsi-ai)
     #[arg(long, default_value = "ntia")]
     standard: String,
 

--- a/src/model/metadata.rs
+++ b/src/model/metadata.rs
@@ -571,6 +571,10 @@ pub struct MlModelInfo {
     /// Quantitative performance metrics (CycloneDX
     /// `modelCard.quantitativeAnalysis.performanceMetrics`, SPDX `ai_metric`).
     pub performance_metrics: Vec<MetricEntry>,
+    /// Data-preprocessing steps applied to the model's inputs (SPDX 3.0 AI
+    /// profile `ai_modelDataPreprocessing`). Surfaced for the BSI/G7
+    /// SBOM-for-AI "Models" cluster; CycloneDX has no direct analogue.
+    pub data_preprocessing: Vec<String>,
 }
 
 /// A fairness assessment for an ML model (CycloneDX 1.5+
@@ -639,4 +643,21 @@ pub struct DatasetInfo {
     pub sensitivity_classifications: Vec<String>,
     /// Data governance owners/custodians
     pub governance_owners: Vec<String>,
+    /// Intended use of the dataset (SPDX 3.0 Dataset profile
+    /// `dataset_intendedUse`). Part of the BSI/G7 SBOM-for-AI "Datasets"
+    /// cluster provenance / intended-use element.
+    pub intended_use: Option<String>,
+    /// Confidentiality level of the dataset (SPDX 3.0 Dataset profile
+    /// `dataset_confidentialityLevel`). Distinct from the sensitivity
+    /// classifications above, which already fold this in for AI-Act scoring;
+    /// retained verbatim here for the BSI sensitivity-classification element.
+    pub confidentiality_level: Option<String>,
+    /// Data-preprocessing steps applied to the dataset (SPDX 3.0 Dataset
+    /// profile `dataset_dataPreprocessing`). Surfaced for the BSI/G7
+    /// SBOM-for-AI "Datasets" cluster provenance element.
+    pub preprocessing: Vec<String>,
+    /// Anonymization methods applied to the dataset (SPDX 3.0 Dataset profile
+    /// `dataset_anonymizationMethodUsed`). Surfaced for the BSI/G7
+    /// SBOM-for-AI "Datasets" cluster provenance element.
+    pub anonymization: Vec<String>,
 }

--- a/src/parsers/cyclonedx.rs
+++ b/src/parsers/cyclonedx.rs
@@ -588,6 +588,10 @@ impl CycloneDxParser {
                 dataset_type: data_component.data_type.clone(),
                 sensitivity_classifications: data_component.sensitivity_data.clone(),
                 governance_owners,
+                // intended_use / confidentiality_level / preprocessing /
+                // anonymization have no CycloneDX `componentData` analogue; they
+                // are SPDX-3.0-only and left unset here.
+                ..Default::default()
             });
         }
 

--- a/src/parsers/spdx3.rs
+++ b/src/parsers/spdx3.rs
@@ -587,6 +587,8 @@ impl Spdx3Parser {
                     ethical_considerations: ethical,
                     use_cases,
                     performance_metrics,
+                    // Data-preprocessing steps (BSI/G7 SBOM-for-AI Models cluster).
+                    data_preprocessing: pkg.ai_model_data_preprocessing.clone().unwrap_or_default(),
                     // training_datasets are linked via TRAINED_ON relationships in
                     // SPDX (populated in process_relationship), not an inline field.
                     ..Default::default()
@@ -625,7 +627,14 @@ impl Spdx3Parser {
                         .and_then(|v| v.first().cloned()),
                     sensitivity_classifications: sensitivity,
                     governance_owners: owners,
-                    ..Default::default()
+                    // BSI/G7 SBOM-for-AI Datasets cluster provenance / intended-use.
+                    intended_use: pkg.dataset_intended_use.clone(),
+                    confidentiality_level: pkg.dataset_confidentiality_level.clone(),
+                    preprocessing: pkg.dataset_data_preprocessing.clone().unwrap_or_default(),
+                    anonymization: pkg
+                        .dataset_anonymization_method_used
+                        .clone()
+                        .unwrap_or_default(),
                 });
             }
             PackageKind::Software => {}
@@ -1891,6 +1900,55 @@ mod tests {
         )
         .expect("dataset_DatasetPackage should deserialize");
         assert!(matches!(ds, Spdx3Element::DatasetPackage(_)));
+    }
+
+    #[test]
+    fn test_spdx3_dataset_provenance_fields_mapped() {
+        // The Dataset profile provenance fields (intended use, confidentiality
+        // level, preprocessing, anonymization) must be carried into DatasetInfo,
+        // not dropped — they feed the BSI/G7 SBOM-for-AI Datasets cluster.
+        let pkg: Spdx3Package = serde_json::from_str(
+            r#"{
+                "type": "dataset_DatasetPackage",
+                "spdxId": "urn:x:d",
+                "name": "reviews",
+                "dataset_intendedUse": "model fine-tuning",
+                "dataset_confidentialityLevel": "amber",
+                "dataset_dataPreprocessing": ["dedup", "normalize"],
+                "dataset_anonymizationMethodUsed": ["k-anonymity"],
+                "dataset_hasSensitivePersonalInformation": "no"
+            }"#,
+        )
+        .expect("dataset package should deserialize");
+        let converter = Spdx3Parser::new();
+        let comp = converter.convert_package(&pkg, PackageKind::Dataset, &HashMap::new());
+        let ds = comp.dataset.expect("dataset info present");
+        assert_eq!(ds.intended_use.as_deref(), Some("model fine-tuning"));
+        assert_eq!(ds.confidentiality_level.as_deref(), Some("amber"));
+        assert_eq!(ds.preprocessing, vec!["dedup", "normalize"]);
+        assert_eq!(ds.anonymization, vec!["k-anonymity"]);
+        // Confidentiality level is also folded into sensitivity for AI-Act scoring.
+        assert!(
+            ds.sensitivity_classifications
+                .contains(&"amber".to_string())
+        );
+    }
+
+    #[test]
+    fn test_spdx3_model_data_preprocessing_mapped() {
+        let pkg: Spdx3Package = serde_json::from_str(
+            r#"{
+                "type": "ai_AIPackage",
+                "spdxId": "urn:x:m",
+                "name": "model",
+                "ai_modelDataPreprocessing": ["tokenize", "truncate"]
+            }"#,
+        )
+        .expect("ai package should deserialize");
+        let converter = Spdx3Parser::new();
+        let comp = converter.convert_package(&pkg, PackageKind::AiModel, &HashMap::new());
+        let ml = comp.ml_model.expect("ml model info present");
+        assert_eq!(ml.data_preprocessing, vec!["tokenize", "truncate"]);
     }
 
     #[test]

--- a/src/quality/compliance/bsi_sbom_for_ai.rs
+++ b/src/quality/compliance/bsi_sbom_for_ai.rs
@@ -1,0 +1,860 @@
+//! BSI/G7 "SBOM for AI — Minimum Elements" (Feb 2026) minimum-elements
+//! READINESS checks.
+//!
+//! The BSI/G7 guidance enumerates the minimum elements an AI-BOM should carry,
+//! grouped into seven clusters: document **Metadata**, **System-Level**
+//! description, **Models**, **Datasets**, **Infrastructure**, and **Security**.
+//! This module maps each minimum element onto the AI-BOM metadata sbom-tools
+//! already parses ([`MlModelInfo`], [`DatasetInfo`], [`DocumentMetadata`]) and
+//! reports, element-by-element, which are present.
+//!
+//! Scope and framing:
+//! - This is a *minimum-elements readiness* assessment, not a legal-conformity
+//!   guarantee. Passing every check does not certify an AI-BOM as BSI/G7
+//!   conformant; it reports which minimum elements are declared.
+//! - When the SBOM carries no ML-model or dataset metadata the profile is
+//!   *not applicable* and returns a single informational finding rather than
+//!   failing every non-AI SBOM (mirrors the EU-AI-Act non-AI guard exactly).
+//! - Some clusters (data-flow, AI-specific security controls, exploitability
+//!   references) have no home in the model yet; those elements emit an
+//!   informational "not declared" finding so the readiness scorecard stays
+//!   complete rather than silently omitting them.
+//!
+//! Severity is tuned to the BSI/G7 normative language: MUST elements are
+//! Errors, SHOULD elements are Warnings, and discretionary / not-yet-modeled
+//! elements are informational.
+
+use super::*;
+use crate::model::{ComponentType, CreatorType, HashAlgorithm};
+
+impl ComplianceChecker {
+    // ════════════════════════════════════════════════════════════════════
+    // BSI/G7 SBOM-for-AI Minimum Elements readiness
+    // ════════════════════════════════════════════════════════════════════
+
+    pub(crate) fn check_bsi_sbom_for_ai(
+        &self,
+        sbom: &NormalizedSbom,
+        violations: &mut Vec<Violation>,
+    ) {
+        // ML-model and dataset components drive the readiness checks.
+        let ml_components: Vec<_> = sbom
+            .components
+            .values()
+            .filter(|c| c.component_type == ComponentType::MachineLearningModel)
+            .collect();
+        let dataset_components: Vec<_> = sbom
+            .components
+            .values()
+            .filter(|c| c.dataset.is_some() || c.component_type == ComponentType::Data)
+            .collect();
+
+        // N/A gate: no AI/ML content at all → single informational finding,
+        // never a failure (a non-AI SBOM is simply out of scope here). Mirrors
+        // the EU-AI-Act non-AI guard exactly.
+        if ml_components.is_empty() && dataset_components.is_empty() {
+            violations.push(Violation {
+                severity: ViolationSeverity::Info,
+                category: ViolationCategory::DocumentMetadata,
+                message: "[BSI-AI] Not applicable: SBOM contains no machine-learning-model or \
+                          dataset components, so BSI/G7 SBOM-for-AI minimum-elements readiness \
+                          cannot be assessed (readiness profile, not a legal-conformity guarantee)"
+                    .to_string(),
+                element: None,
+                requirement: "BSI/G7 SBOM-for-AI: applicability".to_string(),
+                rule_id: "SBOM-BSIAI-NA",
+                standard_refs: Vec::new(),
+            });
+            return;
+        }
+
+        self.check_bsiai_metadata_cluster(sbom, violations);
+        self.check_bsiai_system_level_cluster(sbom, &ml_components, violations);
+        self.check_bsiai_models_cluster(&ml_components, violations);
+        self.check_bsiai_datasets_cluster(&dataset_components, violations);
+        self.check_bsiai_infrastructure_cluster(sbom, &ml_components, violations);
+        self.check_bsiai_security_cluster(violations);
+    }
+
+    /// Metadata cluster — the document-level minimum elements: author/creator,
+    /// data-format name + version, timestamp, ≥1 tool creator, and a signature
+    /// (informational when absent).
+    fn check_bsiai_metadata_cluster(&self, sbom: &NormalizedSbom, violations: &mut Vec<Violation>) {
+        let doc = &sbom.document;
+
+        // Author / creator present (MUST).
+        if doc.creators.is_empty() {
+            violations.push(Violation {
+                severity: ViolationSeverity::Error,
+                category: ViolationCategory::DocumentMetadata,
+                message: "[BSI-AI] Metadata readiness: SBOM declares no author/creator".to_string(),
+                element: None,
+                requirement: "BSI/G7 SBOM-for-AI — Metadata / Author".to_string(),
+                rule_id: "SBOM-BSIAI-META-AUTHOR",
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // Data-format name + version present (MUST). NormalizedSbom always knows
+        // its format; the practical gap is a missing format_version string.
+        if doc.format_version.is_empty() && doc.spec_version.is_empty() {
+            violations.push(Violation {
+                severity: ViolationSeverity::Error,
+                category: ViolationCategory::DocumentMetadata,
+                message: format!(
+                    "[BSI-AI] Metadata readiness: SBOM data-format version is not declared \
+                     (format: {})",
+                    doc.format
+                ),
+                element: None,
+                requirement: "BSI/G7 SBOM-for-AI — Metadata / Data format name + version"
+                    .to_string(),
+                rule_id: "SBOM-BSIAI-META-FORMAT",
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // Timestamp present (MUST). DocumentMetadata::created is DateTime<Utc>,
+        // always ISO-8601; the risk is the source SBOM not carrying one (which
+        // surfaces as a unix-epoch / pre-epoch fallback).
+        if doc.created.timestamp() <= 0 {
+            violations.push(Violation {
+                severity: ViolationSeverity::Error,
+                category: ViolationCategory::DocumentMetadata,
+                message: "[BSI-AI] Metadata readiness: SBOM creation timestamp missing or invalid"
+                    .to_string(),
+                element: None,
+                requirement: "BSI/G7 SBOM-for-AI — Metadata / Timestamp".to_string(),
+                rule_id: "SBOM-BSIAI-META-TIMESTAMP",
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // At least one tool creator (SHOULD).
+        let has_tool_creator = doc
+            .creators
+            .iter()
+            .any(|c| c.creator_type == CreatorType::Tool);
+        if !has_tool_creator {
+            violations.push(Violation {
+                severity: ViolationSeverity::Warning,
+                category: ViolationCategory::DocumentMetadata,
+                message: "[BSI-AI] Metadata readiness: SBOM does not identify the generation tool"
+                    .to_string(),
+                element: None,
+                requirement: "BSI/G7 SBOM-for-AI — Metadata / Generation tool".to_string(),
+                rule_id: "SBOM-BSIAI-META-TOOL",
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // Signature present (informational when absent — discretionary element).
+        if doc.signature.is_none() {
+            violations.push(Violation {
+                severity: ViolationSeverity::Info,
+                category: ViolationCategory::IntegrityInfo,
+                message: "[BSI-AI] Metadata readiness: SBOM carries no document signature \
+                          (integrity attestation recommended)"
+                    .to_string(),
+                element: None,
+                requirement: "BSI/G7 SBOM-for-AI — Metadata / Signature".to_string(),
+                rule_id: "SBOM-BSIAI-META-SIGNATURE",
+                standard_refs: Vec::new(),
+            });
+        }
+    }
+
+    /// System-Level cluster — a primary AI-system component must be
+    /// identifiable, and a producer/supplier should be declared. Data-flow /
+    /// usage / I/O elements have no model home yet → informational.
+    fn check_bsiai_system_level_cluster(
+        &self,
+        sbom: &NormalizedSbom,
+        ml_components: &[&crate::model::Component],
+        violations: &mut Vec<Violation>,
+    ) {
+        // A primary AI-system component is identifiable when either the SBOM's
+        // primary component is an ML model / application, or — failing an
+        // explicit primary — at least one ML component exists to anchor the
+        // system description.
+        let primary_is_ai_system = sbom.primary_component().is_some_and(|c| {
+            matches!(
+                c.component_type,
+                ComponentType::MachineLearningModel | ComponentType::Application
+            )
+        });
+        let has_ai_anchor = primary_is_ai_system || !ml_components.is_empty();
+        if !has_ai_anchor {
+            violations.push(Violation {
+                severity: ViolationSeverity::Warning,
+                category: ViolationCategory::ComponentIdentification,
+                message: "[BSI-AI] System-Level readiness: no primary AI-system component is \
+                          identifiable (expected a MachineLearningModel or primary Application)"
+                    .to_string(),
+                element: None,
+                requirement: "BSI/G7 SBOM-for-AI — System-Level / Primary AI system".to_string(),
+                rule_id: "SBOM-BSIAI-SYS-PRIMARY",
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // Producer / supplier of the AI system (SHOULD). Satisfied when the
+        // primary component (or, lacking one, any ML component) declares a
+        // supplier/author, or the document carries an organization creator.
+        let producer_known = sbom
+            .primary_component()
+            .is_some_and(|c| c.supplier.is_some() || c.author.is_some())
+            || ml_components
+                .iter()
+                .any(|c| c.supplier.is_some() || c.author.is_some())
+            || sbom
+                .document
+                .creators
+                .iter()
+                .any(|c| c.creator_type == CreatorType::Organization);
+        if !producer_known {
+            violations.push(Violation {
+                severity: ViolationSeverity::Warning,
+                category: ViolationCategory::SupplierInfo,
+                message: "[BSI-AI] System-Level readiness: no producer/supplier of the AI system \
+                          is declared"
+                    .to_string(),
+                element: None,
+                requirement: "BSI/G7 SBOM-for-AI — System-Level / Producer".to_string(),
+                rule_id: "SBOM-BSIAI-SYS-PRODUCER",
+                standard_refs: Vec::new(),
+            });
+        }
+
+        // Data-flow / usage / input-output description: not modeled yet →
+        // informational "not declared" so the scorecard is complete.
+        violations.push(Violation {
+            severity: ViolationSeverity::Info,
+            category: ViolationCategory::DocumentMetadata,
+            message: "[BSI-AI] System-Level readiness: AI-system data-flow / usage / input-output \
+                      description is not declared (no SBOM field carries it today)"
+                .to_string(),
+            element: None,
+            requirement: "BSI/G7 SBOM-for-AI — System-Level / Data flow & usage".to_string(),
+            rule_id: "SBOM-BSIAI-SYS-DATAFLOW",
+            standard_refs: Vec::new(),
+        });
+    }
+
+    /// Models cluster — the strongest cluster: per ML component, check name,
+    /// version, identifier, weight hash, NIST-approved hash algorithm, model
+    /// card, architecture, training datasets, limitations, and license.
+    fn check_bsiai_models_cluster(
+        &self,
+        ml_components: &[&crate::model::Component],
+        violations: &mut Vec<Violation>,
+    ) {
+        let mut without_name = Vec::new();
+        let mut without_version = Vec::new();
+        let mut without_identifier = Vec::new();
+        let mut without_hash = Vec::new();
+        let mut weak_hash = Vec::new();
+        let mut without_model_card = Vec::new();
+        let mut without_architecture = Vec::new();
+        let mut without_datasets = Vec::new();
+        let mut without_limitations = Vec::new();
+        let mut without_license = Vec::new();
+
+        for c in ml_components {
+            let ml = c.ml_model.as_ref();
+            if c.name.trim().is_empty() {
+                without_name.push(c.canonical_id.to_string());
+            }
+            if c.version.as_ref().is_none_or(|v| v.trim().is_empty()) {
+                without_version.push(c.name.clone());
+            }
+            if !c.identifiers.has_cra_identifier() {
+                without_identifier.push(c.name.clone());
+            }
+
+            // Weight hash present (AI-010 logic: any hash on the component).
+            if c.hashes.is_empty() {
+                without_hash.push(c.name.clone());
+            } else if !c.hashes.iter().any(|h| nist_approved_hash(&h.algorithm)) {
+                // Hash present but none use a NIST-approved algorithm
+                // (reuses the bsi.rs SHA-256+ gate).
+                weak_hash.push(c.name.clone());
+            }
+
+            // Model card URL (AI-001).
+            if ml.and_then(|m| m.model_card_url.as_ref()).is_none() {
+                without_model_card.push(c.name.clone());
+            }
+            // Architecture declared (AI-002).
+            let has_architecture = ml
+                .is_some_and(|m| m.architecture_family.is_some() || m.architecture_name.is_some());
+            if !has_architecture {
+                without_architecture.push(c.name.clone());
+            }
+            // Training datasets referenced (AI-003).
+            if ml.is_none_or(|m| m.training_datasets.is_empty()) {
+                without_datasets.push(c.name.clone());
+            }
+            // Limitations stated (AI-008).
+            if ml.and_then(|m| m.limitations.as_ref()).is_none() {
+                without_limitations.push(c.name.clone());
+            }
+            // License present.
+            if c.licenses.declared.is_empty() && c.licenses.concluded.is_none() {
+                without_license.push(c.name.clone());
+            }
+        }
+
+        // MUST elements (Error).
+        push_model_finding(
+            violations,
+            ViolationSeverity::Error,
+            ViolationCategory::ComponentIdentification,
+            &without_name,
+            "declare no name",
+            "BSI/G7 SBOM-for-AI — Models / Model name",
+            "SBOM-BSIAI-MODEL-NAME",
+        );
+        push_model_finding(
+            violations,
+            ViolationSeverity::Error,
+            ViolationCategory::ComponentIdentification,
+            &without_version,
+            "declare no version",
+            "BSI/G7 SBOM-for-AI — Models / Model version",
+            "SBOM-BSIAI-MODEL-VERSION",
+        );
+        push_model_finding(
+            violations,
+            ViolationSeverity::Error,
+            ViolationCategory::ComponentIdentification,
+            &without_identifier,
+            "carry no unique identifier (PURL/CPE/SWHID/SWID)",
+            "BSI/G7 SBOM-for-AI — Models / Model identifier",
+            "SBOM-BSIAI-MODEL-IDENTIFIER",
+        );
+        push_model_finding(
+            violations,
+            ViolationSeverity::Error,
+            ViolationCategory::IntegrityInfo,
+            &without_hash,
+            "carry no model-weight hash value",
+            "BSI/G7 SBOM-for-AI — Models / Model hash value",
+            "SBOM-BSIAI-MODEL-HASH",
+        );
+        push_model_finding(
+            violations,
+            ViolationSeverity::Error,
+            ViolationCategory::IntegrityInfo,
+            &weak_hash,
+            "use no NIST-approved hash algorithm (SHA-256+) for their weights",
+            "BSI/G7 SBOM-for-AI — Models / Hash algorithm",
+            "SBOM-BSIAI-MODEL-HASH-ALGO",
+        );
+
+        // SHOULD elements (Warning).
+        push_model_finding(
+            violations,
+            ViolationSeverity::Warning,
+            ViolationCategory::DocumentMetadata,
+            &without_model_card,
+            "reference no model card",
+            "BSI/G7 SBOM-for-AI — Models / Model card",
+            "SBOM-BSIAI-MODEL-CARD",
+        );
+        push_model_finding(
+            violations,
+            ViolationSeverity::Warning,
+            ViolationCategory::DocumentMetadata,
+            &without_architecture,
+            "declare no architecture",
+            "BSI/G7 SBOM-for-AI — Models / Architecture",
+            "SBOM-BSIAI-MODEL-ARCHITECTURE",
+        );
+        push_model_finding(
+            violations,
+            ViolationSeverity::Warning,
+            ViolationCategory::DependencyInfo,
+            &without_datasets,
+            "reference no training datasets",
+            "BSI/G7 SBOM-for-AI — Models / Training datasets",
+            "SBOM-BSIAI-MODEL-DATASETS",
+        );
+        push_model_finding(
+            violations,
+            ViolationSeverity::Warning,
+            ViolationCategory::DocumentMetadata,
+            &without_limitations,
+            "state no limitations",
+            "BSI/G7 SBOM-for-AI — Models / Limitations",
+            "SBOM-BSIAI-MODEL-LIMITATIONS",
+        );
+        push_model_finding(
+            violations,
+            ViolationSeverity::Warning,
+            ViolationCategory::LicenseInfo,
+            &without_license,
+            "declare no license",
+            "BSI/G7 SBOM-for-AI — Models / Model license",
+            "SBOM-BSIAI-MODEL-LICENSE",
+        );
+    }
+
+    /// Datasets cluster — per Data component: name, identifier, hash, license,
+    /// sensitivity classification, and provenance / intended-use (now available
+    /// from the SPDX dataset-field wiring).
+    fn check_bsiai_datasets_cluster(
+        &self,
+        dataset_components: &[&crate::model::Component],
+        violations: &mut Vec<Violation>,
+    ) {
+        let mut without_name = Vec::new();
+        let mut without_identifier = Vec::new();
+        let mut without_hash = Vec::new();
+        let mut without_license = Vec::new();
+        let mut without_sensitivity = Vec::new();
+        let mut without_provenance = Vec::new();
+
+        for c in dataset_components {
+            if c.name.trim().is_empty() {
+                without_name.push(c.canonical_id.to_string());
+            }
+            if !c.identifiers.has_cra_identifier() {
+                without_identifier.push(c.name.clone());
+            }
+            if c.hashes.is_empty() {
+                without_hash.push(c.name.clone());
+            }
+            if c.licenses.declared.is_empty() && c.licenses.concluded.is_none() {
+                without_license.push(c.name.clone());
+            }
+            let ds = c.dataset.as_ref();
+            // Sensitivity classification present (a classification of "none"
+            // still counts as a declaration).
+            let has_sensitivity = ds.is_some_and(|d| {
+                !d.sensitivity_classifications.is_empty() || d.confidentiality_level.is_some()
+            });
+            if !has_sensitivity {
+                without_sensitivity.push(c.name.clone());
+            }
+            // Provenance / intended-use (now available from Part 1: intended
+            // use, preprocessing, anonymization, or governance owners).
+            let has_provenance = ds.is_some_and(|d| {
+                d.intended_use.is_some()
+                    || !d.preprocessing.is_empty()
+                    || !d.anonymization.is_empty()
+                    || !d.governance_owners.is_empty()
+            });
+            if !has_provenance {
+                without_provenance.push(c.name.clone());
+            }
+        }
+
+        // MUST elements (Error).
+        push_model_finding(
+            violations,
+            ViolationSeverity::Error,
+            ViolationCategory::ComponentIdentification,
+            &without_name,
+            "declare no name",
+            "BSI/G7 SBOM-for-AI — Datasets / Dataset name",
+            "SBOM-BSIAI-DATASET-NAME",
+        );
+        push_model_finding(
+            violations,
+            ViolationSeverity::Error,
+            ViolationCategory::ComponentIdentification,
+            &without_identifier,
+            "carry no unique identifier (PURL/CPE/SWHID/SWID)",
+            "BSI/G7 SBOM-for-AI — Datasets / Dataset identifier",
+            "SBOM-BSIAI-DATASET-IDENTIFIER",
+        );
+
+        // SHOULD elements (Warning).
+        push_model_finding(
+            violations,
+            ViolationSeverity::Warning,
+            ViolationCategory::IntegrityInfo,
+            &without_hash,
+            "carry no hash value",
+            "BSI/G7 SBOM-for-AI — Datasets / Dataset hash value",
+            "SBOM-BSIAI-DATASET-HASH",
+        );
+        push_model_finding(
+            violations,
+            ViolationSeverity::Warning,
+            ViolationCategory::LicenseInfo,
+            &without_license,
+            "declare no license",
+            "BSI/G7 SBOM-for-AI — Datasets / Dataset license",
+            "SBOM-BSIAI-DATASET-LICENSE",
+        );
+        push_model_finding(
+            violations,
+            ViolationSeverity::Warning,
+            ViolationCategory::DocumentMetadata,
+            &without_sensitivity,
+            "declare no sensitivity classification",
+            "BSI/G7 SBOM-for-AI — Datasets / Sensitivity classification",
+            "SBOM-BSIAI-DATASET-SENSITIVITY",
+        );
+        push_model_finding(
+            violations,
+            ViolationSeverity::Warning,
+            ViolationCategory::DocumentMetadata,
+            &without_provenance,
+            "declare no provenance / intended-use",
+            "BSI/G7 SBOM-for-AI — Datasets / Provenance & intended use",
+            "SBOM-BSIAI-DATASET-PROVENANCE",
+        );
+    }
+
+    /// Infrastructure cluster — an ML component should link to its runtime /
+    /// framework dependencies (a BOM / HBOM link, or any dependency edge).
+    /// Informational when no such link exists.
+    fn check_bsiai_infrastructure_cluster(
+        &self,
+        sbom: &NormalizedSbom,
+        ml_components: &[&crate::model::Component],
+        violations: &mut Vec<Violation>,
+    ) {
+        use crate::model::ExternalRefType;
+
+        // Does any ML component participate in a dependency edge, or carry an
+        // ExternalRefType::Bom link to a runtime/framework BOM?
+        let has_infra_link = ml_components.iter().any(|c| {
+            let in_edges = sbom
+                .edges
+                .iter()
+                .any(|e| e.from == c.canonical_id || e.to == c.canonical_id);
+            let has_bom_ref = c
+                .external_refs
+                .iter()
+                .any(|r| r.ref_type == ExternalRefType::Bom);
+            in_edges || has_bom_ref
+        });
+
+        if !has_infra_link {
+            violations.push(Violation {
+                severity: ViolationSeverity::Info,
+                category: ViolationCategory::DependencyInfo,
+                message: "[BSI-AI] Infrastructure readiness: no ML component links to its runtime \
+                          / framework dependencies (no dependency edge or BOM/HBOM reference)"
+                    .to_string(),
+                element: None,
+                requirement: "BSI/G7 SBOM-for-AI — Infrastructure / Runtime & framework"
+                    .to_string(),
+                rule_id: "SBOM-BSIAI-INFRA-RUNTIME",
+                standard_refs: Vec::new(),
+            });
+        }
+    }
+
+    /// Security cluster — AI-specific security controls and exploitability
+    /// references have no model home yet, so both elements emit an
+    /// informational "not declared" finding to keep the scorecard complete.
+    fn check_bsiai_security_cluster(&self, violations: &mut Vec<Violation>) {
+        violations.push(Violation {
+            severity: ViolationSeverity::Info,
+            category: ViolationCategory::SecurityInfo,
+            message: "[BSI-AI] Security readiness: no AI-specific security controls are declared \
+                      (no SBOM field carries them today)"
+                .to_string(),
+            element: None,
+            requirement: "BSI/G7 SBOM-for-AI — Security / AI security controls".to_string(),
+            rule_id: "SBOM-BSIAI-SEC-CONTROLS",
+            standard_refs: Vec::new(),
+        });
+        violations.push(Violation {
+            severity: ViolationSeverity::Info,
+            category: ViolationCategory::SecurityInfo,
+            message: "[BSI-AI] Security readiness: no exploitability reference is declared \
+                      (no SBOM field carries it today)"
+                .to_string(),
+            element: None,
+            requirement: "BSI/G7 SBOM-for-AI — Security / Exploitability reference".to_string(),
+            rule_id: "SBOM-BSIAI-SEC-EXPLOITABILITY",
+            standard_refs: Vec::new(),
+        });
+    }
+}
+
+/// NIST-approved cryptographic hash gate (SHA-256 or stronger). Reuses the
+/// same allowlist as the BSI TR-03183-2 §5.4 check in [`super::bsi`].
+fn nist_approved_hash(a: &HashAlgorithm) -> bool {
+    matches!(
+        a,
+        HashAlgorithm::Sha256
+            | HashAlgorithm::Sha384
+            | HashAlgorithm::Sha512
+            | HashAlgorithm::Sha3_256
+            | HashAlgorithm::Sha3_384
+            | HashAlgorithm::Sha3_512
+            | HashAlgorithm::Blake2b256
+            | HashAlgorithm::Blake2b384
+            | HashAlgorithm::Blake2b512
+            | HashAlgorithm::Blake3
+    )
+}
+
+/// Push a per-component readiness finding when `failing` is non-empty. `verb`
+/// completes the sentence "N component(s) <verb>: <list>".
+fn push_model_finding(
+    violations: &mut Vec<Violation>,
+    severity: ViolationSeverity,
+    category: ViolationCategory,
+    failing: &[String],
+    verb: &str,
+    requirement: &str,
+    rule_id: &'static str,
+) {
+    if failing.is_empty() {
+        return;
+    }
+    violations.push(Violation {
+        severity,
+        category,
+        message: format!(
+            "[BSI-AI] {} readiness: {} component(s) {}: {}",
+            requirement.rsplit('/').next().unwrap_or(requirement).trim(),
+            failing.len(),
+            verb,
+            truncate_list(failing, 5)
+        ),
+        element: failing.first().cloned(),
+        requirement: requirement.to_string(),
+        rule_id,
+        standard_refs: Vec::new(),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::{
+        Component, DatasetInfo, DatasetRef, Hash, HashAlgorithm, MlModelInfo, Organization,
+    };
+
+    fn full_ml_component(name: &str) -> Component {
+        let mut c = Component::new(name.to_string(), name.to_string())
+            .with_version("1.0.0".to_string())
+            .with_purl(format!("pkg:huggingface/{name}@1.0.0"));
+        c.component_type = ComponentType::MachineLearningModel;
+        c.description = Some("A documented model".to_string());
+        c.licenses.declared = vec![crate::model::LicenseExpression::new(
+            "Apache-2.0".to_string(),
+        )];
+        c.hashes.push(Hash::new(
+            HashAlgorithm::Sha256,
+            "0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+        ));
+        c.ml_model = Some(MlModelInfo {
+            architecture_family: Some("transformer".to_string()),
+            model_card_url: Some("https://example.test/card".to_string()),
+            use_cases: vec!["sentiment-analysis".to_string()],
+            training_datasets: vec![DatasetRef {
+                reference: Some("data-1".to_string()),
+                name: Some("reviews".to_string()),
+                purl: None,
+            }],
+            limitations: Some("English only".to_string()),
+            ..MlModelInfo::default()
+        });
+        c
+    }
+
+    fn bare_ml_component(name: &str) -> Component {
+        let mut c = Component::new(name.to_string(), name.to_string());
+        c.component_type = ComponentType::MachineLearningModel;
+        c.ml_model = Some(MlModelInfo::default());
+        c
+    }
+
+    fn full_dataset_component(name: &str) -> Component {
+        let mut c = Component::new(name.to_string(), name.to_string())
+            .with_purl(format!("pkg:generic/{name}"));
+        c.component_type = ComponentType::Data;
+        c.supplier = Some(Organization::new("DataCorp".to_string()));
+        c.licenses.declared = vec![crate::model::LicenseExpression::new(
+            "CC-BY-4.0".to_string(),
+        )];
+        c.hashes.push(Hash::new(
+            HashAlgorithm::Sha256,
+            "1111111111111111111111111111111111111111111111111111111111111111".to_string(),
+        ));
+        c.dataset = Some(DatasetInfo {
+            dataset_type: Some("training".to_string()),
+            sensitivity_classifications: vec!["none".to_string()],
+            intended_use: Some("model fine-tuning".to_string()),
+            governance_owners: vec!["Data Team".to_string()],
+            ..DatasetInfo::default()
+        });
+        c
+    }
+
+    fn add(sbom: &mut NormalizedSbom, c: Component) {
+        sbom.components.insert(c.canonical_id.clone(), c);
+    }
+
+    #[test]
+    fn non_ai_sbom_returns_not_applicable_and_does_not_fail() {
+        let mut sbom = NormalizedSbom::default();
+        let mut sw =
+            Component::new("lib".to_string(), "lib".to_string()).with_version("1.0.0".to_string());
+        sw.component_type = ComponentType::Library;
+        add(&mut sbom, sw);
+
+        let result = ComplianceChecker::new(ComplianceLevel::BsiSbomForAi).check(&sbom);
+        assert!(result.is_compliant, "non-AI SBOM must not fail BSI-AI");
+        assert_eq!(result.error_count, 0);
+        assert_eq!(
+            result.violations.len(),
+            1,
+            "exactly one informational N/A finding"
+        );
+        let v = &result.violations[0];
+        assert_eq!(v.rule_id, "SBOM-BSIAI-NA");
+        assert_eq!(v.severity, ViolationSeverity::Info);
+    }
+
+    #[test]
+    fn fully_documented_aibom_passes_model_and_dataset_checks() {
+        use crate::model::{Creator, CreatorType, DependencyEdge, DependencyType};
+        let mut sbom = NormalizedSbom::default();
+        sbom.document.format_version = "1.6".to_string();
+        sbom.document.creators.push(Creator {
+            creator_type: CreatorType::Tool,
+            name: "sbom-tools".to_string(),
+            email: None,
+        });
+        let model = full_ml_component("model-a");
+        let dataset = full_dataset_component("data-1");
+        let model_id = model.canonical_id.clone();
+        let dataset_id = dataset.canonical_id.clone();
+        add(&mut sbom, model);
+        add(&mut sbom, dataset);
+        // Give the model an infrastructure (runtime) dependency edge.
+        sbom.edges.push(DependencyEdge::new(
+            model_id,
+            dataset_id,
+            DependencyType::DependsOn,
+        ));
+
+        let result = ComplianceChecker::new(ComplianceLevel::BsiSbomForAi).check(&sbom);
+        // No Error-severity (MUST) findings on a well-documented AI-BOM.
+        assert!(
+            result.is_compliant,
+            "well-documented AI-BOM should pass all MUST checks; violations: {:?}",
+            result
+                .violations
+                .iter()
+                .filter(|v| v.severity == ViolationSeverity::Error)
+                .collect::<Vec<_>>()
+        );
+        // The Models / Datasets MUST element checks must not appear.
+        let ids: Vec<_> = result.violations.iter().map(|v| v.rule_id).collect();
+        for must in [
+            "SBOM-BSIAI-MODEL-NAME",
+            "SBOM-BSIAI-MODEL-VERSION",
+            "SBOM-BSIAI-MODEL-IDENTIFIER",
+            "SBOM-BSIAI-MODEL-HASH",
+            "SBOM-BSIAI-MODEL-HASH-ALGO",
+            "SBOM-BSIAI-DATASET-NAME",
+            "SBOM-BSIAI-DATASET-IDENTIFIER",
+        ] {
+            assert!(!ids.contains(&must), "unexpected MUST finding {must}");
+        }
+    }
+
+    #[test]
+    fn sparse_aibom_flags_specific_element_checks() {
+        let mut sbom = NormalizedSbom::default();
+        add(&mut sbom, bare_ml_component("model-a"));
+
+        let result = ComplianceChecker::new(ComplianceLevel::BsiSbomForAi).check(&sbom);
+        let ids: Vec<_> = result.violations.iter().map(|v| v.rule_id).collect();
+        // Bare model has no version, identifier, hash, model card, architecture,
+        // datasets, limitations, or license.
+        assert!(ids.contains(&"SBOM-BSIAI-MODEL-VERSION"));
+        assert!(ids.contains(&"SBOM-BSIAI-MODEL-IDENTIFIER"));
+        assert!(ids.contains(&"SBOM-BSIAI-MODEL-HASH"));
+        assert!(ids.contains(&"SBOM-BSIAI-MODEL-CARD"));
+        assert!(ids.contains(&"SBOM-BSIAI-MODEL-ARCHITECTURE"));
+        assert!(ids.contains(&"SBOM-BSIAI-MODEL-DATASETS"));
+        assert!(ids.contains(&"SBOM-BSIAI-MODEL-LIMITATIONS"));
+        assert!(ids.contains(&"SBOM-BSIAI-MODEL-LICENSE"));
+        // Document metadata gaps too (no creators/timestamp default is valid).
+        assert!(ids.contains(&"SBOM-BSIAI-META-AUTHOR"));
+        // MUST gaps make it non-compliant.
+        assert!(!result.is_compliant);
+    }
+
+    #[test]
+    fn weak_hash_algorithm_flags_hash_algo_element() {
+        let mut sbom = NormalizedSbom::default();
+        let mut c = full_ml_component("model-a");
+        // Replace the SHA-256 weight hash with a weak MD5 one.
+        c.hashes.clear();
+        c.hashes
+            .push(Hash::new(HashAlgorithm::Md5, "abc".to_string()));
+        add(&mut sbom, c);
+
+        let result = ComplianceChecker::new(ComplianceLevel::BsiSbomForAi).check(&sbom);
+        let ids: Vec<_> = result.violations.iter().map(|v| v.rule_id).collect();
+        assert!(
+            ids.contains(&"SBOM-BSIAI-MODEL-HASH-ALGO"),
+            "MD5 weight hash should flag the hash-algorithm element"
+        );
+        // A hash IS present, so the missing-hash element must not fire.
+        assert!(!ids.contains(&"SBOM-BSIAI-MODEL-HASH"));
+    }
+
+    #[test]
+    fn dataset_provenance_available_from_spdx_fields() {
+        let mut sbom = NormalizedSbom::default();
+        let mut c = Component::new("data-x".to_string(), "data-x".to_string())
+            .with_purl("pkg:generic/data-x".to_string());
+        c.component_type = ComponentType::Data;
+        c.dataset = Some(DatasetInfo {
+            // Provenance via preprocessing only (no governance owners).
+            preprocessing: vec!["dedup".to_string()],
+            sensitivity_classifications: vec!["none".to_string()],
+            ..DatasetInfo::default()
+        });
+        add(&mut sbom, c);
+
+        let result = ComplianceChecker::new(ComplianceLevel::BsiSbomForAi).check(&sbom);
+        assert!(
+            !result
+                .violations
+                .iter()
+                .any(|v| v.rule_id == "SBOM-BSIAI-DATASET-PROVENANCE"),
+            "preprocessing should satisfy the dataset provenance element"
+        );
+    }
+
+    #[test]
+    fn all_emitted_rule_ids_are_registered_and_prefixed() {
+        let mut sbom = NormalizedSbom::default();
+        add(&mut sbom, bare_ml_component("model-a"));
+        add(&mut sbom, {
+            let mut c = Component::new("data-1".to_string(), "data-1".to_string());
+            c.component_type = ComponentType::Data;
+            c.dataset = Some(DatasetInfo::default());
+            c
+        });
+        let result = ComplianceChecker::new(ComplianceLevel::BsiSbomForAi).check(&sbom);
+        for v in &result.violations {
+            assert!(
+                super::super::rule_meta(v.rule_id).is_some(),
+                "rule_id {:?} must be registered",
+                v.rule_id
+            );
+            assert!(
+                v.rule_id.starts_with("SBOM-BSIAI-"),
+                "all BSI-AI rule ids start with SBOM-BSIAI-, got {:?}",
+                v.rule_id
+            );
+        }
+    }
+}

--- a/src/quality/compliance/context.rs
+++ b/src/quality/compliance/context.rs
@@ -131,9 +131,14 @@ dedicated_checker!(
     check_eucc_substantial
 );
 dedicated_checker!(EuAiActChecker, ComplianceLevel::EuAiAct, check_eu_ai_act);
+dedicated_checker!(
+    BsiSbomForAiChecker,
+    ComplianceLevel::BsiSbomForAi,
+    check_bsi_sbom_for_ai
+);
 
-/// Resolve the [`StandardChecker`] for a given level. The eight dedicated
-/// profiles get their own checker; everything else takes the generic path.
+/// Resolve the [`StandardChecker`] for a given level. The dedicated profiles
+/// get their own checker; everything else takes the generic path.
 pub(crate) fn checker_for(level: ComplianceLevel) -> Box<dyn StandardChecker> {
     match level {
         ComplianceLevel::NistSsdf => Box::new(NistSsdfChecker),
@@ -144,6 +149,7 @@ pub(crate) fn checker_for(level: ComplianceLevel) -> Box<dyn StandardChecker> {
         ComplianceLevel::CraOssSteward => Box::new(CraOssStewardChecker),
         ComplianceLevel::EuccSubstantial => Box::new(EuccSubstantialChecker),
         ComplianceLevel::EuAiAct => Box::new(EuAiActChecker),
+        ComplianceLevel::BsiSbomForAi => Box::new(BsiSbomForAiChecker),
         other => Box::new(GenericChecker::new(other)),
     }
 }

--- a/src/quality/compliance/eu_ai_act.rs
+++ b/src/quality/compliance/eu_ai_act.rs
@@ -458,6 +458,7 @@ mod tests {
             dataset_type: Some("training".to_string()),
             sensitivity_classifications: sensitivity.iter().map(|s| (*s).to_string()).collect(),
             governance_owners: Vec::new(),
+            ..DatasetInfo::default()
         });
         c
     }

--- a/src/quality/compliance/mod.rs
+++ b/src/quality/compliance/mod.rs
@@ -11,6 +11,7 @@ use crate::model::{NormalizedSbom, SbomFormat};
 use serde::{Deserialize, Serialize};
 
 mod bsi;
+mod bsi_sbom_for_ai;
 mod context;
 mod cra;
 mod crypto;
@@ -100,6 +101,16 @@ pub enum ComplianceLevel {
     /// legal-conformity guarantee, and does not classify a system as high-risk.
     /// Returns N/A for SBOMs with no ML-model or dataset metadata.
     EuAiAct,
+    /// BSI/G7 "SBOM for AI — Minimum Elements" (Feb 2026) READINESS. Scores an
+    /// AI-BOM element-by-element against the seven clusters (Metadata,
+    /// System-Level, Models, Datasets, Infrastructure, Security, plus the
+    /// document-author elements) of the BSI/G7 minimum-elements guidance, using
+    /// the AI-BOM metadata sbom-tools already parses (model card, training-data
+    /// characteristics, weight hashes with NIST-approved algorithms, dataset
+    /// provenance). This is a minimum-elements *readiness* assessment, not a
+    /// legal-conformity guarantee. Returns N/A for SBOMs with no ML-model or
+    /// dataset metadata.
+    BsiSbomForAi,
     /// Comprehensive compliance (all recommended fields)
     Comprehensive,
 }
@@ -123,6 +134,7 @@ impl ComplianceLevel {
             Self::CraOssSteward => "CRA OSS Steward (Art. 24)",
             Self::EuccSubstantial => "EUCC Substantial (Reg. 2024/482)",
             Self::EuAiAct => "EU AI Act Annex IV Readiness",
+            Self::BsiSbomForAi => "BSI/G7 SBOM-for-AI Minimum Elements Readiness",
             Self::Comprehensive => "Comprehensive",
         }
     }
@@ -145,6 +157,7 @@ impl ComplianceLevel {
             Self::CraOssSteward => "OSS",
             Self::EuccSubstantial => "EUCC",
             Self::EuAiAct => "AI-Act",
+            Self::BsiSbomForAi => "BSI-AI",
             Self::Comprehensive => "Full",
         }
     }
@@ -187,6 +200,9 @@ impl ComplianceLevel {
             Self::EuAiAct => {
                 "EU AI Act (Reg. (EU) 2024/1689) Annex IV technical-documentation READINESS — model description, training-data characteristics, validation/testing metrics, limitations (readiness only, not a legal-conformity guarantee; N/A for non-AI SBOMs)"
             }
+            Self::BsiSbomForAi => {
+                "BSI/G7 SBOM-for-AI Minimum Elements (Feb 2026) READINESS — scores an AI-BOM element-by-element across the Metadata, System-Level, Models, Datasets, Infrastructure, and Security clusters (readiness only, not a legal-conformity guarantee; N/A for non-AI SBOMs)"
+            }
             Self::Comprehensive => "All recommended fields and best practices",
         }
     }
@@ -209,6 +225,7 @@ impl ComplianceLevel {
             Self::CraOssSteward,
             Self::EuccSubstantial,
             Self::EuAiAct,
+            Self::BsiSbomForAi,
             Self::Comprehensive,
         ]
     }
@@ -269,6 +286,8 @@ pub enum StandardKind {
     NistPqc,
     /// EU AI Act (Regulation (EU) 2024/1689) — Annex IV technical documentation
     EuAiAct,
+    /// BSI/G7 "SBOM for AI — Minimum Elements" (Feb 2026)
+    BsiSbomForAi,
     /// Other / unrecognised standard
     Other,
 }
@@ -290,6 +309,7 @@ impl StandardKind {
             Self::Cnsa2 => "CNSA 2.0",
             Self::NistPqc => "NIST PQC",
             Self::EuAiAct => "EU AI Act",
+            Self::BsiSbomForAi => "BSI/G7 AI-SBOM",
             Self::Other => "Other",
         }
     }
@@ -379,6 +399,8 @@ impl StandardKind {
             Self::NistPqc => "https://csrc.nist.gov/projects/post-quantum-cryptography",
             // EU AI Act Regulation (EU) 2024/1689 — EUR-Lex ELI is the canonical home.
             Self::EuAiAct => "https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng",
+            // BSI/G7 "SBOM for AI — Minimum Elements" — BSI is the publishing body.
+            Self::BsiSbomForAi => "https://www.bsi.bund.de",
             Self::Other => return None,
         };
         Some(url.to_string())
@@ -1799,11 +1821,12 @@ mod tests {
 
     #[test]
     fn bsi_tr_03183_2_in_compliance_level_all() {
-        assert_eq!(ComplianceLevel::all().len(), 15);
+        assert_eq!(ComplianceLevel::all().len(), 16);
         assert!(ComplianceLevel::all().contains(&ComplianceLevel::BsiTr03183_2));
         assert!(ComplianceLevel::all().contains(&ComplianceLevel::CraOssSteward));
         assert!(ComplianceLevel::all().contains(&ComplianceLevel::EuccSubstantial));
         assert!(ComplianceLevel::all().contains(&ComplianceLevel::EuAiAct));
+        assert!(ComplianceLevel::all().contains(&ComplianceLevel::BsiSbomForAi));
     }
 
     #[test]

--- a/src/quality/compliance/registry.rs
+++ b/src/quality/compliance/registry.rs
@@ -37,6 +37,18 @@ const REMEDIATION_EO14028: &str = "Follow EO 14028 Section 4(e) requirements: us
 /// EU AI Act not-applicable remediation.
 const REMEDIATION_AIACT_NA: &str = "EU AI Act Annex IV readiness applies only to SBOMs that describe AI/ML systems. Add machine-learning-model or dataset components (CycloneDX 1.5+ AI/ML BOM) to enable the assessment.";
 
+/// BSI/G7 SBOM-for-AI not-applicable remediation.
+const REMEDIATION_BSIAI_NA: &str = "BSI/G7 SBOM-for-AI minimum-elements readiness applies only to SBOMs that describe AI/ML systems. Add machine-learning-model or dataset components (CycloneDX 1.5+ AI/ML BOM, or an SPDX 3.0 AI/Dataset profile) to enable the assessment.";
+
+/// BSI/G7 SBOM-for-AI Models-cluster remediation.
+const REMEDIATION_BSIAI_MODELS: &str = "Declare the BSI/G7 SBOM-for-AI Models minimum elements for each MachineLearningModel component: name, version, a unique identifier (PURL/CPE/SWHID/SWID), a model-weight hash using a NIST-approved algorithm (SHA-256+), a model card, the architecture, training datasets, limitations, and a license.";
+
+/// BSI/G7 SBOM-for-AI Datasets-cluster remediation.
+const REMEDIATION_BSIAI_DATASETS: &str = "Declare the BSI/G7 SBOM-for-AI Datasets minimum elements for each Data component: name, a unique identifier, a hash value, a license, a sensitivity classification, and provenance / intended-use (SPDX 3.0 dataset_intendedUse / dataPreprocessing / anonymizationMethodUsed, or governance owners).";
+
+/// BSI/G7 SBOM-for-AI document/metadata/system/infra/security remediation.
+const REMEDIATION_BSIAI_GENERAL: &str = "Declare the BSI/G7 SBOM-for-AI minimum elements: document author, data-format name + version, timestamp, generation tool, and signature; the primary AI system, its producer, and its data-flow/usage; runtime/framework infrastructure links; and AI-specific security controls / exploitability references where they can be expressed.";
+
 /// Look up the static [`RuleMeta`] for a stable internal rule key.
 ///
 /// The key is the [`Violation::rule_id`] set at each check site. Returns
@@ -304,6 +316,181 @@ pub fn rule_meta(rule_id: &str) -> Option<RuleMeta> {
             default_severity: ViolationSeverity::Info,
             refs: &[(K::EuAiAct, "Annex IV §3")],
             remediation: "State the foreseeable limitations and risks of the model, including ethical and fairness considerations. CycloneDX: set modelCard.considerations.technicalLimitations / ethicalConsiderations / fairnessAssessments.",
+        },
+        // ---- BSI/G7 SBOM-for-AI Minimum Elements readiness ---------------
+        "SBOM-BSIAI-NA" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-NA",
+            default_severity: ViolationSeverity::Info,
+            refs: &[(K::BsiSbomForAi, "Applicability")],
+            remediation: REMEDIATION_BSIAI_NA,
+        },
+        // Metadata cluster
+        "SBOM-BSIAI-META-AUTHOR" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-META",
+            default_severity: ViolationSeverity::Error,
+            refs: &[(K::BsiSbomForAi, "Metadata / Author")],
+            remediation: REMEDIATION_BSIAI_GENERAL,
+        },
+        "SBOM-BSIAI-META-FORMAT" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-META",
+            default_severity: ViolationSeverity::Error,
+            refs: &[(K::BsiSbomForAi, "Metadata / Data format name + version")],
+            remediation: REMEDIATION_BSIAI_GENERAL,
+        },
+        "SBOM-BSIAI-META-TIMESTAMP" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-META",
+            default_severity: ViolationSeverity::Error,
+            refs: &[(K::BsiSbomForAi, "Metadata / Timestamp")],
+            remediation: REMEDIATION_BSIAI_GENERAL,
+        },
+        "SBOM-BSIAI-META-TOOL" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-META",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "Metadata / Generation tool")],
+            remediation: REMEDIATION_BSIAI_GENERAL,
+        },
+        "SBOM-BSIAI-META-SIGNATURE" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-META",
+            default_severity: ViolationSeverity::Info,
+            refs: &[(K::BsiSbomForAi, "Metadata / Signature")],
+            remediation: REMEDIATION_BSIAI_GENERAL,
+        },
+        // System-Level cluster
+        "SBOM-BSIAI-SYS-PRIMARY" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-SYS",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "System-Level / Primary AI system")],
+            remediation: REMEDIATION_BSIAI_GENERAL,
+        },
+        "SBOM-BSIAI-SYS-PRODUCER" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-SYS",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "System-Level / Producer")],
+            remediation: REMEDIATION_BSIAI_GENERAL,
+        },
+        "SBOM-BSIAI-SYS-DATAFLOW" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-SYS",
+            default_severity: ViolationSeverity::Info,
+            refs: &[(K::BsiSbomForAi, "System-Level / Data flow & usage")],
+            remediation: REMEDIATION_BSIAI_GENERAL,
+        },
+        // Models cluster
+        "SBOM-BSIAI-MODEL-NAME" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-MODEL",
+            default_severity: ViolationSeverity::Error,
+            refs: &[(K::BsiSbomForAi, "Models / Model name")],
+            remediation: REMEDIATION_BSIAI_MODELS,
+        },
+        "SBOM-BSIAI-MODEL-VERSION" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-MODEL",
+            default_severity: ViolationSeverity::Error,
+            refs: &[(K::BsiSbomForAi, "Models / Model version")],
+            remediation: REMEDIATION_BSIAI_MODELS,
+        },
+        "SBOM-BSIAI-MODEL-IDENTIFIER" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-MODEL",
+            default_severity: ViolationSeverity::Error,
+            refs: &[(K::BsiSbomForAi, "Models / Model identifier")],
+            remediation: REMEDIATION_BSIAI_MODELS,
+        },
+        "SBOM-BSIAI-MODEL-HASH" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-MODEL",
+            default_severity: ViolationSeverity::Error,
+            refs: &[(K::BsiSbomForAi, "Models / Model hash value")],
+            remediation: REMEDIATION_BSIAI_MODELS,
+        },
+        "SBOM-BSIAI-MODEL-HASH-ALGO" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-MODEL",
+            default_severity: ViolationSeverity::Error,
+            refs: &[(K::BsiSbomForAi, "Models / Hash algorithm")],
+            remediation: REMEDIATION_BSIAI_MODELS,
+        },
+        "SBOM-BSIAI-MODEL-CARD" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-MODEL",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "Models / Model card")],
+            remediation: REMEDIATION_BSIAI_MODELS,
+        },
+        "SBOM-BSIAI-MODEL-ARCHITECTURE" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-MODEL",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "Models / Architecture")],
+            remediation: REMEDIATION_BSIAI_MODELS,
+        },
+        "SBOM-BSIAI-MODEL-DATASETS" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-MODEL",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "Models / Training datasets")],
+            remediation: REMEDIATION_BSIAI_MODELS,
+        },
+        "SBOM-BSIAI-MODEL-LIMITATIONS" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-MODEL",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "Models / Limitations")],
+            remediation: REMEDIATION_BSIAI_MODELS,
+        },
+        "SBOM-BSIAI-MODEL-LICENSE" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-MODEL",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "Models / Model license")],
+            remediation: REMEDIATION_BSIAI_MODELS,
+        },
+        // Datasets cluster
+        "SBOM-BSIAI-DATASET-NAME" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-DATASET",
+            default_severity: ViolationSeverity::Error,
+            refs: &[(K::BsiSbomForAi, "Datasets / Dataset name")],
+            remediation: REMEDIATION_BSIAI_DATASETS,
+        },
+        "SBOM-BSIAI-DATASET-IDENTIFIER" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-DATASET",
+            default_severity: ViolationSeverity::Error,
+            refs: &[(K::BsiSbomForAi, "Datasets / Dataset identifier")],
+            remediation: REMEDIATION_BSIAI_DATASETS,
+        },
+        "SBOM-BSIAI-DATASET-HASH" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-DATASET",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "Datasets / Dataset hash value")],
+            remediation: REMEDIATION_BSIAI_DATASETS,
+        },
+        "SBOM-BSIAI-DATASET-LICENSE" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-DATASET",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "Datasets / Dataset license")],
+            remediation: REMEDIATION_BSIAI_DATASETS,
+        },
+        "SBOM-BSIAI-DATASET-SENSITIVITY" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-DATASET",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "Datasets / Sensitivity classification")],
+            remediation: REMEDIATION_BSIAI_DATASETS,
+        },
+        "SBOM-BSIAI-DATASET-PROVENANCE" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-DATASET",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "Datasets / Provenance & intended use")],
+            remediation: REMEDIATION_BSIAI_DATASETS,
+        },
+        // Infrastructure cluster
+        "SBOM-BSIAI-INFRA-RUNTIME" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-INFRA",
+            default_severity: ViolationSeverity::Info,
+            refs: &[(K::BsiSbomForAi, "Infrastructure / Runtime & framework")],
+            remediation: REMEDIATION_BSIAI_GENERAL,
+        },
+        // Security cluster
+        "SBOM-BSIAI-SEC-CONTROLS" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-SEC",
+            default_severity: ViolationSeverity::Info,
+            refs: &[(K::BsiSbomForAi, "Security / AI security controls")],
+            remediation: REMEDIATION_BSIAI_GENERAL,
+        },
+        "SBOM-BSIAI-SEC-EXPLOITABILITY" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-SEC",
+            default_severity: ViolationSeverity::Info,
+            refs: &[(K::BsiSbomForAi, "Security / Exploitability reference")],
+            remediation: REMEDIATION_BSIAI_GENERAL,
         },
         // ---- NTIA --------------------------------------------------------
         "SBOM-NTIA-VERSION" => RuleMeta {

--- a/src/reports/sarif.rs
+++ b/src/reports/sarif.rs
@@ -702,6 +702,8 @@ fn rule_help_uri(rule_id: &str) -> Option<&'static str> {
         Some("https://cyclonedx.org/capabilities/mlbom/")
     } else if rule_id.starts_with("SBOM-AIACT-") {
         Some("https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng")
+    } else if rule_id.starts_with("SBOM-BSIAI-") {
+        Some("https://www.bsi.bund.de")
     } else {
         None
     }
@@ -724,6 +726,7 @@ fn sarif_standard_label(kind: crate::quality::StandardKind) -> &'static str {
         StandardKind::Cnsa2 => "CNSA-2.0",
         StandardKind::NistPqc => "NIST-PQC",
         StandardKind::EuAiAct => "EU-AI-Act",
+        StandardKind::BsiSbomForAi => "BSI-G7-SBOM-for-AI",
         StandardKind::Other => "Other",
     }
 }
@@ -1469,6 +1472,63 @@ fn get_sarif_compliance_rules() -> Vec<SarifRule> {
             name: "AiActLimitations".to_string(),
             short_description: SarifMessage {
                 text: "EU AI Act Annex IV §3: foreseeable limitations and risks".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Note },
+        },
+        // BSI/G7 SBOM-for-AI Minimum Elements readiness (7 clusters).
+        SarifRule {
+            id: "SBOM-BSIAI-NA".to_string(),
+            name: "BsiSbomForAiNotApplicable".to_string(),
+            short_description: SarifMessage {
+                text: "BSI/G7 SBOM-for-AI minimum-elements readiness not applicable — SBOM has no ML-model or dataset components".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Note },
+        },
+        SarifRule {
+            id: "SBOM-BSIAI-META".to_string(),
+            name: "BsiSbomForAiMetadata".to_string(),
+            short_description: SarifMessage {
+                text: "BSI/G7 SBOM-for-AI Metadata cluster: author, data-format name + version, timestamp, generation tool, signature".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Error },
+        },
+        SarifRule {
+            id: "SBOM-BSIAI-SYS".to_string(),
+            name: "BsiSbomForAiSystemLevel".to_string(),
+            short_description: SarifMessage {
+                text: "BSI/G7 SBOM-for-AI System-Level cluster: primary AI system, producer, data flow & usage".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Warning },
+        },
+        SarifRule {
+            id: "SBOM-BSIAI-MODEL".to_string(),
+            name: "BsiSbomForAiModels".to_string(),
+            short_description: SarifMessage {
+                text: "BSI/G7 SBOM-for-AI Models cluster: name, version, identifier, weight hash (NIST-approved algorithm), model card, architecture, datasets, limitations, license".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Error },
+        },
+        SarifRule {
+            id: "SBOM-BSIAI-DATASET".to_string(),
+            name: "BsiSbomForAiDatasets".to_string(),
+            short_description: SarifMessage {
+                text: "BSI/G7 SBOM-for-AI Datasets cluster: name, identifier, hash, license, sensitivity classification, provenance & intended use".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Error },
+        },
+        SarifRule {
+            id: "SBOM-BSIAI-INFRA".to_string(),
+            name: "BsiSbomForAiInfrastructure".to_string(),
+            short_description: SarifMessage {
+                text: "BSI/G7 SBOM-for-AI Infrastructure cluster: runtime / framework dependency links".to_string(),
+            },
+            default_configuration: SarifConfiguration { level: SarifLevel::Note },
+        },
+        SarifRule {
+            id: "SBOM-BSIAI-SEC".to_string(),
+            name: "BsiSbomForAiSecurity".to_string(),
+            short_description: SarifMessage {
+                text: "BSI/G7 SBOM-for-AI Security cluster: AI-specific security controls, exploitability references".to_string(),
             },
             default_configuration: SarifConfiguration { level: SarifLevel::Note },
         },

--- a/src/tui/app_states/compliance.rs
+++ b/src/tui/app_states/compliance.rs
@@ -29,6 +29,8 @@ pub enum PolicyPreset {
     EuccSubstantial,
     /// EU AI Act — Reg. (EU) 2024/1689 Annex IV technical-documentation readiness
     EuAiAct,
+    /// BSI/G7 SBOM-for-AI — Feb 2026 minimum-elements readiness
+    BsiSbomForAi,
 }
 
 impl PolicyPreset {
@@ -47,7 +49,8 @@ impl PolicyPreset {
             Self::BsiTr03183_2 => Self::CraOssSteward,
             Self::CraOssSteward => Self::EuccSubstantial,
             Self::EuccSubstantial => Self::EuAiAct,
-            Self::EuAiAct => Self::Enterprise,
+            Self::EuAiAct => Self::BsiSbomForAi,
+            Self::BsiSbomForAi => Self::Enterprise,
         }
     }
 
@@ -67,6 +70,7 @@ impl PolicyPreset {
             Self::CraOssSteward => "CRA OSS Steward",
             Self::EuccSubstantial => "EUCC",
             Self::EuAiAct => "EU AI Act",
+            Self::BsiSbomForAi => "BSI/G7 SBOM-for-AI",
         }
     }
 
@@ -85,6 +89,7 @@ impl PolicyPreset {
                 | Self::CraOssSteward
                 | Self::EuccSubstantial
                 | Self::EuAiAct
+                | Self::BsiSbomForAi
         )
     }
 
@@ -102,6 +107,7 @@ impl PolicyPreset {
             Self::CraOssSteward => Some(crate::quality::ComplianceLevel::CraOssSteward),
             Self::EuccSubstantial => Some(crate::quality::ComplianceLevel::EuccSubstantial),
             Self::EuAiAct => Some(crate::quality::ComplianceLevel::EuAiAct),
+            Self::BsiSbomForAi => Some(crate::quality::ComplianceLevel::BsiSbomForAi),
             _ => None,
         }
     }

--- a/tests/bsi_sbom_for_ai_tests.rs
+++ b/tests/bsi_sbom_for_ai_tests.rs
@@ -1,0 +1,242 @@
+//! Integration tests for the BSI/G7 "SBOM for AI — Minimum Elements" (Feb 2026)
+//! minimum-elements readiness profile (`ComplianceLevel::BsiSbomForAi`,
+//! SBOM-BSIAI-* rules).
+//!
+//! Frames the profile as a minimum-elements READINESS assessment, not a
+//! legal-conformity guarantee: a well-documented AI-BOM passes the Models /
+//! Datasets element checks, a non-AI SBOM is N/A (never fails), a sparse
+//! AI-BOM fails specific element checks with the right rule_ids / cluster refs,
+//! the `validate --standard bsi-ai` CLI path works, and the SARIF output
+//! carries SBOM-BSIAI-* rules.
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use sbom_tools::parsers::parse_sbom;
+use sbom_tools::quality::{ComplianceChecker, ComplianceLevel, StandardKind, ViolationSeverity};
+use sbom_tools::reports::generate_compliance_sarif;
+
+const FIXTURES_DIR: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures");
+
+fn fixture(rel: &str) -> PathBuf {
+    Path::new(FIXTURES_DIR).join(rel)
+}
+
+fn base_command() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_sbom-tools"));
+    cmd.arg("--no-color");
+    cmd.env("RUST_LOG", "error");
+    cmd.env("RUST_LOG_STYLE", "never");
+    cmd
+}
+
+fn stdout(output: &Output) -> String {
+    String::from_utf8(output.stdout.clone()).expect("stdout should be utf-8")
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8(output.stderr.clone()).expect("stderr should be utf-8")
+}
+
+#[test]
+fn well_documented_aibom_passes_models_and_datasets_element_checks() {
+    let sbom = parse_sbom(&fixture("cyclonedx/bsi-aibom-complete.cdx.json"))
+        .expect("parse bsi-aibom-complete fixture");
+    let result = ComplianceChecker::new(ComplianceLevel::BsiSbomForAi).check(&sbom);
+
+    assert!(
+        result.is_compliant,
+        "well-documented AI-BOM should pass all MUST element checks; errors: {:?}",
+        result
+            .violations
+            .iter()
+            .filter(|v| v.severity == ViolationSeverity::Error)
+            .collect::<Vec<_>>()
+    );
+
+    // None of the Models / Datasets MUST element checks should fire.
+    let ids: Vec<_> = result.violations.iter().map(|v| v.rule_id).collect();
+    for must in [
+        "SBOM-BSIAI-MODEL-NAME",
+        "SBOM-BSIAI-MODEL-VERSION",
+        "SBOM-BSIAI-MODEL-IDENTIFIER",
+        "SBOM-BSIAI-MODEL-HASH",
+        "SBOM-BSIAI-MODEL-HASH-ALGO",
+        "SBOM-BSIAI-MODEL-CARD",
+        "SBOM-BSIAI-MODEL-ARCHITECTURE",
+        "SBOM-BSIAI-MODEL-DATASETS",
+        "SBOM-BSIAI-MODEL-LIMITATIONS",
+        "SBOM-BSIAI-MODEL-LICENSE",
+        "SBOM-BSIAI-DATASET-NAME",
+        "SBOM-BSIAI-DATASET-IDENTIFIER",
+        "SBOM-BSIAI-DATASET-HASH",
+        "SBOM-BSIAI-DATASET-LICENSE",
+        "SBOM-BSIAI-DATASET-SENSITIVITY",
+        "SBOM-BSIAI-DATASET-PROVENANCE",
+    ] {
+        assert!(
+            !ids.contains(&must),
+            "well-documented AI-BOM unexpectedly flagged {must}; violations: {:?}",
+            result.violations
+        );
+    }
+
+    // It is an AI SBOM, so it must NOT report the not-applicable finding.
+    assert!(
+        !ids.contains(&"SBOM-BSIAI-NA"),
+        "AI SBOM must not be marked not-applicable"
+    );
+}
+
+#[test]
+fn non_ai_sbom_is_not_applicable_and_does_not_fail() {
+    let sbom = parse_sbom(&fixture("cyclonedx/minimal.cdx.json")).expect("parse minimal fixture");
+    let result = ComplianceChecker::new(ComplianceLevel::BsiSbomForAi).check(&sbom);
+
+    assert!(result.is_compliant, "non-AI SBOM must not fail BSI-AI");
+    assert_eq!(result.error_count, 0);
+    assert_eq!(
+        result.violations.len(),
+        1,
+        "non-AI SBOM should produce exactly one informational N/A finding; got {:?}",
+        result.violations
+    );
+    let v = &result.violations[0];
+    assert_eq!(v.rule_id, "SBOM-BSIAI-NA");
+    assert_eq!(v.severity, ViolationSeverity::Info);
+}
+
+#[test]
+fn sparse_aibom_fails_specific_element_checks_with_cluster_refs() {
+    // minimal-mlbom has model components with no PURL, hash, license, model
+    // card, architecture, or limitations — so the corresponding MUST/SHOULD
+    // element checks must fire.
+    let sbom = parse_sbom(&fixture("cyclonedx/minimal-mlbom.cdx.json"))
+        .expect("parse minimal-mlbom fixture");
+    let result = ComplianceChecker::new(ComplianceLevel::BsiSbomForAi).check(&sbom);
+
+    let ids: Vec<_> = result.violations.iter().map(|v| v.rule_id).collect();
+    for expected in [
+        "SBOM-BSIAI-MODEL-IDENTIFIER",
+        "SBOM-BSIAI-MODEL-HASH",
+        "SBOM-BSIAI-MODEL-CARD",
+        "SBOM-BSIAI-MODEL-LICENSE",
+    ] {
+        assert!(
+            ids.contains(&expected),
+            "sparse AI-BOM should flag {expected}; got {ids:?}"
+        );
+    }
+
+    // MUST gaps (e.g. missing identifier / weight hash) make it non-compliant.
+    assert!(
+        !result.is_compliant,
+        "sparse AI-BOM with MUST gaps must fail"
+    );
+
+    // The Models-cluster findings must carry a BSI/G7 SBOM-for-AI standard
+    // reference whose id names the cluster + element.
+    let model_hash = result
+        .violations
+        .iter()
+        .find(|v| v.rule_id == "SBOM-BSIAI-MODEL-HASH")
+        .expect("model-hash finding present");
+    assert!(
+        model_hash
+            .standard_refs
+            .iter()
+            .any(|r| r.standard == StandardKind::BsiSbomForAi
+                && r.id.contains("Models")
+                && r.id.contains("hash")),
+        "model-hash finding should reference the Models / Model hash element; got {:?}",
+        model_hash.standard_refs
+    );
+}
+
+#[test]
+fn compliance_sarif_emits_bsiai_rules() {
+    let sbom = parse_sbom(&fixture("cyclonedx/minimal-mlbom.cdx.json"))
+        .expect("parse minimal-mlbom fixture");
+    let result = ComplianceChecker::new(ComplianceLevel::BsiSbomForAi).check(&sbom);
+    let sarif = generate_compliance_sarif(&result).expect("generate SARIF");
+    let value: serde_json::Value = serde_json::from_str(&sarif).expect("valid SARIF JSON");
+
+    // At least one result must carry an SBOM-BSIAI-* rule id.
+    let result_rule_ids: Vec<String> = value["runs"][0]["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .map(|r| r["ruleId"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(
+        result_rule_ids
+            .iter()
+            .any(|id| id.starts_with("SBOM-BSIAI-")),
+        "expected an SBOM-BSIAI-* result; got {result_rule_ids:?}"
+    );
+
+    // The rule catalogue must register the BSI-AI rules too.
+    let catalogue_rule_ids: Vec<String> = value["runs"][0]["tool"]["driver"]["rules"]
+        .as_array()
+        .expect("rules array")
+        .iter()
+        .map(|r| r["id"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(
+        catalogue_rule_ids
+            .iter()
+            .any(|id| id.starts_with("SBOM-BSIAI-")),
+        "rule catalogue should list SBOM-BSIAI-* rules; got {catalogue_rule_ids:?}"
+    );
+}
+
+#[test]
+fn cli_validate_standard_bsi_ai_runs() {
+    // A sparse AI-BOM has MUST gaps → exit code 1 (compliance errors).
+    let output = base_command()
+        .arg("validate")
+        .arg(fixture("cyclonedx/minimal-mlbom.cdx.json"))
+        .args(["--standard", "bsi-ai", "--summary"])
+        .output()
+        .expect("validate --standard bsi-ai should run");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "sparse AI-BOM should fail bsi-ai with exit code 1; stderr: {}",
+        stderr(&output)
+    );
+    // Summary JSON should name the BSI/G7 SBOM-for-AI readiness profile.
+    let out = stdout(&output);
+    assert!(
+        out.contains("BSI/G7 SBOM-for-AI"),
+        "summary should name the BSI/G7 SBOM-for-AI profile; got: {out}"
+    );
+}
+
+#[test]
+fn cli_validate_standard_bsi_ai_sarif_emits_rules() {
+    let output = base_command()
+        .arg("validate")
+        .arg(fixture("cyclonedx/minimal-mlbom.cdx.json"))
+        .args(["--standard", "bsi-ai", "-o", "sarif"])
+        .output()
+        .expect("validate --standard bsi-ai -o sarif should run");
+
+    let out = stdout(&output);
+    let start = out.find('{').expect("sarif JSON object on stdout");
+    let value: serde_json::Value =
+        serde_json::from_str(&out[start..]).expect("stdout payload should be valid SARIF JSON");
+    let result_rule_ids: Vec<String> = value["runs"][0]["results"]
+        .as_array()
+        .expect("results array")
+        .iter()
+        .map(|r| r["ruleId"].as_str().unwrap_or_default().to_string())
+        .collect();
+    assert!(
+        result_rule_ids
+            .iter()
+            .any(|id| id.starts_with("SBOM-BSIAI-")),
+        "CLI SARIF output should carry SBOM-BSIAI-* results; got {result_rule_ids:?}"
+    );
+}

--- a/tests/fixtures/cyclonedx/bsi-aibom-complete.cdx.json
+++ b/tests/fixtures/cyclonedx/bsi-aibom-complete.cdx.json
@@ -1,0 +1,133 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.6",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2026-06-14T00:00:00Z",
+    "tools": [
+      {
+        "vendor": "sbom-tools",
+        "name": "sbom-tools",
+        "version": "0.1.21"
+      }
+    ],
+    "component": {
+      "bom-ref": "root",
+      "type": "application",
+      "name": "bsi-aibom-complete-app",
+      "version": "1.0.0",
+      "supplier": {
+        "name": "Example AI GmbH"
+      }
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "ml-model-1",
+      "type": "machine-learning-model",
+      "name": "sentiment-classifier",
+      "version": "1.0.0",
+      "purl": "pkg:huggingface/example/sentiment-classifier@1.0.0",
+      "description": "A fully documented sentiment classification model",
+      "supplier": {
+        "name": "Example AI GmbH"
+      },
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "modelCard": {
+        "modelParameters": {
+          "approach": {
+            "type": "supervised"
+          },
+          "task": "nlp",
+          "architectureFamily": "transformer",
+          "modelArchitecture": "bert",
+          "datasets": [
+            {
+              "ref": "data-reviews"
+            }
+          ]
+        },
+        "quantitativeAnalysis": {
+          "performanceMetrics": [
+            {
+              "type": "accuracy",
+              "value": "0.97",
+              "slice": "overall"
+            }
+          ]
+        },
+        "considerations": {
+          "useCases": [
+            "Customer review sentiment analysis"
+          ],
+          "technicalLimitations": [
+            "Optimized for English text; may not generalize to other languages."
+          ]
+        }
+      },
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        }
+      ],
+      "externalReferences": [
+        {
+          "type": "model-card",
+          "url": "https://example.test/model-cards/sentiment-classifier"
+        }
+      ]
+    },
+    {
+      "bom-ref": "data-reviews",
+      "type": "data",
+      "name": "product-reviews-1M",
+      "purl": "pkg:generic/product-reviews-1M@2026.01",
+      "licenses": [
+        {
+          "license": {
+            "id": "CC-BY-4.0"
+          }
+        }
+      ],
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"
+        }
+      ],
+      "data": [
+        {
+          "type": "dataset",
+          "name": "product-reviews",
+          "sensitiveData": [
+            "none"
+          ],
+          "governance": {
+            "owners": [
+              {
+                "organization": {
+                  "name": "Data Stewardship Team"
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "ml-model-1",
+      "dependsOn": [
+        "data-reviews"
+      ]
+    }
+  ]
+}

--- a/tests/snapshots/golden_reports__sarif.snap
+++ b/tests/snapshots/golden_reports__sarif.snap
@@ -410,6 +410,83 @@ expression: "render(&SarifReporter::new())"
                 "level": "note"
               },
               "helpUri": "https://eur-lex.europa.eu/eli/reg/2024/1689/oj/eng"
+            },
+            {
+              "id": "SBOM-BSIAI-NA",
+              "name": "BsiSbomForAiNotApplicable",
+              "shortDescription": {
+                "text": "BSI/G7 SBOM-for-AI minimum-elements readiness not applicable — SBOM has no ML-model or dataset components"
+              },
+              "defaultConfiguration": {
+                "level": "note"
+              },
+              "helpUri": "https://www.bsi.bund.de"
+            },
+            {
+              "id": "SBOM-BSIAI-META",
+              "name": "BsiSbomForAiMetadata",
+              "shortDescription": {
+                "text": "BSI/G7 SBOM-for-AI Metadata cluster: author, data-format name + version, timestamp, generation tool, signature"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://www.bsi.bund.de"
+            },
+            {
+              "id": "SBOM-BSIAI-SYS",
+              "name": "BsiSbomForAiSystemLevel",
+              "shortDescription": {
+                "text": "BSI/G7 SBOM-for-AI System-Level cluster: primary AI system, producer, data flow & usage"
+              },
+              "defaultConfiguration": {
+                "level": "warning"
+              },
+              "helpUri": "https://www.bsi.bund.de"
+            },
+            {
+              "id": "SBOM-BSIAI-MODEL",
+              "name": "BsiSbomForAiModels",
+              "shortDescription": {
+                "text": "BSI/G7 SBOM-for-AI Models cluster: name, version, identifier, weight hash (NIST-approved algorithm), model card, architecture, datasets, limitations, license"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://www.bsi.bund.de"
+            },
+            {
+              "id": "SBOM-BSIAI-DATASET",
+              "name": "BsiSbomForAiDatasets",
+              "shortDescription": {
+                "text": "BSI/G7 SBOM-for-AI Datasets cluster: name, identifier, hash, license, sensitivity classification, provenance & intended use"
+              },
+              "defaultConfiguration": {
+                "level": "error"
+              },
+              "helpUri": "https://www.bsi.bund.de"
+            },
+            {
+              "id": "SBOM-BSIAI-INFRA",
+              "name": "BsiSbomForAiInfrastructure",
+              "shortDescription": {
+                "text": "BSI/G7 SBOM-for-AI Infrastructure cluster: runtime / framework dependency links"
+              },
+              "defaultConfiguration": {
+                "level": "note"
+              },
+              "helpUri": "https://www.bsi.bund.de"
+            },
+            {
+              "id": "SBOM-BSIAI-SEC",
+              "name": "BsiSbomForAiSecurity",
+              "shortDescription": {
+                "text": "BSI/G7 SBOM-for-AI Security cluster: AI-specific security controls, exploitability references"
+              },
+              "defaultConfiguration": {
+                "level": "note"
+              },
+              "helpUri": "https://www.bsi.bund.de"
             }
           ]
         }


### PR DESCRIPTION
## Summary

Adds a machine-checkable compliance profile that scores an AI-BOM **element-by-element** against the BSI/G7 *"SBOM for AI — Minimum Elements"* (Feb 2026) guidance, across its seven clusters: **Metadata, System-Level, Models, Datasets, Infrastructure, Security**. It mirrors the proven `EuAiAct` profile structure and is framed throughout as a **minimum-elements READINESS** assessment — not a legal-conformity guarantee. Non-AI SBOMs return a single informational N/A finding (never fail).

### Part 1 — wire dropped SPDX dataset/model fields
Several SPDX 3.0 AI/Dataset-profile fields were parsed but dropped in the mapping, leaving Dataset provenance empty. Now carried into the model:
- `DatasetInfo` gains `intended_use` / `confidentiality_level` / `preprocessing` / `anonymization`; `MlModelInfo` gains `data_preprocessing` (`src/model/metadata.rs`).
- Mapped from `dataset_intendedUse` / `dataset_confidentialityLevel` / `dataset_dataPreprocessing` / `dataset_anonymizationMethodUsed` / `ai_modelDataPreprocessing` (`src/parsers/spdx3.rs`). CycloneDX has no `componentData` analogue, so those fields default there.

### Part 2/3 — the profile
- `ComplianceLevel::BsiSbomForAi` + `StandardKind::BsiSbomForAi` (name, `short_name` `"BSI-AI"`, description, `all()`, label, canonical URL `https://www.bsi.bund.de`).
- `dedicated_checker!` + `checker_for` arm in `context.rs`.
- New `src/quality/compliance/bsi_sbom_for_ai.rs` with one `Violation` per minimum element grouped by cluster, each carrying a stable `SBOM-BSIAI-*` rule_id. Reuses the AI-010 weight-hash logic and the `bsi.rs` SHA-256+ NIST-approved-hash gate. Severity tuned MUST→Error / SHOULD→Warning / discretionary→Info. Elements with no model home yet (data-flow, AI security controls, exploitability) emit an informational "not declared" so the readiness scorecard stays complete.
- 28 `SBOM-BSIAI-*` rules registered with cluster+element standard refs (`registry.rs`).

### Part 4 — wiring
- `validate --standard bsi-ai` (+ aliases), help text at `main.rs`.
- `PolicyPreset::BsiSbomForAi` mirrors `EuAiAct` (TUI compliance tab).
- `SBOM-BSIAI-*` SARIF rules + help-uri + standard label; golden SARIF snapshot updated (**additive only**, reviewed: 7 new rule entries, 0 deletions).
- `ComplianceLevel::all()` inclusion auto-surfaces it in the TUI compliance tabs.

## Test plan
- `cargo test` — full suite green (968 lib + all integration, 0 failures).
- New `tests/bsi_sbom_for_ai_tests.rs`: a well-documented AI-BOM passes the Models/Datasets element checks; a non-AI SBOM returns N/A and does not fail; a sparse AI-BOM fails specific element checks with the right rule_ids and cluster refs; `validate --standard bsi-ai` exits non-zero on a sparse AI-BOM and names the profile; CLI + library SARIF emit `SBOM-BSIAI-*` rules.
- New fixture `tests/fixtures/cyclonedx/bsi-aibom-complete.cdx.json`.
- Unit tests for the SPDX dataset/model field mapping and the per-cluster checks.
- `cargo clippy` (pinned 1.88, default features) `-D warnings`: clean. `cargo fmt`: clean.
- Existing `compliance_rule_registry_tests` (no orphan rules across `ComplianceLevel::all()`) and golden reports pass.

### Notes / deviations
- The BSI/G7 spec PDF is not bundled; cluster/element names follow the public guidance structure. Where an element has no model home today (System-Level data-flow, Security AI-controls / exploitability), the checker emits an informational "not declared" finding rather than inventing fields — flagged in code comments.
- The all-features clippy gate surfaces ~375 pre-existing `unwrap_used` errors in the existing test suite; none are in files touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)