### PR TITLE
feat(tui): make AI-BOM a first-class profile (AiReadiness scoring + Models/Datasets/AI-Readiness tabs)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -440,7 +440,7 @@ struct ViewArgs {
     #[arg(long)]
     fail_on_vuln: bool,
 
-    /// BOM type override (sbom, cbom). Auto-detected from content if omitted
+    /// BOM type override (sbom, cbom, aibom). Auto-detected from content if omitted
     #[arg(long, value_name = "TYPE")]
     bom_type: Option<String>,
 

--- a/src/model/bom_profile.rs
+++ b/src/model/bom_profile.rs
@@ -19,14 +19,27 @@ pub enum BomProfile {
     Sbom,
     /// Cryptographic Bill of Materials (CycloneDX 1.6+ cryptoProperties)
     Cbom,
-    // Future: AiBom, Hbom
+    /// AI/ML Bill of Materials (CycloneDX 1.5+ ML model + dataset components)
+    AiBom,
+    // Future: Hbom
 }
 
 impl BomProfile {
     /// Auto-detect the BOM profile from SBOM content.
     ///
-    /// Classifies as CBOM when >50% of components are `ComponentType::Cryptographic`
-    /// and there are at least 3 crypto components.
+    /// Classifies as:
+    /// - `AiBom` when the SBOM is ML-centric: any `MachineLearningModel`
+    ///   component is present, AND the AI-relevant components
+    ///   (`MachineLearningModel` + `Data`) either form a majority (>50%) or
+    ///   number at least 3.
+    /// - `Cbom` when >50% of components are `ComponentType::Cryptographic`
+    ///   and there are at least 3 crypto components.
+    /// - `Sbom` otherwise.
+    ///
+    /// Precedence when both crypto and ML are significant: the larger
+    /// component count wins (AI-relevant vs. crypto). On a tie, AI-BOM is
+    /// preferred because a model-bearing SBOM is the rarer, more specific
+    /// classification.
     #[must_use]
     pub fn detect(sbom: &NormalizedSbom) -> Self {
         let total = sbom.components.len();
@@ -40,10 +53,35 @@ impl BomProfile {
             .filter(|c| c.component_type == ComponentType::Cryptographic)
             .count();
 
-        if crypto_count >= 3 && crypto_count * 2 > total {
-            Self::Cbom
-        } else {
-            Self::Sbom
+        let ml_count = sbom
+            .components
+            .values()
+            .filter(|c| c.component_type == ComponentType::MachineLearningModel)
+            .count();
+        // AI-relevant components: models plus their training/eval datasets.
+        let ai_count = ml_count
+            + sbom
+                .components
+                .values()
+                .filter(|c| c.component_type == ComponentType::Data)
+                .count();
+
+        // An AI-BOM must contain at least one model; datasets alone are not enough.
+        let is_aibom = ml_count >= 1 && (ai_count * 2 > total || ai_count >= 3);
+        let is_cbom = crypto_count >= 3 && crypto_count * 2 > total;
+
+        match (is_aibom, is_cbom) {
+            (true, true) => {
+                // Both significant: pick by component majority, AI on tie.
+                if crypto_count > ai_count {
+                    Self::Cbom
+                } else {
+                    Self::AiBom
+                }
+            }
+            (true, false) => Self::AiBom,
+            (false, true) => Self::Cbom,
+            (false, false) => Self::Sbom,
         }
     }
 
@@ -53,6 +91,7 @@ impl BomProfile {
         match self {
             Self::Sbom => "SBOM",
             Self::Cbom => "CBOM",
+            Self::AiBom => "AI-BOM",
         }
     }
 
@@ -62,6 +101,7 @@ impl BomProfile {
         match s.to_lowercase().as_str() {
             "sbom" => Some(Self::Sbom),
             "cbom" => Some(Self::Cbom),
+            "ai" | "aibom" | "mlbom" => Some(Self::AiBom),
             _ => None,
         }
     }
@@ -138,11 +178,89 @@ mod tests {
         assert_eq!(BomProfile::detect(&sbom), BomProfile::Sbom);
     }
 
+    fn ml_component(name: &str) -> Component {
+        let mut c = Component::new(name.to_string(), format!("{name}@1.0"));
+        c.component_type = ComponentType::MachineLearningModel;
+        c
+    }
+
+    fn data_component(name: &str) -> Component {
+        let mut c = Component::new(name.to_string(), format!("{name}@1.0"));
+        c.component_type = ComponentType::Data;
+        c
+    }
+
+    #[test]
+    fn test_detect_aibom_ml_majority() {
+        let mut sbom = NormalizedSbom::default();
+        // 1 app + 1 model + 1 dataset = 2/3 AI-relevant (majority) → AI-BOM.
+        sbom.add_component(Component::new("app".to_string(), "app@1.0".to_string()));
+        sbom.add_component(ml_component("classifier"));
+        sbom.add_component(data_component("reviews"));
+        assert_eq!(BomProfile::detect(&sbom), BomProfile::AiBom);
+    }
+
+    #[test]
+    fn test_detect_aibom_min_three_without_majority() {
+        let mut sbom = NormalizedSbom::default();
+        // 5 libs + 2 models + 1 dataset = 3 AI-relevant (37.5%, not a majority)
+        // but >= 3 with at least one model → AI-BOM.
+        for i in 0..5 {
+            sbom.add_component(Component::new(format!("lib-{i}"), format!("lib-{i}@1.0")));
+        }
+        sbom.add_component(ml_component("model-a"));
+        sbom.add_component(ml_component("model-b"));
+        sbom.add_component(data_component("train"));
+        assert_eq!(BomProfile::detect(&sbom), BomProfile::AiBom);
+    }
+
+    #[test]
+    fn test_detect_not_aibom_datasets_only() {
+        let mut sbom = NormalizedSbom::default();
+        // Datasets with no model must not classify as AI-BOM.
+        for i in 0..4 {
+            sbom.add_component(data_component(&format!("data-{i}")));
+        }
+        assert_eq!(BomProfile::detect(&sbom), BomProfile::Sbom);
+    }
+
+    #[test]
+    fn test_detect_aibom_beats_cbom_on_majority() {
+        let mut sbom = NormalizedSbom::default();
+        // 4 ML + 3 crypto: both significant, AI count (4) > crypto (3) → AI-BOM.
+        for i in 0..4 {
+            sbom.add_component(ml_component(&format!("model-{i}")));
+        }
+        for i in 0..3 {
+            let mut c = Component::new(format!("algo-{i}"), format!("algo-{i}@1.0"));
+            c.component_type = ComponentType::Cryptographic;
+            sbom.add_component(c);
+        }
+        assert_eq!(BomProfile::detect(&sbom), BomProfile::AiBom);
+    }
+
+    #[test]
+    fn test_detect_cbom_beats_aibom_when_crypto_dominates() {
+        let mut sbom = NormalizedSbom::default();
+        // 5 crypto + 1 model + 1 dataset: crypto (5) > AI (2) → CBOM.
+        for i in 0..5 {
+            let mut c = Component::new(format!("algo-{i}"), format!("algo-{i}@1.0"));
+            c.component_type = ComponentType::Cryptographic;
+            sbom.add_component(c);
+        }
+        sbom.add_component(ml_component("model"));
+        sbom.add_component(data_component("data"));
+        assert_eq!(BomProfile::detect(&sbom), BomProfile::Cbom);
+    }
+
     #[test]
     fn test_from_str_opt() {
         assert_eq!(BomProfile::from_str_opt("sbom"), Some(BomProfile::Sbom));
         assert_eq!(BomProfile::from_str_opt("CBOM"), Some(BomProfile::Cbom));
         assert_eq!(BomProfile::from_str_opt("cbom"), Some(BomProfile::Cbom));
+        assert_eq!(BomProfile::from_str_opt("ai"), Some(BomProfile::AiBom));
+        assert_eq!(BomProfile::from_str_opt("AiBom"), Some(BomProfile::AiBom));
+        assert_eq!(BomProfile::from_str_opt("mlbom"), Some(BomProfile::AiBom));
         assert_eq!(BomProfile::from_str_opt("hbom"), None);
     }
 
@@ -150,11 +268,13 @@ mod tests {
     fn test_label() {
         assert_eq!(BomProfile::Sbom.label(), "SBOM");
         assert_eq!(BomProfile::Cbom.label(), "CBOM");
+        assert_eq!(BomProfile::AiBom.label(), "AI-BOM");
     }
 
     #[test]
     fn test_display() {
         assert_eq!(format!("{}", BomProfile::Sbom), "SBOM");
         assert_eq!(format!("{}", BomProfile::Cbom), "CBOM");
+        assert_eq!(format!("{}", BomProfile::AiBom), "AI-BOM");
     }
 }

--- a/src/tui/app_impl_constructors.rs
+++ b/src/tui/app_impl_constructors.rs
@@ -6,7 +6,7 @@ use super::app_states::{
 };
 use crate::diff::{DiffResult, MatrixResult, MultiDiffResult, TimelineResult};
 use crate::model::NormalizedSbom;
-use crate::quality::{ComplianceChecker, ComplianceLevel, QualityScorer, ScoringProfile};
+use crate::quality::{ComplianceChecker, ComplianceLevel, QualityScorer};
 
 impl App {
     /// Shared default initialization for all mode-independent fields.
@@ -80,17 +80,13 @@ impl App {
         new_raw: &str,
     ) -> Self {
         // Calculate quality reports for both SBOMs using profile-aware scoring
-        let old_profile = match crate::model::BomProfile::detect(&old_sbom) {
-            crate::model::BomProfile::Cbom => ScoringProfile::Cbom,
-            crate::model::BomProfile::Sbom => ScoringProfile::Standard,
-        };
+        let old_profile =
+            crate::tui::scoring_profile_for(crate::model::BomProfile::detect(&old_sbom));
         let old_scorer = QualityScorer::new(old_profile);
         let old_quality = Some(old_scorer.score(&old_sbom));
 
-        let new_profile = match crate::model::BomProfile::detect(&new_sbom) {
-            crate::model::BomProfile::Cbom => ScoringProfile::Cbom,
-            crate::model::BomProfile::Sbom => ScoringProfile::Standard,
-        };
+        let new_profile =
+            crate::tui::scoring_profile_for(crate::model::BomProfile::detect(&new_sbom));
         let new_scorer = QualityScorer::new(new_profile);
         let new_quality = Some(new_scorer.score(&new_sbom));
 
@@ -157,8 +153,9 @@ impl App {
     /// for exploring a single SBOM interactively.
     #[must_use]
     pub fn new_view(sbom: NormalizedSbom, raw_content: &str) -> Self {
-        // Quality scoring
-        let scorer = QualityScorer::new(ScoringProfile::Standard);
+        // Quality scoring — profile-aware so AI-BOMs / CBOMs score correctly.
+        let profile = crate::tui::scoring_profile_for(crate::model::BomProfile::detect(&sbom));
+        let scorer = QualityScorer::new(profile);
         let quality_report = Some(scorer.score(&sbom));
 
         // Build index for O(1) lookups

--- a/src/tui/export.rs
+++ b/src/tui/export.rs
@@ -92,7 +92,10 @@ pub const fn view_tab_to_report_type(tab: ViewTab) -> ReportType {
         | ViewTab::Certificates
         | ViewTab::Keys
         | ViewTab::Protocols
-        | ViewTab::PqcCompliance => ReportType::All,
+        | ViewTab::PqcCompliance
+        | ViewTab::Models
+        | ViewTab::Datasets
+        | ViewTab::AiReadiness => ReportType::All,
     }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -68,3 +68,23 @@ pub use ui::run_tui;
 
 // New View TUI exports
 pub use view::{ViewApp, ViewTab, run_view_tui};
+
+/// Map a detected [`BomProfile`](crate::model::BomProfile) to the
+/// [`ScoringProfile`](crate::quality::ScoringProfile) the TUI scores it with.
+///
+/// This is the single source of truth for the profile mapping. All TUI scoring
+/// sites (the `ViewApp` constructor, the `'P'` re-score handler, and the diff
+/// constructors) route through it so the mapping cannot drift — in particular,
+/// `AiBom` always activates the dedicated AI-readiness scoring/rendering path.
+#[must_use]
+pub(crate) const fn scoring_profile_for(
+    profile: crate::model::BomProfile,
+) -> crate::quality::ScoringProfile {
+    use crate::model::BomProfile;
+    use crate::quality::ScoringProfile;
+    match profile {
+        BomProfile::Cbom => ScoringProfile::Cbom,
+        BomProfile::AiBom => ScoringProfile::AiReadiness,
+        BomProfile::Sbom => ScoringProfile::Standard,
+    }
+}

--- a/src/tui/test_support.rs
+++ b/src/tui/test_support.rs
@@ -18,6 +18,12 @@ pub(crate) const DEMO_OLD: &str = include_str!("../../tests/fixtures/demo-old.cd
 /// New demo SBOM (CycloneDX 1.5) used as the diff "after" side.
 pub(crate) const DEMO_NEW: &str = include_str!("../../tests/fixtures/demo-new.cdx.json");
 
+/// A complete BSI-aligned AI-BOM fixture (ML model + dataset components).
+/// Used by AI-BOM `ViewApp` tab tests; `BomProfile::detect` classifies it as
+/// `BomProfile::AiBom`.
+pub(crate) const AIBOM_BSI: &str =
+    include_str!("../../tests/fixtures/cyclonedx/bsi-aibom-complete.cdx.json");
+
 /// Snapshot terminal sizes: a standard 80x24 and a wide 120x40.
 pub(crate) const SIZES: [(u16, u16); 2] = [(80, 24), (120, 40)];
 
@@ -43,6 +49,13 @@ pub(crate) fn demo_diff() -> (DiffResult, NormalizedSbom, NormalizedSbom) {
 /// Parse the new demo fixture as a single SBOM for `ViewApp` tests.
 pub(crate) fn demo_single() -> (NormalizedSbom, BomProfile) {
     let sbom = parse_sbom_str(DEMO_NEW).expect("demo-new fixture must parse");
+    let profile = BomProfile::detect(&sbom);
+    (sbom, profile)
+}
+
+/// Parse the BSI AI-BOM fixture as a single SBOM for AI-BOM `ViewApp` tests.
+pub(crate) fn aibom_single() -> (NormalizedSbom, BomProfile) {
+    let sbom = parse_sbom_str(AIBOM_BSI).expect("bsi-aibom fixture must parse");
     let profile = BomProfile::detect(&sbom);
     (sbom, profile)
 }

--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -912,6 +912,12 @@ impl FooterHints {
             "pqc-compliance" => {
                 hints.insert(0, ("↑↓", "scroll"));
             }
+            "models" | "datasets" => {
+                hints.insert(0, ("↑↓", "select"));
+            }
+            "ai-readiness" => {
+                hints.insert(0, ("↑↓", "scroll"));
+            }
             _ => {}
         }
 

--- a/src/tui/view/app.rs
+++ b/src/tui/view/app.rs
@@ -4,7 +4,7 @@
 //! with hierarchical navigation, search, and deep inspection.
 
 use crate::model::{Component, NormalizedSbom, NormalizedSbomIndex, VulnerabilityRef};
-use crate::quality::{ComplianceResult, QualityReport, QualityScorer, ScoringProfile};
+use crate::quality::{ComplianceResult, QualityReport, QualityScorer};
 use crate::tui::app_states::SourcePanelState;
 use crate::tui::state::ListNavigation;
 use crate::tui::widgets::TreeState;
@@ -126,6 +126,11 @@ pub struct ViewApp {
     /// CBOM Algorithms tab: sort order
     pub(crate) algorithm_sort_by: AlgorithmSortBy,
 
+    /// AI-BOM Models tab: selected index
+    pub(crate) models_selected: usize,
+    /// AI-BOM Datasets tab: selected index
+    pub(crate) datasets_selected: usize,
+
     /// Bookmarked component canonical IDs (in-memory, no persistence)
     pub(crate) bookmarked: HashSet<String>,
 
@@ -150,10 +155,7 @@ impl ViewApp {
         let stats = SbomStats::from_sbom(&sbom);
 
         // Calculate quality score
-        let scoring_profile = match bom_profile {
-            crate::model::BomProfile::Cbom => ScoringProfile::Cbom,
-            crate::model::BomProfile::Sbom => ScoringProfile::Standard,
-        };
+        let scoring_profile = crate::tui::scoring_profile_for(bom_profile);
         let scorer = QualityScorer::new(scoring_profile);
         let quality_report = scorer.score(&sbom);
         let quality_state = QualityViewState::new(quality_report.recommendations.len());
@@ -221,6 +223,8 @@ impl ViewApp {
             keys_selected: 0,
             protocols_selected: 0,
             algorithm_sort_by: AlgorithmSortBy::default(),
+            models_selected: 0,
+            datasets_selected: 0,
             bookmarked: HashSet::new(),
             export_template: None,
             cra_sidecar: None,
@@ -322,6 +326,32 @@ impl ViewApp {
                             .is_some_and(|cp| &cp.asset_type == f)
                     })
             })
+            .count()
+    }
+
+    // ========================================================================
+    // AI-BOM per-tab selection helpers
+    // ========================================================================
+
+    /// Count `MachineLearningModel` components (Models tab).
+    #[must_use]
+    pub fn ml_model_count(&self) -> usize {
+        use crate::model::ComponentType;
+        self.sbom
+            .components
+            .values()
+            .filter(|c| c.component_type == ComponentType::MachineLearningModel)
+            .count()
+    }
+
+    /// Count `Data` components (Datasets tab).
+    #[must_use]
+    pub fn dataset_count(&self) -> usize {
+        use crate::model::ComponentType;
+        self.sbom
+            .components
+            .values()
+            .filter(|c| c.component_type == ComponentType::Data)
             .count()
     }
 
@@ -851,7 +881,13 @@ impl ViewApp {
                 let sel = self.active_crypto_selected_mut();
                 *sel = sel.saturating_sub(1);
             }
-            ViewTab::Overview | ViewTab::PqcCompliance => {}
+            ViewTab::Models => {
+                self.models_selected = self.models_selected.saturating_sub(1);
+            }
+            ViewTab::Datasets => {
+                self.datasets_selected = self.datasets_selected.saturating_sub(1);
+            }
+            ViewTab::Overview | ViewTab::PqcCompliance | ViewTab::AiReadiness => {}
         }
     }
 
@@ -878,7 +914,15 @@ impl ViewApp {
                 let sel = self.active_crypto_selected_mut();
                 *sel = sel.saturating_add(1).min(max);
             }
-            ViewTab::Overview | ViewTab::PqcCompliance => {}
+            ViewTab::Models => {
+                let max = self.ml_model_count().saturating_sub(1);
+                self.models_selected = self.models_selected.saturating_add(1).min(max);
+            }
+            ViewTab::Datasets => {
+                let max = self.dataset_count().saturating_sub(1);
+                self.datasets_selected = self.datasets_selected.saturating_add(1).min(max);
+            }
+            ViewTab::Overview | ViewTab::PqcCompliance | ViewTab::AiReadiness => {}
         }
     }
 
@@ -939,7 +983,9 @@ impl ViewApp {
             | ViewTab::Certificates
             | ViewTab::Keys
             | ViewTab::Protocols => *self.active_crypto_selected_mut() = 0,
-            ViewTab::Overview | ViewTab::PqcCompliance => {}
+            ViewTab::Models => self.models_selected = 0,
+            ViewTab::Datasets => self.datasets_selected = 0,
+            ViewTab::Overview | ViewTab::PqcCompliance | ViewTab::AiReadiness => {}
         }
     }
 
@@ -974,7 +1020,9 @@ impl ViewApp {
                 let max = self.crypto_count_for_tab();
                 *self.active_crypto_selected_mut() = max.saturating_sub(1);
             }
-            ViewTab::Overview | ViewTab::PqcCompliance => {}
+            ViewTab::Models => self.models_selected = self.ml_model_count().saturating_sub(1),
+            ViewTab::Datasets => self.datasets_selected = self.dataset_count().saturating_sub(1),
+            ViewTab::Overview | ViewTab::PqcCompliance | ViewTab::AiReadiness => {}
         }
     }
 
@@ -1148,7 +1196,10 @@ impl ViewApp {
             | ViewTab::Certificates
             | ViewTab::Keys
             | ViewTab::Protocols
-            | ViewTab::PqcCompliance => {}
+            | ViewTab::PqcCompliance
+            | ViewTab::Models
+            | ViewTab::Datasets
+            | ViewTab::AiReadiness => {}
         }
     }
 
@@ -1821,6 +1872,14 @@ pub enum ViewTab {
     /// PQC compliance (CNSA 2.0 + NIST PQC dedicated view)
     PqcCompliance,
 
+    // ── AI-BOM-specific ──
+    /// Machine-learning model inventory with model-card metadata
+    Models,
+    /// Training/evaluation dataset inventory with governance metadata
+    Datasets,
+    /// AI-readiness scoring dashboard (model-card completeness)
+    AiReadiness,
+
     // ── Legacy ──
     /// Single crypto tab (kept for preference migration)
     Crypto,
@@ -1844,6 +1903,9 @@ impl ViewTab {
             Self::Keys => "Keys",
             Self::Protocols => "Protocols",
             Self::PqcCompliance => "PQC Compliance",
+            Self::Models => "Models",
+            Self::Datasets => "Datasets",
+            Self::AiReadiness => "AI-Readiness",
             Self::Crypto => "Crypto",
         }
     }
@@ -1874,6 +1936,9 @@ impl ViewTab {
             Self::Keys => "keys",
             Self::Protocols => "protocols",
             Self::PqcCompliance => "pqc-compliance",
+            Self::Models => "models",
+            Self::Datasets => "datasets",
+            Self::AiReadiness => "ai-readiness",
             Self::Crypto => "crypto",
         }
     }
