### PR TITLE
fix(reports,tui): align severity colors, disambiguate FW badge, profile-accurate help overlay

### DIFF
--- a/src/reports/summary.rs
+++ b/src/reports/summary.rs
@@ -14,6 +14,7 @@ fn ansi_color(text: &str, color: &str, colored: bool) -> String {
             "red" => format!("\x1b[31m{text}\x1b[0m"),
             "green" => format!("\x1b[32m{text}\x1b[0m"),
             "yellow" => format!("\x1b[33m{text}\x1b[0m"),
+            "magenta" => format!("\x1b[35m{text}\x1b[0m"),
             "cyan" => format!("\x1b[36m{text}\x1b[0m"),
             "bold" => format!("\x1b[1m{text}\x1b[0m"),
             "dim" => format!("\x1b[2m{text}\x1b[0m"),
@@ -21,6 +22,19 @@ fn ansi_color(text: &str, color: &str, colored: bool) -> String {
         }
     } else {
         text.to_string()
+    }
+}
+
+/// Map a severity label to the shared 4-color scheme used by the TUI
+/// (`src/tui/theme.rs`) and the side-by-side report: Critical=magenta,
+/// High=red, Medium=yellow, Low=cyan. Unknown severities are left uncolored.
+fn severity_color_name(severity: &str) -> &'static str {
+    match severity.to_lowercase().as_str() {
+        "critical" => "magenta",
+        "high" => "red",
+        "medium" => "yellow",
+        "low" => "cyan",
+        _ => "",
     }
 }
 
@@ -323,25 +337,34 @@ impl ReportGenerator for SummaryReporter {
             if counts.critical > 0 {
                 lines.push(format!(
                     "  {}",
-                    self.color(&format!("Critical: {}", counts.critical), "red")
+                    self.color(
+                        &format!("Critical: {}", counts.critical),
+                        severity_color_name("critical")
+                    )
                 ));
             }
             if counts.high > 0 {
                 lines.push(format!(
                     "  {}",
-                    self.color(&format!("High: {}", counts.high), "red")
+                    self.color(
+                        &format!("High: {}", counts.high),
+                        severity_color_name("high")
+                    )
                 ));
             }
             if counts.medium > 0 {
                 lines.push(format!(
                     "  {}",
-                    self.color(&format!("Medium: {}", counts.medium), "yellow")
+                    self.color(
+                        &format!("Medium: {}", counts.medium),
+                        severity_color_name("medium")
+                    )
                 ));
             }
             if counts.low > 0 {
                 lines.push(format!(
                     "  {}",
-                    self.color(&format!("Low: {}", counts.low), "dim")
+                    self.color(&format!("Low: {}", counts.low), severity_color_name("low"))
                 ));
             }
         }
