### PR TITLE
ci: document why the SLSA generator must be tag-pinned (not SHA)

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -113,7 +113,12 @@ jobs:
       actions: read
       id-token: write
       contents: write
-    # Must reference by tag, not SHA — generator requirement
+    # Must be referenced by a version TAG, not a SHA. The SLSA generator
+    # verifies its own tag at runtime to mint trustworthy provenance and
+    # refuses to run when called by commit SHA, so SHA-pinning here would
+    # break SLSA L3 provenance. This is a known OpenSSF Scorecard
+    # Pinned-Dependencies false-positive (do NOT "secure" it by pinning).
+    # Ref: https://github.com/slsa-framework/slsa-github-generator#referencing-slsa-builders-and-generators
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.publish.outputs.hashes }}"


### PR DESCRIPTION
Expands the inline comment on the SLSA provenance generator `uses:` in `publish-crates.yml` so the pinning exception is self-documenting.

**Context:** OpenSSF Scorecard's Pinned-Dependencies check flags this one action (`slsa-framework/slsa-github-generator/...@v2.1.0`) as "not pinned by hash" and normalizes the score to 9. It's the only unpinned action in the repo — 61 of 62 are SHA-pinned.

**Why it must stay a tag, not a SHA:** the SLSA generator verifies its own tag at runtime to mint trustworthy provenance and refuses to run when invoked by commit SHA. SHA-pinning it would break SLSA L3 provenance on every release — a net supply-chain loss for one Scorecard point. This is a documented, accepted false-positive.

This PR just makes that reasoning explicit in the comment (and links the SLSA docs) so nobody "helpfully" SHA-pins it later. No behavior change — comment only; `v2.1.0` is already the latest stable generator release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)