@@ -1905,6 +1970,14 @@ impl ViewTab {
                 Self::PqcCompliance,
                 Self::Source,
             ],
+            crate::model::BomProfile::AiBom => &[
+                Self::Overview,
+                Self::Models,
+                Self::Datasets,
+                Self::AiReadiness,
+                Self::Compliance,
+                Self::Source,
+            ],
         }
     }
 
@@ -1925,6 +1998,9 @@ impl ViewTab {
             "keys" => Some(Self::Keys),
             "protocols" => Some(Self::Protocols),
             "pqc-compliance" => Some(Self::PqcCompliance),
+            "models" => Some(Self::Models),
+            "datasets" => Some(Self::Datasets),
+            "ai-readiness" => Some(Self::AiReadiness),
             "crypto" => Some(Self::Crypto),
             _ => None,
         }

--- a/src/tui/view/events.rs
+++ b/src/tui/view/events.rs
@@ -379,17 +379,16 @@ pub fn handle_key_event(app: &mut ViewApp, key: KeyEvent) {
             let _ = prefs.save();
         }
         KeyCode::Char('P') => {
-            // Toggle BOM profile (SBOM <-> CBOM) and re-score
+            // Cycle BOM profile (SBOM → CBOM → AI-BOM → SBOM) and re-score.
             app.bom_profile = match app.bom_profile {
                 crate::model::BomProfile::Sbom => crate::model::BomProfile::Cbom,
-                crate::model::BomProfile::Cbom => crate::model::BomProfile::Sbom,
+                crate::model::BomProfile::Cbom => crate::model::BomProfile::AiBom,
+                crate::model::BomProfile::AiBom => crate::model::BomProfile::Sbom,
             };
-            let scoring_profile = match app.bom_profile {
-                crate::model::BomProfile::Cbom => crate::quality::ScoringProfile::Cbom,
-                crate::model::BomProfile::Sbom => crate::quality::ScoringProfile::Standard,
-            };
+            let scoring_profile = crate::tui::scoring_profile_for(app.bom_profile);
             let scorer = crate::quality::QualityScorer::new(scoring_profile);
             app.quality_report = scorer.score(&app.sbom);
+            // The active tab may not exist in the new profile's tab set; reset.
             app.active_tab = ViewTab::Overview;
             app.status_message = Some(format!("Switched to {} mode", app.bom_profile.label()));
         }