@@ -517,10 +540,9 @@ impl ReportGenerator for TableReporter {
 
             for vuln in &result.vulnerabilities.introduced {
                 let severity = sanitize_terminal(&vuln.severity);
-                let severity_colored = match vuln.severity.to_lowercase().as_str() {
-                    "critical" | "high" => self.color(&severity, "red"),
-                    "medium" => self.color(&severity, "yellow"),
-                    _ => severity.into_owned(),
+                let severity_colored = match severity_color_name(&vuln.severity) {
+                    "" => severity.into_owned(),
+                    name => self.color(&severity, name),
                 };
                 lines.push(format!(
                     "{:<12} {:<20} {:<10} {:<40}",
@@ -687,5 +709,52 @@ const fn floor_char_boundary(s: &str, index: usize) -> usize {
             i -= 1;
         }
         i
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ansi_color, severity_color_name};
+
+    #[test]
+    fn severity_colors_match_shared_four_color_scheme() {
+        // The shared scheme (src/tui/theme.rs, src/reports/sidebyside.rs):
+        // Critical=magenta, High=red, Medium=yellow, Low=cyan.
+        assert_eq!(severity_color_name("critical"), "magenta");
+        assert_eq!(severity_color_name("high"), "red");
+        assert_eq!(severity_color_name("medium"), "yellow");
+        assert_eq!(severity_color_name("low"), "cyan");
+
+        // Case-insensitive.
+        assert_eq!(severity_color_name("CRITICAL"), "magenta");
+        assert_eq!(severity_color_name("High"), "red");
+
+        // Unknown severities are left uncolored.
+        assert_eq!(severity_color_name("none"), "");
+        assert_eq!(severity_color_name(""), "");
+    }
+
+    #[test]
+    fn four_severities_render_distinct_ansi_colors() {
+        let critical = ansi_color("x", severity_color_name("critical"), true);
+        let high = ansi_color("x", severity_color_name("high"), true);
+        let medium = ansi_color("x", severity_color_name("medium"), true);
+        let low = ansi_color("x", severity_color_name("low"), true);
+
+        // Each severity maps to its own ANSI SGR code: 35/31/33/36.
+        assert_eq!(critical, "\x1b[35mx\x1b[0m");
+        assert_eq!(high, "\x1b[31mx\x1b[0m");
+        assert_eq!(medium, "\x1b[33mx\x1b[0m");
+        assert_eq!(low, "\x1b[36mx\x1b[0m");
+
+        // All four are distinct from one another.
+        let all = [&critical, &high, &medium, &low];
+        for (i, a) in all.iter().enumerate() {
+            for (j, b) in all.iter().enumerate() {
+                if i != j {
+                    assert_ne!(a, b, "severities {i} and {j} share a color");
+                }
+            }
+        }
     }
 }

--- a/src/tui/app_states/overlays.rs
+++ b/src/tui/app_states/overlays.rs
@@ -196,6 +196,10 @@ pub struct ShortcutsOverlayState {
     pub visible: bool,
     /// Current view context for showing relevant shortcuts
     pub context: ShortcutsContext,
+    /// Active BOM profile, when known. Drives a profile-accurate "Tabs"
+    /// section and "Jump to tab" range in the overlay (view mode only —
+    /// `None` falls back to the generic hint).
+    pub profile: Option<crate::model::BomProfile>,
 }
 
 /// Context for showing relevant shortcuts

--- a/src/tui/traits.rs
+++ b/src/tui/traits.rs
@@ -293,7 +293,12 @@ pub trait ViewState: Send {
 
     /// Get keyboard shortcuts for this view.
     ///
-    /// These are displayed in the help overlay and footer hints.
+    /// NOTE: currently UNUSED by any render path. The help overlay
+    /// (`tui::views::overlays::render_shortcuts_overlay`) and footer hints
+    /// (`tui::theme::FooterHints`) are hand-maintained per profile/tab rather
+    /// than driven from this method. Wiring those to `shortcuts()` as the
+    /// single source of truth is a deliberate future refactor; until then this
+    /// is exercised only by unit tests.
     fn shortcuts(&self) -> Vec<Shortcut>;
 
     /// Called when this view becomes active.

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -178,7 +178,7 @@ fn render(frame: &mut Frame, app: &mut App) {
 
     // Render overlays
     if app.overlays.show_help {
-        render_help_overlay(frame, area);
+        render_help_overlay(frame, area, diff_tab_count(app));
     }
 
     if app.overlays.search.active {
@@ -388,6 +388,32 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(tabs, area);
 }
 
+/// Number of number-key-addressable tabs currently shown in the diff-mode tab
+/// bar. Mirrors the tab set assembled in [`render_tabs`] so the help overlay's
+/// "Jump to tab" hint never advertises a number the user cannot reach.
+fn diff_tab_count(app: &App) -> usize {
+    // Base tabs: Summary, Components, Dependencies, Licenses, Vulnerabilities,
+    // Quality (always present).
+    let mut count = 6;
+    if matches!(app.mode, AppMode::Diff | AppMode::View) {
+        // Compliance + Side-by-side.
+        count += 2;
+    }
+    if app
+        .data
+        .diff_result
+        .as_ref()
+        .is_some_and(|r| !r.graph_changes.is_empty())
+    {
+        count += 1;
+    }
+    if matches!(app.mode, AppMode::Diff | AppMode::View) {
+        // Source.
+        count += 1;
+    }
+    count
+}
+
 fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
     let (comp_count, vuln_count, score) = match app.mode {
         AppMode::Diff => {
@@ -540,9 +566,18 @@ fn render_footer(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(footer, area);
 }
 
-fn render_help_overlay(frame: &mut Frame, area: Rect) {
+fn render_help_overlay(frame: &mut Frame, area: Rect, tab_count: usize) {
     let popup_area = centered_rect(65, 80, area);
     frame.render_widget(Clear, popup_area);
+
+    // Pad to the fixed-width key column used elsewhere in this overlay so the
+    // descriptions stay aligned regardless of the digit count.
+    let jump_key = if tab_count <= 1 {
+        "1".to_string()
+    } else {
+        format!("1-{tab_count}")
+    };
+    let jump_key = format!("  {jump_key:<15}");
 
     let help_text = vec![
         Line::styled(
@@ -559,7 +594,7 @@ fn render_help_overlay(frame: &mut Frame, area: Rect) {
             Span::styled("Switch between views", Style::default().fg(colors().text)),
         ]),
         Line::from(vec![
-            Span::styled("  1-8            ", Style::default().fg(colors().accent)),
+            Span::styled(jump_key, Style::default().fg(colors().accent)),
             Span::styled("Jump to specific tab", Style::default().fg(colors().text)),
         ]),
         Line::from(vec![

--- a/src/tui/view/ui.rs
+++ b/src/tui/view/ui.rs
@@ -134,6 +134,7 @@ fn render(frame: &mut Frame, app: &mut ViewApp) {
         let shortcuts_state = crate::tui::app::ShortcutsOverlayState {
             visible: true,
             context: crate::tui::app::ShortcutsContext::View,
+            profile: Some(app.bom_profile),
         };
         crate::tui::views::render_shortcuts_overlay(frame, &shortcuts_state);
     }

--- a/src/tui/view/views/dependencies.rs
+++ b/src/tui/view/views/dependencies.rs
@@ -591,7 +591,9 @@ fn component_type_badge(ct: &crate::model::ComponentType) -> (&'static str, Colo
         ComponentType::Container => ("CTR", scheme.secondary),
         ComponentType::OperatingSystem => ("OS", scheme.warning),
         ComponentType::Device => ("DEV", scheme.text_muted),
-        ComponentType::Firmware => ("FW", scheme.warning),
+        // Distinct from Framework's "FW" so the two are unambiguous when the
+        // badge color is hard to read.
+        ComponentType::Firmware => ("FRMW", scheme.warning),
         ComponentType::File => ("FILE", scheme.text_muted),
         ComponentType::Data => ("DATA", scheme.text_muted),
         ComponentType::MachineLearningModel => ("ML", scheme.info),
@@ -1425,6 +1427,21 @@ mod tests {
     fn max_depth_single_node() {
         let graph = graph_from_edges(1, &[]);
         assert_eq!(calculate_max_depth(&graph), 1);
+    }
+
+    #[test]
+    fn firmware_and_framework_have_distinct_badge_labels() {
+        use crate::model::ComponentType;
+        let (framework_label, _) = component_type_badge(&ComponentType::Framework);
+        let (firmware_label, _) = component_type_badge(&ComponentType::Firmware);
+        // The two used to collapse to the same "FW" label; they must now be
+        // unambiguous even when badge color is hard to read.
+        assert_ne!(
+            framework_label, firmware_label,
+            "Framework and Firmware must not share a badge label"
+        );
+        assert_eq!(framework_label, "FW");
+        assert_eq!(firmware_label, "FRMW");
     }
 
     #[test]

--- a/src/tui/views/overlays.rs
+++ b/src/tui/views/overlays.rs
@@ -119,7 +119,7 @@ pub fn render_shortcuts_overlay(f: &mut Frame, state: &ShortcutsOverlayState) {
     f.render_widget(block, overlay_area);
 
     // Get shortcuts for the current context
-    let shortcuts = get_shortcuts_for_context(state.context);
+    let shortcuts = get_shortcuts_for_context(state.context, state.profile);
 
     let mut lines: Vec<Line> = Vec::new();
 
@@ -458,54 +458,94 @@ const fn context_name(context: ShortcutsContext) -> &'static str {
 
 struct ShortcutSection {
     title: &'static str,
-    items: Vec<(&'static str, &'static str)>,
+    items: Vec<(String, String)>,
 }
 
-fn get_shortcuts_for_context(context: ShortcutsContext) -> Vec<ShortcutSection> {
+/// Owned `(key, description)` pair for a shortcut row.
+fn item(key: &str, desc: &str) -> (String, String) {
+    (key.to_string(), desc.to_string())
+}
+
+fn get_shortcuts_for_context(
+    context: ShortcutsContext,
+    profile: Option<crate::model::BomProfile>,
+) -> Vec<ShortcutSection> {
+    // When the active profile is known (view mode), the number keys map
+    // positionally to that profile's tab set, so derive the "Jump to tab"
+    // range from the real tab count instead of a hard-coded "1-8".
+    let jump_hint = profile.map_or_else(
+        || "1-8".to_string(),
+        |p| {
+            let n = crate::tui::view::ViewTab::tabs_for_profile(p).len();
+            if n <= 1 {
+                "1".to_string()
+            } else {
+                format!("1-{n}")
+            }
+        },
+    );
+
     let mut sections = vec![
         ShortcutSection {
             title: "Global",
             items: vec![
-                ("q", "Quit application"),
-                ("?", "Toggle help"),
-                ("e", "Export dialog"),
-                ("l", "Color legend"),
-                ("T", "Toggle theme"),
-                ("/", "Search"),
-                ("K", "Keyboard shortcuts"),
-                ("V", "View switcher (multi-views)"),
-                ("D", "Component deep dive"),
-                ("y/Ctrl+C", "Copy selected to clipboard"),
-                ("Shift+drag", "Select text with mouse"),
-                ("b/Backspace", "Navigate back"),
+                item("q", "Quit application"),
+                item("?", "Toggle help"),
+                item("e", "Export dialog"),
+                item("l", "Color legend"),
+                item("T", "Toggle theme"),
+                item("/", "Search"),
+                item("K", "Keyboard shortcuts"),
+                item("V", "View switcher (multi-views)"),
+                item("D", "Component deep dive"),
+                item("y/Ctrl+C", "Copy selected to clipboard"),
+                item("Shift+drag", "Select text with mouse"),
+                item("b/Backspace", "Navigate back"),
             ],
         },
         ShortcutSection {
             title: "Navigation",
             items: vec![
-                ("j/k", "Up/Down"),
-                ("h/l", "Left/Right"),
-                ("g/G", "First/Last"),
-                ("PgUp/PgDn", "Page up/down"),
-                ("Tab", "Next panel/tab"),
-                ("1-8", "Jump to tab"),
+                item("j/k", "Up/Down"),
+                item("h/l", "Left/Right"),
+                item("g/G", "First/Last"),
+                item("PgUp/PgDn", "Page up/down"),
+                item("Tab", "Next panel/tab"),
+                (jump_hint, "Jump to tab".to_string()),
             ],
         },
     ];
+
+    // Profile-accurate tab listing (view mode only): show exactly the tabs
+    // available for the active BOM profile so the overlay never advertises a
+    // tab the user cannot reach (e.g. AI-BOM shows Models/Datasets/AI-Readiness,
+    // not the SBOM-specific tabs).
+    if let Some(p) = profile {
+        let tabs = crate::tui::view::ViewTab::tabs_for_profile(p);
+        let items = tabs
+            .iter()
+            .enumerate()
+            .map(|(i, tab)| item(&(i + 1).to_string(), tab.title()))
+            .collect();
+        sections.push(ShortcutSection {
+            title: "Tabs (this profile)",
+            items,
+        });
+    }
 
     match context {
         ShortcutsContext::MultiDiff => {
             sections.push(ShortcutSection {
                 title: "Multi-Diff View",
                 items: vec![
-                    ("p/Tab", "Switch panel"),
-                    ("Enter", "View details"),
-                    ("f", "Cycle filter preset"),
-                    ("s", "Cycle sort field"),
-                    ("S", "Toggle sort direction"),
-                    ("v", "Variable components drill-down"),
-                    ("x", "Toggle cross-target analysis"),
-                    ("h", "Toggle heat map mode"),
+                    item("p/Tab", "Switch panel"),
+                    item("Enter", "View details"),
+                    item("f", "Cycle filter preset"),
+                    item("s", "Cycle sort field"),
+                    item("S", "Toggle sort direction"),
+                    item("v", "Variable components drill-down"),
+                    item("x", "Toggle cross-target analysis"),
+                    item("h", "Toggle heat map mode"),
                 ],
             });
         }
@@ -513,14 +553,14 @@ fn get_shortcuts_for_context(context: ShortcutsContext) -> Vec<ShortcutSection> 
             sections.push(ShortcutSection {
                 title: "Timeline View",
                 items: vec![
-                    ("p/Tab", "Switch panel"),
-                    ("d", "Compare versions"),
-                    ("t", "Toggle statistics"),
-                    ("g", "Jump to version"),
-                    ("+/-", "Zoom chart"),
-                    ("h/l", "Scroll chart"),
-                    ("f", "Filter components"),
-                    ("s", "Sort components"),
+                    item("p/Tab", "Switch panel"),
+                    item("d", "Compare versions"),
+                    item("t", "Toggle statistics"),
+                    item("g", "Jump to version"),
+                    item("+/-", "Zoom chart"),
+                    item("h/l", "Scroll chart"),
+                    item("f", "Filter components"),
+                    item("s", "Sort components"),
                 ],
             });
         }
@@ -528,13 +568,13 @@ fn get_shortcuts_for_context(context: ShortcutsContext) -> Vec<ShortcutSection> 
             sections.push(ShortcutSection {
                 title: "Matrix View",
                 items: vec![
-                    ("p/Tab", "Switch panel"),
-                    ("Enter", "View pair diff"),
-                    ("t", "Cycle threshold"),
-                    ("z", "Toggle focus mode"),
-                    ("H", "Toggle row/col highlight"),
-                    ("C", "Show cluster details"),
-                    ("x", "Export options"),
+                    item("p/Tab", "Switch panel"),
+                    item("Enter", "View pair diff"),
+                    item("t", "Cycle threshold"),
+                    item("z", "Toggle focus mode"),
+                    item("H", "Toggle row/col highlight"),
+                    item("C", "Show cluster details"),
+                    item("x", "Export options"),
                 ],
             });
         }
@@ -542,16 +582,16 @@ fn get_shortcuts_for_context(context: ShortcutsContext) -> Vec<ShortcutSection> 
             sections.push(ShortcutSection {
                 title: "Diff View",
                 items: vec![
-                    ("f", "Filter/toggle options"),
-                    ("s", "Sort/cycle options"),
-                    ("d", "Toggle deduplication"),
-                    ("t", "Toggle transitive deps"),
-                    ("v", "Multi-select mode"),
-                    ("Enter", "View details"),
-                    ("n/N", "Navigate to next/prev match"),
-                    ("p", "Toggle panel focus"),
-                    ("h/l", "Collapse/expand (tree tabs)"),
-                    ("E", "Export compliance (compliance tab)"),
+                    item("f", "Filter/toggle options"),
+                    item("s", "Sort/cycle options"),
+                    item("d", "Toggle deduplication"),
+                    item("t", "Toggle transitive deps"),
+                    item("v", "Multi-select mode"),
+                    item("Enter", "View details"),
+                    item("n/N", "Navigate to next/prev match"),
+                    item("p", "Toggle panel focus"),
+                    item("h/l", "Collapse/expand (tree tabs)"),
+                    item("E", "Export compliance (compliance tab)"),
                 ],
             });
         }
@@ -559,22 +599,22 @@ fn get_shortcuts_for_context(context: ShortcutsContext) -> Vec<ShortcutSection> 
             sections.push(ShortcutSection {
                 title: "View Mode",
                 items: vec![
-                    ("f", "Filter (tree/vulns/compliance)"),
-                    ("s", "Sort (vulnerabilities)"),
-                    ("d", "Toggle deduplication (vulns)"),
-                    ("g", "Toggle grouping (tree/vulns/licenses)"),
-                    ("v", "Toggle view mode (quality/source)"),
-                    ("p", "Toggle panel focus"),
-                    ("m", "Bookmark component (tree)"),
-                    ("y/Ctrl+C", "Copy selected to clipboard"),
-                    ("Shift+drag", "Select text with mouse"),
-                    ("h/l", "Collapse/expand, prev/next standard"),
-                    ("Enter", "Select / expand node"),
-                    ("[/]", "Prev/next detail tab"),
-                    ("E", "Export compliance"),
-                    ("n/N", "Next/prev search match (source)"),
-                    ("H/L", "Collapse/expand all (source)"),
-                    ("w", "Toggle focus (source)"),
+                    item("f", "Filter (tree/vulns/compliance)"),
+                    item("s", "Sort (vulnerabilities)"),
+                    item("d", "Toggle deduplication (vulns)"),
+                    item("g", "Toggle grouping (tree/vulns/licenses)"),
+                    item("v", "Toggle view mode (quality/source)"),
+                    item("p", "Toggle panel focus"),
+                    item("m", "Bookmark component (tree)"),
+                    item("y/Ctrl+C", "Copy selected to clipboard"),
+                    item("Shift+drag", "Select text with mouse"),
+                    item("h/l", "Collapse/expand, prev/next standard"),
+                    item("Enter", "Select / expand node"),
+                    item("[/]", "Prev/next detail tab"),
+                    item("E", "Export compliance"),
+                    item("n/N", "Next/prev search match (source)"),
+                    item("H/L", "Collapse/expand all (source)"),
+                    item("w", "Toggle focus (source)"),
                 ],
             });
         }
@@ -785,4 +825,95 @@ pub fn render_threshold_tuning(f: &mut Frame, state: &ThresholdTuningState) {
         .alignment(Alignment::Left)
         .wrap(Wrap { trim: true });
     f.render_widget(paragraph, inner_area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ShortcutsContext, get_shortcuts_for_context};
+    use crate::model::BomProfile;
+
+    /// Collect every `(key, description)` pair across all sections.
+    fn flatten(context: ShortcutsContext, profile: Option<BomProfile>) -> Vec<(String, String)> {
+        get_shortcuts_for_context(context, profile)
+            .into_iter()
+            .flat_map(|s| s.items)
+            .collect()
+    }
+
+    fn descriptions(items: &[(String, String)]) -> Vec<String> {
+        items.iter().map(|(_, d)| d.clone()).collect()
+    }
+
+    fn jump_range(items: &[(String, String)]) -> String {
+        items
+            .iter()
+            .find(|(_, d)| d == "Jump to tab")
+            .map(|(k, _)| k.clone())
+            .expect("a Jump to tab hint should always be present")
+    }
+
+    #[test]
+    fn aibom_overlay_lists_ai_tabs_not_sbom_tabs() {
+        let items = flatten(ShortcutsContext::View, Some(BomProfile::AiBom));
+        let descs = descriptions(&items);
+
+        // AI-BOM profile tabs (ViewTab::tabs_for_profile): Overview, Models,
+        // Datasets, AI-Readiness, Compliance, Source.
+        for expected in ["Overview", "Models", "Datasets", "AI-Readiness"] {
+            assert!(
+                descs.iter().any(|d| d == expected),
+                "AI-BOM overlay should list the {expected} tab; got {descs:?}"
+            );
+        }
+
+        // It must NOT advertise SBOM-only tabs the user cannot reach.
+        for sbom_only in ["Components", "Vulns", "Licenses", "Deps"] {
+            assert!(
+                !descs.iter().any(|d| d == sbom_only),
+                "AI-BOM overlay must not list the SBOM-only {sbom_only} tab"
+            );
+        }
+
+        // 6 AI-BOM tabs -> "1-6", never the generic "1-8".
+        assert_eq!(jump_range(&items), "1-6");
+    }
+
+    #[test]
+    fn sbom_overlay_lists_sbom_tabs_and_full_range() {
+        let items = flatten(ShortcutsContext::View, Some(BomProfile::Sbom));
+        let descs = descriptions(&items);
+        for expected in ["Components", "Vulns", "Licenses", "Deps", "Compliance"] {
+            assert!(
+                descs.iter().any(|d| d == expected),
+                "SBOM overlay should list the {expected} tab; got {descs:?}"
+            );
+        }
+        assert_eq!(jump_range(&items), "1-8");
+    }
+
+    #[test]
+    fn cbom_overlay_lists_crypto_tabs() {
+        let items = flatten(ShortcutsContext::View, Some(BomProfile::Cbom));
+        let descs = descriptions(&items);
+        for expected in ["Algorithms", "Certs", "Keys", "Protocols"] {
+            assert!(
+                descs.iter().any(|d| d == expected),
+                "CBOM overlay should list the {expected} tab; got {descs:?}"
+            );
+        }
+        assert_eq!(jump_range(&items), "1-8");
+    }
+
+    #[test]
+    fn no_profile_falls_back_to_generic_hint_without_tab_section() {
+        // Diff-mode passes None: keep the existing generic "1-8" hint and no
+        // profile-specific tab listing.
+        let sections = get_shortcuts_for_context(ShortcutsContext::Diff, None);
+        assert!(
+            sections.iter().all(|s| s.title != "Tabs (this profile)"),
+            "no profile -> no profile-tab section"
+        );
+        let items: Vec<_> = sections.into_iter().flat_map(|s| s.items).collect();
+        assert_eq!(jump_range(&items), "1-8");
+    }
 }


### PR DESCRIPTION
## Summary

Three cross-cutting visual-polish gaps that broke consistency between the CLI reports and the TUI.

1. **CLI summary severity colors** now match the shared 4-color scheme used by the TUI (`src/tui/theme.rs`) and the side-by-side report (`src/reports/sidebyside.rs`): **Critical=magenta, High=red, Medium=yellow, Low=cyan**. Previously `summary.rs` collapsed Critical+High to red and left Low uncolored, losing the Critical/High and Low distinctions. Added `magenta` to `ansi_color` and a single-source `severity_color_name()` helper applied to both the introduced-vuln list and the vuln-count summary block.

2. **Firmware badge disambiguation**: Firmware no longer shares the `FW` badge with Framework — it now renders **`FRMW`** so the two are unambiguous where badge color is hard to read (`component_type_badge`, `src/tui/view/views/dependencies.rs`). The diff-side renders component type via `Debug` (`Firmware`/`Framework`), already unambiguous, so no change was needed there.

3. **Profile-aware help / shortcuts overlay**: the overlay no longer advertises tabs the active BOM profile cannot reach. The view-mode shortcuts overlay now derives the "Jump to tab" range and a "Tabs (this profile)" listing from `ViewTab::tabs_for_profile`, so **AI-BOM shows Models/Datasets/AI-Readiness and `1-6`** instead of the SBOM tabs and `1-8`. The diff-mode `?` overlay's `1-8` hint now derives from the live diff tab count. `ShortcutsOverlayState` gained an optional `profile` field (`None` keeps the old generic hint for diff mode). The `ViewState::shortcuts()` trait remains unused by any render path; its doc comment now flags that and notes wiring it as the single source is a deliberate future refactor (no large refactor done here).

## Test plan

- `cargo fmt` — clean
- `cargo build` — clean
- New unit tests:
  - `reports::summary` — the four severities map to distinct ANSI colors (35/31/33/36) and to the magenta/red/yellow/cyan names.
  - `tui::view::views::dependencies` — `Firmware != Framework` badge label (`FRMW` vs `FW`).
  - `tui::views::overlays` — overlay tab listing is profile-accurate (AI-BOM lists Models/Datasets/AI-Readiness and `1-6`, never the SBOM tabs; SBOM/CBOM list their own tabs and `1-8`; `None` falls back to `1-8` with no profile-tab section).
- `cargo test` — 1003 lib tests pass + integration suites pass. The only failure is the **pre-existing** `snapshot_aibom_tabs` (`aibom_models_120x40`, model Use Cases/Metrics rendering) which is present at base HEAD (verified via stash) and is unrelated to this change — left untouched, not re-baked.
- No new clippy warnings on changed code (existing 35 are the known toolchain false positives; CI true-1.88 is the lint authority).

🤖 Generated with [Claude Code](https://claude.com/claude-code)