### PR TITLE
docs: align v0.1.21 + v0.1.22 release notes to the v0.1.20 format

### DIFF
--- a/RELEASE_NOTES_v0.1.21.md
+++ b/RELEASE_NOTES_v0.1.21.md
@@ -1,3 +1,5 @@
+# sbom-tools v0.1.21
+
 ## Highlights
 
 Focused bug-fix release. `view -o json` now emits the full enriched
@@ -35,6 +37,8 @@ components.
   `tokio` 1.52.2 → 1.52.3 (dagger SDK only).
 - GitHub Actions bumps: `codeql-action` 4.35.3 → 4.35.5,
   `cargo-deny-action` 2.0.17 → 2.0.18, `crates-io-auth-action` SHA-pin refresh.
+- **Total tests: 1214** (787 lib + 427 integration), up from 1196 in v0.1.20.
+- **0 clippy warnings** (default + all-features) on Rust 1.88; **0 production `unwrap()`**.
 
 ## Acknowledgments
 
@@ -44,6 +48,7 @@ to **@cmyank0** and **@VincentR-OCD** for the bug reports that drove them.
 
 ---
 
-Install: `cargo install sbom-tools` · `brew install sbom-tool/tap/sbom-tools`
+Install: `cargo install sbom-tools`
+Homebrew: `brew install sbom-tool/tap/sbom-tools`
 Crate: https://crates.io/crates/sbom-tools
 Full changelog: https://github.com/sbom-tool/sbom-tools/compare/v0.1.20...v0.1.21

--- a/RELEASE_NOTES_v0.1.22.md
+++ b/RELEASE_NOTES_v0.1.22.md
@@ -1,3 +1,5 @@
+# sbom-tools v0.1.22
+
 ## Highlights
 
 The **AI BOM release.** sbom-tools now treats AI systems as a first-class
@@ -19,7 +21,7 @@ air-gapped mode, and broad CLI/TUI alignment.
 > changes several user-visible behaviors (scoring engine 2.1, stricter
 > license-policy gating, logs moved to stderr, official EPSS endpoint).
 
-## New Features
+## What's New
 
 ### AI / ML Bill of Materials
 
@@ -179,6 +181,8 @@ air-gapped mode, and broad CLI/TUI alignment.
   2.0.20, `actions/checkout` → 6.0.3; SHA-pin hygiene + expanded Dependabot
   coverage; fuzz CI now installs `cargo-fuzz` with the nightly toolchain.
   (#193, #194, #199, #200, #202)
+- **Total tests: 1560** (1014 lib + 546 integration), up from 1214 in v0.1.21.
+- **0 clippy warnings** (default + all-features) on Rust 1.88; **0 production `unwrap()`**.
 
 ## Upgrade notes
 
@@ -219,6 +223,7 @@ KEV**, and **FIRST EPSS**.
 
 ---
 
-Install: `cargo install sbom-tools` · `brew install sbom-tool/tap/sbom-tools`
+Install: `cargo install sbom-tools`
+Homebrew: `brew install sbom-tool/tap/sbom-tools`
 Crate: https://crates.io/crates/sbom-tools
 Full changelog: https://github.com/sbom-tool/sbom-tools/compare/v0.1.21...v0.1.22


### PR DESCRIPTION
Reformats the committed `RELEASE_NOTES_v0.1.21.md` and `RELEASE_NOTES_v0.1.22.md` to match the established release-notes manner used on the [v0.1.20 release page](https://github.com/sbom-tool/sbom-tools/releases/tag/v0.1.20):

- `# sbom-tools vX.Y.Z` H1 title
- `## What's New` section heading (v0.1.22 previously used "New Features")
- Infrastructure section closes with a **Total tests** line + **0 clippy warnings / 0 production `unwrap()`** line
- 4-line install footer (Install / Homebrew / Crate / Full changelog) instead of a combined Install·Homebrew line

The live GitHub release bodies for both tags have already been updated to match; this keeps the in-repo sources in sync.

Test counts were measured: v0.1.21 = 1214 (787 lib + 427 integration, built from the tag), v0.1.22 = 1560 (1014 lib + 546 integration).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)