@@ -1236,7 +1235,7 @@ fn handle_list_click(app: &mut ViewApp, clicked_index: usize, _x: u16) {
                 app.source_state.selected = idx;
             }
         }
-        ViewTab::Overview | ViewTab::PqcCompliance => {
+        ViewTab::Overview | ViewTab::PqcCompliance | ViewTab::AiReadiness => {
             // No list navigation
         }
         ViewTab::Crypto
@@ -1247,6 +1246,16 @@ fn handle_list_click(app: &mut ViewApp, clicked_index: usize, _x: u16) {
             let max = app.crypto_count_for_tab();
             if clicked_index < max {
                 *app.active_crypto_selected_mut() = clicked_index;
+            }
+        }
+        ViewTab::Models => {
+            if clicked_index < app.ml_model_count() {
+                app.models_selected = clicked_index;
+            }
+        }
+        ViewTab::Datasets => {
+            if clicked_index < app.dataset_count() {
+                app.datasets_selected = clicked_index;
             }
         }
     }
@@ -1360,7 +1369,33 @@ pub fn get_yank_text(app: &ViewApp) -> Option<String> {
                 .min(crypto_components.len().saturating_sub(1));
             crypto_components.get(selected).map(|c| c.name.clone())
         }
-        ViewTab::PqcCompliance => None,
+        ViewTab::Models => {
+            let mut models: Vec<_> = app
+                .sbom
+                .components
+                .values()
+                .filter(|c| c.component_type == crate::model::ComponentType::MachineLearningModel)
+                .collect();
+            models.sort_by(|a, b| a.name.cmp(&b.name));
+            let selected = app.models_selected.min(models.len().saturating_sub(1));
+            models
+                .get(selected)
+                .map(|c| c.identifiers.purl.clone().unwrap_or_else(|| c.name.clone()))
+        }
+        ViewTab::Datasets => {
+            let mut datasets: Vec<_> = app
+                .sbom
+                .components
+                .values()
+                .filter(|c| c.component_type == crate::model::ComponentType::Data)
+                .collect();
+            datasets.sort_by(|a, b| a.name.cmp(&b.name));
+            let selected = app.datasets_selected.min(datasets.len().saturating_sub(1));
+            datasets
+                .get(selected)
+                .map(|c| c.identifiers.purl.clone().unwrap_or_else(|| c.name.clone()))
+        }
+        ViewTab::PqcCompliance | ViewTab::AiReadiness => None,
     }
 }
 

