### PR TITLE
fix(cli): write logs to stderr so machine output stays parseable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1425,7 +1425,13 @@ fn main() -> Result<()> {
         .with(tracing_subscriber::EnvFilter::new(
             std::env::var("RUST_LOG").unwrap_or_else(|_| log_level.to_string()),
         ))
-        .with(tracing_subscriber::fmt::layer().with_target(false))
+        // Logs go to stderr so machine-readable report output on stdout
+        // (`-o json`/`sarif`/`ndjson`) stays parseable when piped or redirected.
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_target(false)
+                .with_writer(std::io::stderr),
+        )
         .init();
 
     // Load the file-based config once, up front, so every command can use it


### PR DESCRIPTION
## Summary
Pre-release validation found that `-o json/sarif/ndjson` output was polluted by tracing logs on **stdout**, so `validate x -o sarif > out.sarif` and `diff a b -o json | jq` produced unparseable output (two `INFO` log lines before the JSON). This breaks the tool's core CI use case, including GitHub code-scanning SARIF upload.

Root cause: `src/main.rs` initialized the tracing `fmt::layer()` with its default writer (stdout). Fix routes it to **stderr** — report on stdout, diagnostics on stderr (standard Unix convention). The `-O <file>` path was already correct and is unaffected.

Pre-existing bug (not from the recent AI-BOM work); all machine-output formats were affected.

## Test plan
- Verified `validate -o sarif > f`, `diff -o json | jq`, `quality -o json` all now parse as valid JSON/SARIF; logs still emitted on stderr.
- Full suite + all CLI/CARGO_BIN_EXE integration tests pass (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)