### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 to fix RUSTSEC-2026-0185

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,9 +99,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2281,9 +2281,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",


### PR DESCRIPTION
## Summary
- `cargo audit` was failing on `main` due to RUSTSEC-2026-0185: remote memory exhaustion in `quinn-proto` 0.11.14 from unbounded out-of-order stream reassembly (CVSS 7.5, high).
- `quinn-proto` is a transitive dependency via `reqwest` -> `quinn`.
- `cargo update -p quinn-proto` relocks it to 0.11.15, which fixes the advisory.

## Test plan
- [x] `cargo audit` passes (only a non-blocking `anyhow` unsoundness warning remains, RUSTSEC-2026-0190, unrelated)
- [ ] CI green