--- a/src/tui/view/ui.rs
+++ b/src/tui/view/ui.rs
@@ -118,6 +118,9 @@ fn render(frame: &mut Frame, app: &mut ViewApp) {
         ViewTab::Certificates => views::render_certificates(frame, chunks[2], app),
         ViewTab::Keys => views::render_keys(frame, chunks[2], app),
         ViewTab::Protocols => views::render_protocols(frame, chunks[2], app),
+        ViewTab::Models => views::render_models(frame, chunks[2], app),
+        ViewTab::Datasets => views::render_datasets(frame, chunks[2], app),
+        ViewTab::AiReadiness => views::render_ai_readiness(frame, chunks[2], app),
     }
 
     // Render status bar

--- a/src/tui/view/ui/render_snapshot_tests.rs
+++ b/src/tui/view/ui/render_snapshot_tests.rs
@@ -10,7 +10,9 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
 use super::{ViewApp, ViewTab, render};
-use crate::tui::test_support::{DEMO_NEW, SIZES, demo_single, pin_theme, render_to_text};
+use crate::tui::test_support::{
+    AIBOM_BSI, DEMO_NEW, SIZES, aibom_single, demo_single, pin_theme, render_to_text,
+};
 use crate::tui::view::events::handle_key_event;
 
 /// Build a `ViewApp` from the demo fixture with a deterministic tab.
@@ -117,4 +119,66 @@ fn tree_search_entry_activates_filter() {
         app.tree_search_active,
         "'/' on the Tree tab starts the inline tree filter"
     );
+}
+
+// ============================================================================
+// AI-BOM (first-class profile) tests
+// ============================================================================
+
+/// Build a `ViewApp` from the BSI AI-BOM fixture with a deterministic tab.
+fn aibom_view_app(active_tab: ViewTab) -> ViewApp {
+    pin_theme();
+    let (sbom, profile) = aibom_single();
+    let mut app = ViewApp::new(sbom, AIBOM_BSI, profile);
+    app.active_tab = active_tab;
+    app
+}
+
+#[test]
+fn aibom_fixture_detected_as_aibom_profile() {
+    let (_sbom, profile) = aibom_single();
+    assert_eq!(profile, crate::model::BomProfile::AiBom);
+}
+
+#[test]
+fn aibom_view_app_uses_ai_readiness_scoring() {
+    // The single shared `scoring_profile_for` must route AI-BOMs to the
+    // dedicated AI-readiness scoring path (which activates the AI renderer).
+    let app = aibom_view_app(ViewTab::AiReadiness);
+    assert_eq!(
+        app.quality_report.profile,
+        crate::quality::ScoringProfile::AiReadiness
+    );
+}
+
+#[test]
+fn aibom_profile_exposes_ai_tab_suite() {
+    let tabs = ViewTab::tabs_for_profile(crate::model::BomProfile::AiBom);
+    assert!(tabs.contains(&ViewTab::Models));
+    assert!(tabs.contains(&ViewTab::Datasets));
+    assert!(tabs.contains(&ViewTab::AiReadiness));
+}
+
+/// The AI-BOM-profile view tabs (rendered from the BSI AI-BOM fixture).
+const AIBOM_TABS: [(&str, ViewTab); 3] = [
+    ("models", ViewTab::Models),
+    ("datasets", ViewTab::Datasets),
+    ("ai_readiness", ViewTab::AiReadiness),
+];
+
+#[test]
+fn snapshot_aibom_tabs() {
+    let mut settings = insta::Settings::clone_current();
+    // Lifecycle/age content can drift; redact day counts defensively.
+    settings.add_filter(r"Age: \d+d", "Age: [N]d");
+    settings.bind(|| {
+        for (name, tab) in AIBOM_TABS {
+            let mut app = aibom_view_app(tab);
+            // Render at the wide size where AI panels have room to breathe.
+            let text = render_to_text(120, 40, |frame| {
+                render(frame, &mut app);
+            });
+            insta::assert_snapshot!(format!("aibom_{name}_120x40"), text);
+        }
+    });
 }

--- a/src/tui/view/ui/snapshots/sbom_tools__tui__view__ui__render_snapshot_tests__aibom_ai_readiness_120x40.snap
+++ b/src/tui/view/ui/snapshots/sbom_tools__tui__view__ui__render_snapshot_tests__aibom_ai_readiness_120x40.snap
@@ -1,0 +1,44 @@
+---
+source: src/tui/view/ui/render_snapshot_tests.rs
+expression: text
+---
+sbom-tools  VIEW  │ bsi-aibom-complete-app │ CycloneDX 1.6 │ [AI-BOM]
+
+ [1] Overview   │  [2] Models   │  [3] Datasets   │  [4] AI-Readiness   │  [5] Compliance   │  [6] Source
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+┌ AI Readiness Summary ────────────────────────────────────────────────────────────────────────────────────────────────┐
+│Overall Score: 66/100 (D) | Profile: AiReadiness                                                                      │
+│                                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ AI Readiness Overview ───────────────────────────────────────────────────────────────────────────────────────────────┐
+│ ML Components: 1  |  Fully documented: 0                                                                             │
+│ Checks passing for every ML component are shown below.                                                               │
+│                                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ AI Readiness Checks ─────────────────────────────────────────────────────────────────────────────────────────────────┐
+│Check    Description                                                                                 Weight   Status  │
+│                                                                                                                      │
+│AI-001   Model card URL present                                                                      12%      PASS    │
+│AI-002   Architecture family declared                                                                10%      PASS    │
+│AI-003   Training datasets referenced                                                                10%      PASS    │
+│AI-004   Quantitative analysis present                                                               10%      PASS    │
+│AI-005   Fairness assessments included                                                               9%       FAIL    │
+│AI-006   Energy consumption disclosed                                                                8%       FAIL    │
+│AI-007   Use-cases documented                                                                        8%       PASS    │
+│AI-008   Known limitations stated                                                                    7%       PASS    │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+┌ Recommendations (4) - 'v' to switch view ────────────────────────────────────────────────────────────────────────────┐
+│ Actionable Recommendations (ordered by impact):                                                                      │
+│                                                                                                                      │
+│> [P1] [Completeness] [AI-005] Fairness assessments included                                                          │
+│      Why: Complete data enables accurate vulnerability scanning and license compliance                               │
+│      Affected: 1 components  |  Potential gain: +8.9 points                                                          │
+│                                                                                                                      │
+│  [P1] [Completeness] [AI-006] Energy consumption disclosed                                                           │
+│  [P1] [Completeness] [AI-009] Ethical considerations present                                                         │
+│  [P2] [Completeness] [AI-011] Exploitability/advisory reference present                                              │
+│                                                                                                                      │
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
+ Components: 3 │ Vulns: 0 │ Licenses: 3
+                               ↑↓ scroll │  Tab switch  / search  e export  ? help  q quit

--- a/src/tui/view/ui/snapshots/sbom_tools__tui__view__ui__render_snapshot_tests__aibom_datasets_120x40.snap
+++ b/src/tui/view/ui/snapshots/sbom_tools__tui__view__ui__render_snapshot_tests__aibom_datasets_120x40.snap
@@ -1,0 +1,44 @@
+---
+source: src/tui/view/ui/render_snapshot_tests.rs
+expression: text
+---
+sbom-tools  VIEW  │ bsi-aibom-complete-app │ CycloneDX 1.6 │ [AI-BOM]
+
+ [1] Overview   │  [2] Models   │  [3] Datasets   │  [4] AI-Readiness   │  [5] Compliance   │  [6] Source
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+┌ Datasets (1) ────────────────────────────────┐┌ Dataset Detail ──────────────────────────────────────────────────────┐
+│product-reviews-1M                            ││Name: product-reviews-1M                                              │
+│                                              ││PURL: pkg:generic/product-reviews-1M@2026.01                          │
+│                                              ││License: CC-BY-4.0                                                    │
+│                                              ││                                                                      │
+│                                              ││━━━ ML / Dataset ━━━                                                  │
+│                                              ││Dataset Type: dataset                                                 │
+│                                              ││Sensitivity: none                                                     │
+│                                              ││Governance: Data Stewardship Team                                     │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+└──────────────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────┘
+ Components: 3 │ Vulns: 0 │ Licenses: 3
+           ↑↓ select │  Tab switch  / search  e export  ? help  q quit [y] copy pkg:generic/product-reviews...

--- a/src/tui/view/ui/snapshots/sbom_tools__tui__view__ui__render_snapshot_tests__aibom_models_120x40.snap
+++ b/src/tui/view/ui/snapshots/sbom_tools__tui__view__ui__render_snapshot_tests__aibom_models_120x40.snap
@@ -1,0 +1,44 @@
+---
+source: src/tui/view/ui/render_snapshot_tests.rs
+expression: text
+---
+sbom-tools  VIEW  │ bsi-aibom-complete-app │ CycloneDX 1.6 │ [AI-BOM]
+
+ [1] Overview   │  [2] Models   │  [3] Datasets   │  [4] AI-Readiness   │  [5] Compliance   │  [6] Source
+
+────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+┌ Models (1) ──────────────────────────────────┐┌ Model Detail ────────────────────────────────────────────────────────┐
+│sentiment-classifier  1.0.0                   ││Name: sentiment-classifier                                            │
+│                                              ││Version: 1.0.0                                                        │
+│                                              ││PURL: pkg:huggingface/example/sentiment-classifier@1.0.0              │
+│                                              ││                                                                      │
+│                                              ││━━━ ML / Dataset ━━━                                                  │
+│                                              ││Architecture: transformer / bert                                      │
+│                                              ││Approach: supervised                                                  │
+│                                              ││Task: nlp                                                             │
+│                                              ││Limitations: Optimized for English text; may not generalize to othe...│
+│                                              ││Model Card: https://example.test/model-cards/sentiment-classifier     │
+│                                              ││Datasets (1):                                                         │
+│                                              ││• data-reviews                                                        │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+│                                              ││                                                                      │
+└──────────────────────────────────────────────┘└──────────────────────────────────────────────────────────────────────┘
+ Components: 3 │ Vulns: 0 │ Licenses: 3
+           ↑↓ select │  Tab switch  / search  e export  ? help  q quit [y] copy pkg:huggingface/example/sen...

--- a/src/tui/view/views/ai_readiness.rs
+++ b/src/tui/view/views/ai_readiness.rs
@@ -1,0 +1,20 @@
+//! AI-readiness dashboard view for the AI-BOM TUI mode.
+//!
+//! Reuses the existing shared AI-readiness renderer in `shared::quality`. The
+//! renderer is reached through `render_quality_summary`, which dispatches to
+//! `render_ai_readiness_summary` when `report.profile == ScoringProfile::AiReadiness`.
+//! The `ViewApp` quality report carries that profile for AI-BOMs (see
+//! `scoring_profile_for`), so the dedicated panels activate here. The summary
+//! is a self-contained dashboard (score, overview, per-check checklist, and
+//! recommendations) and owns its own vertical layout, so it is rendered at the
+//! full tab area.
+
+use crate::tui::shared::quality as shared;
+use crate::tui::view::app::ViewApp;
+use ratatui::Frame;
+use ratatui::layout::Rect;
+
+/// Render the AI-Readiness tab (AI-BOM mode).
+pub fn render_ai_readiness(frame: &mut Frame, area: Rect, app: &ViewApp) {
+    shared::render_quality_summary(frame, area, &app.quality_report, 0);
+}

--- a/src/tui/view/views/datasets.rs
+++ b/src/tui/view/views/datasets.rs
@@ -1,0 +1,107 @@
+//! Dataset inventory view for the AI-BOM TUI mode.
+//!
+//! Lists `Data` components (training / evaluation datasets) with a detail panel
+//! that reuses the shared ML / dataset metadata renderer.
+
+use crate::model::ComponentType;
+use crate::tui::shared::components::render_ml_dataset_lines;
+use crate::tui::theme::colors;
+use crate::tui::view::app::ViewApp;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+
+/// Render the Datasets tab (AI-BOM mode).
+pub fn render_datasets(frame: &mut Frame, area: Rect, app: &ViewApp) {
+    let scheme = colors();
+    let mut datasets: Vec<_> = app
+        .sbom
+        .components
+        .values()
+        .filter(|c| c.component_type == ComponentType::Data)
+        .collect();
+    datasets.sort_by(|a, b| a.name.cmp(&b.name));
+
+    if datasets.is_empty() {
+        let msg = Paragraph::new("No datasets found in this AI-BOM.")
+            .block(Block::default().borders(Borders::ALL).title(" Datasets "))
+            .wrap(Wrap { trim: true });
+        frame.render_widget(msg, area);
+        return;
+    }
+
+    let panels = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(area);
+
+    // ── Left: dataset list ──
+    let selected = app.datasets_selected.min(datasets.len().saturating_sub(1));
+    let items: Vec<ListItem> = datasets
+        .iter()
+        .enumerate()
+        .map(|(i, comp)| {
+            let style = if i == selected {
+                Style::default()
+                    .bg(scheme.selection)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let ver = comp.version.as_deref().unwrap_or("");
+            ListItem::new(Line::from(vec![
+                Span::styled(comp.name.clone(), Style::default().fg(scheme.text)),
+                Span::styled(format!("  {ver}"), Style::default().fg(scheme.text_muted)),
+            ]))
+            .style(style)
+        })
+        .collect();
+
+    let list = List::new(items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" Datasets ({}) ", datasets.len())),
+    );
+    frame.render_widget(list, panels[0]);
+
+    // ── Right: detail panel ──
+    let Some(comp) = datasets.get(selected) else {
+        return;
+    };
+    let mut lines: Vec<Line> = vec![Line::from(vec![
+        Span::styled("Name: ", Style::default().add_modifier(Modifier::BOLD)),
+        Span::styled(comp.name.clone(), Style::default().fg(scheme.accent)),
+    ])];
+    if let Some(purl) = &comp.identifiers.purl {
+        lines.push(Line::from(vec![
+            Span::styled("PURL: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled(purl.clone(), Style::default().fg(scheme.text_muted)),
+        ]));
+    }
+    if !comp.licenses.declared.is_empty() {
+        lines.push(Line::from(vec![
+            Span::styled("License: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled(
+                comp.licenses.declared[0].expression.clone(),
+                Style::default().fg(scheme.text),
+            ),
+        ]));
+    }
+    // Reuse the shared ML / Dataset metadata renderer (dataset governance, etc.).
+    lines.extend(render_ml_dataset_lines(
+        comp.ml_model.as_ref(),
+        comp.dataset.as_ref(),
+        panels[1].width,
+    ));
+
+    let detail = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Dataset Detail "),
+        )
+        .wrap(Wrap { trim: true });
+    frame.render_widget(detail, panels[1]);
+}

--- a/src/tui/view/views/mod.rs
+++ b/src/tui/view/views/mod.rs
@@ -1,12 +1,15 @@
 //! View-specific rendering for the `ViewApp`.
 
+mod ai_readiness;
 mod algorithms;
 mod certificates;
 mod compliance;
 mod crypto;
+mod datasets;
 mod dependencies;
 mod keys;
 mod licenses;
+mod models;
 mod overview;
 mod pqc_compliance;
 mod protocols;
@@ -15,16 +18,19 @@ mod source;
 mod tree;
 mod vulnerabilities;
 
+pub use ai_readiness::render_ai_readiness;
 pub use algorithms::render_algorithms;
 pub use certificates::render_certificates;
 pub(crate) use compliance::build_groups;
 pub use compliance::{StandardComplianceState, compute_compliance_results, render_compliance};
 pub use crypto::render_crypto;
+pub use datasets::render_datasets;
 pub(crate) use dependencies::DependencyGraph;
 pub use dependencies::{FlatDepNode, render_dependencies};
 pub use keys::render_keys;
 pub use licenses::render_licenses;
 pub(crate) use licenses::{build_license_data_from_app, get_first_component_id_for_license};
+pub use models::render_models;
 pub use overview::render_overview;
 pub use pqc_compliance::render_pqc_compliance;
 pub use protocols::render_protocols;

--- a/src/tui/view/views/models.rs
+++ b/src/tui/view/views/models.rs
@@ -1,0 +1,107 @@
+//! Machine-learning model inventory view for the AI-BOM TUI mode.
+//!
+//! Lists `MachineLearningModel` components with a detail panel that reuses the
+//! shared ML / dataset metadata renderer (`render_ml_dataset_lines`).
+
+use crate::model::ComponentType;
+use crate::tui::shared::components::render_ml_dataset_lines;
+use crate::tui::theme::colors;
+use crate::tui::view::app::ViewApp;
+use ratatui::Frame;
+use ratatui::layout::{Constraint, Direction, Layout, Rect};
+use ratatui::style::{Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, List, ListItem, Paragraph, Wrap};
+
+/// Render the Models tab (AI-BOM mode).
+pub fn render_models(frame: &mut Frame, area: Rect, app: &ViewApp) {
+    let scheme = colors();
+    let mut models: Vec<_> = app
+        .sbom
+        .components
+        .values()
+        .filter(|c| c.component_type == ComponentType::MachineLearningModel)
+        .collect();
+    models.sort_by(|a, b| a.name.cmp(&b.name));
+
+    if models.is_empty() {
+        let msg = Paragraph::new("No machine-learning models found in this AI-BOM.")
+            .block(Block::default().borders(Borders::ALL).title(" Models "))
+            .wrap(Wrap { trim: true });
+        frame.render_widget(msg, area);
+        return;
+    }
+
+    let panels = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(40), Constraint::Percentage(60)])
+        .split(area);
+
+    // ── Left: model list ──
+    let selected = app.models_selected.min(models.len().saturating_sub(1));
+    let items: Vec<ListItem> = models
+        .iter()
+        .enumerate()
+        .map(|(i, comp)| {
+            let style = if i == selected {
+                Style::default()
+                    .bg(scheme.selection)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default()
+            };
+            let ver = comp.version.as_deref().unwrap_or("");
+            ListItem::new(Line::from(vec![
+                Span::styled(comp.name.clone(), Style::default().fg(scheme.text)),
+                Span::styled(format!("  {ver}"), Style::default().fg(scheme.text_muted)),
+            ]))
+            .style(style)
+        })
+        .collect();
+
+    let list = List::new(items).block(
+        Block::default()
+            .borders(Borders::ALL)
+            .title(format!(" Models ({}) ", models.len())),
+    );
+    frame.render_widget(list, panels[0]);
+
+    // ── Right: detail panel ──
+    let Some(comp) = models.get(selected) else {
+        return;
+    };
+    let mut lines: Vec<Line> = vec![
+        Line::from(vec![
+            Span::styled("Name: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled(comp.name.clone(), Style::default().fg(scheme.accent)),
+        ]),
+        Line::from(vec![
+            Span::styled("Version: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled(
+                comp.version.clone().unwrap_or_else(|| "-".to_string()),
+                Style::default().fg(scheme.text),
+            ),
+        ]),
+    ];
+    if let Some(purl) = &comp.identifiers.purl {
+        lines.push(Line::from(vec![
+            Span::styled("PURL: ", Style::default().add_modifier(Modifier::BOLD)),
+            Span::styled(purl.clone(), Style::default().fg(scheme.text_muted)),
+        ]));
+    }
+    // Reuse the shared ML / Dataset metadata renderer.
+    lines.extend(render_ml_dataset_lines(
+        comp.ml_model.as_ref(),
+        comp.dataset.as_ref(),
+        panels[1].width,
+    ));
+
+    let detail = Paragraph::new(lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Model Detail "),
+        )
+        .wrap(Wrap { trim: true });
+    frame.render_widget(detail, panels[1]);
+}

--- a/src/tui/view/views/overview.rs
+++ b/src/tui/view/views/overview.rs
@@ -11,7 +11,11 @@ use ratatui::{
 pub fn render_overview(frame: &mut Frame, area: Rect, app: &ViewApp) {
     match app.bom_profile {
         crate::model::BomProfile::Cbom => render_cbom_overview(frame, area, app),
-        crate::model::BomProfile::Sbom => render_sbom_overview(frame, area, app),
+        // AI-BOMs use the standard SBOM overview; AI-specific detail lives in
+        // the dedicated Models / Datasets / AI-Readiness tabs.
+        crate::model::BomProfile::Sbom | crate::model::BomProfile::AiBom => {
+            render_sbom_overview(frame, area, app);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

AI-BOMs were second-class in the TUI while CBOM was first-class. This PR mirrors the CBOM precedent end-to-end so AI-BOMs get AI-readiness scoring and a dedicated tab suite, and activates the previously-dead AI-readiness renderer.

Problems fixed:
- `model/bom_profile.rs` had only `Sbom`/`Cbom` (a `// Future: AiBom` comment).
- Every TUI scoring site mapped only `Cbom->Cbom` / `Sbom->Standard`, **never** `AiReadiness` (`view/app.rs`, `view/events.rs` 'P' re-score, `app_impl_constructors.rs` x2 + a hardcoded `ScoringProfile::Standard`), so AI-BOMs got the generic 8-category Standard score.
- The complete AI-readiness renderer in `shared/quality.rs` (`render_ai_readiness_summary`/`_metrics`) was dead code because no path produced `ScoringProfile::AiReadiness`.
- `tabs_for_profile` gave CBOM a dedicated suite but AI-BOMs got the plain SBOM tabs.

Changes:
- **Model**: add `BomProfile::AiBom` (label `"AI-BOM"`). `detect()` classifies `AiBom` when ML-centric — any `MachineLearningModel` present AND AI-relevant (`MachineLearningModel` + `Data`) components form a majority or number >= 3. Precedence vs CBOM: larger component count wins, AI on tie (documented). `from_str_opt` accepts `ai`/`aibom`/`mlbom`.
- **Single source of truth**: new `tui::scoring_profile_for(BomProfile) -> ScoringProfile` (`Cbom->Cbom`, `AiBom->AiReadiness`, `Sbom->Standard`). All five duplicated match arms now call it, so the mapping cannot drift again — this is what activates the dead AI-readiness renderer.
- **AI tab suite**: new `ViewTab::Models`/`Datasets`/`AiReadiness` (+ title/as_str/from_str_opt entries) and an `AiBom` arm in `tabs_for_profile` = `[Overview, Models, Datasets, AiReadiness, Compliance, Source]`. New render modules `view/views/{models,datasets,ai_readiness}.rs`: Models/Datasets reuse the shared `render_ml_dataset_lines` detail renderer; AiReadiness reuses the existing `shared::quality` renderer via the `AiReadiness` report. Wired into render dispatch (`view/ui.rs`), nav/click/yank (`view/app.rs`, `view/events.rs`), footer hints (`theme.rs`), export mapping (`export.rs`), module registration (`view/views/mod.rs`).
- **CLI**: `--bom-type` help now lists `aibom`.

## Test plan

- `cargo fmt`, `cargo build` clean.
- New `bom_profile` unit tests: `detect()` on ML-majority / min-3 / datasets-only / AI-vs-CBOM precedence both ways; `from_str_opt` for ai/aibom/mlbom.
- New `ViewApp` tests: the BSI AI-BOM fixture detects as `AiBom`; a `ViewApp` built from it has `quality_report.profile == AiReadiness`; `tabs_for_profile(AiBom)` exposes the AI tabs.
- New insta snapshots for the Models / Datasets / AI-Readiness tabs rendered from `tests/fixtures/cyclonedx/bsi-aibom-complete.cdx.json` at 120x40 (baselines committed and reviewed).
- Existing plain-SBOM demo snapshots are unchanged — `cargo test --lib render_snapshot` stays green.
- Full `cargo test`: 990 lib tests + all integration/doc tests pass, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)