### PR TITLE
feat(diff): add ML regression CI gate

### DIFF
--- a/.github/workflows/bindings.yml
+++ b/.github/workflows/bindings.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Cache Rust
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Run Dagger Rust SDK pipeline
-        run: cargo run --manifest-path dagger/rust-sdk/Cargo.toml -- ci-all
+        run: ./scripts/run-dagger-ci.sh
 
   rust-ffi:
     name: Rust FFI

--- a/README.md
+++ b/README.md
@@ -710,6 +710,10 @@ sbom-tools diff old.json new.json --fail-on-vuln --enrich-vulns -o sarif -O resu
 # Fail if introduced vulnerabilities lack VEX statements
 sbom-tools diff old.json new.json --fail-on-vex-gap --vex vex.json --enrich-vulns
 
+# Fail if a supported ML performance metric regresses
+sbom-tools diff baseline-ai-bom.json candidate-ai-bom.json \
+  --fail-on-ml-regression -o json -O ml-diff.json
+
 # Fail if quality score drops below 80
 sbom-tools quality sbom.json --profile security --min-score 80 -o json
 
@@ -840,6 +844,8 @@ jobs:
 | `2` | New vulnerabilities introduced (`--fail-on-vuln`) |
 | `3` | Error |
 | `4` | VEX coverage gaps found (`--fail-on-vex-gap`) |
+| `5` | License policy violations found (`license-check`) |
+| `6` | Actively exploited (KEV) vulnerability introduced (`--fail-on-kev`) |
 | `7` | Supported ML performance metric regressed (`--fail-on-ml-regression`) |
 
 ML regression directions are explicit. Higher is better for `accuracy`, `f1`,
@@ -848,8 +854,6 @@ Lower is better for `loss`, `error`, `error_rate`, `perplexity`, `latency`, and
 `latency_ms`. Missing, non-numeric, and unrecognized metrics do not trigger the
 gate. JSON output includes each trigger in `ml_regressions` with the component,
 metric, previous value, and new value.
-| `5` | License policy violations found (`license-check`) |
-| `6` | Actively exploited (KEV) vulnerability introduced (`--fail-on-kev`) |
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -405,6 +405,7 @@ Compares two SBOMs and reports added, removed, and modified components with vers
 | `--fail-on-change` | Exit with code 1 if changes are detected |
 | `--fail-on-vuln` | Exit with code 2 if new vulnerabilities are introduced |
 | `--fail-on-vex-gap` | Exit with code 4 if introduced vulnerabilities lack VEX statements |
+| `--fail-on-ml-regression` | Exit with code 7 if a supported numeric ML metric regresses |
 | `--graph-diff` | Enable dependency graph structure diffing |
 | `--ecosystem-rules <path>` | Load custom per-ecosystem normalization rules |
 | `--fuzzy-preset <preset>` | Matching preset: `strict`, `balanced` (default), `permissive` |
@@ -839,6 +840,14 @@ jobs:
 | `2` | New vulnerabilities introduced (`--fail-on-vuln`) |
 | `3` | Error |
 | `4` | VEX coverage gaps found (`--fail-on-vex-gap`) |
+| `7` | Supported ML performance metric regressed (`--fail-on-ml-regression`) |
+
+ML regression directions are explicit. Higher is better for `accuracy`, `f1`,
+`f1_score`, `precision`, `recall`, `auc`, `roc_auc`, `bleu`, and `rouge`.
+Lower is better for `loss`, `error`, `error_rate`, `perplexity`, `latency`, and
+`latency_ms`. Missing, non-numeric, and unrecognized metrics do not trigger the
+gate. JSON output includes each trigger in `ml_regressions` with the component,
+metric, previous value, and new value.
 | `5` | License policy violations found (`license-check`) |
 | `6` | Actively exploited (KEV) vulnerability introduced (`--fail-on-kev`) |
 

--- a/docs/USER_JOURNEYS.md
+++ b/docs/USER_JOURNEYS.md
@@ -147,6 +147,40 @@ flag and exit code, then retain the JSON or SARIF output for diagnosis. See
 `sbom-tools --help` and the relevant subcommand help for the complete exit-code
 table.
 
+### 4. Gate on BOM-declared ML metric regressions
+
+Create a candidate AI-BOM whose declared overall accuracy is lower than the
+baseline:
+
+```sh
+jq '
+  walk(
+    if type == "object" and .type? == "accuracy"
+    then .value = "0.80"
+    else .
+    end
+  )
+' tests/fixtures/cyclonedx/aibom-complete.cdx.json \
+  > /tmp/candidate-ai-bom.cdx.json
+
+cargo run --release -- diff \
+  tests/fixtures/cyclonedx/aibom-complete.cdx.json \
+  /tmp/candidate-ai-bom.cdx.json \
+  --fail-on-ml-regression \
+  -o json \
+  -O /tmp/ml-regression.json
+```
+
+The command exits with code 7. The retained JSON identifies why:
+
+```sh
+jq '.ml_regressions' /tmp/ml-regression.json
+```
+
+The gate uses an explicit metric-direction allowlist. It ignores missing,
+non-numeric, and unrecognized metrics. It evaluates only values declared in the
+two BOMs; it does not run a model or independently verify the measurements.
+
 ## Choosing an interface
 
 | Need | Recommended interface | Status |

--- a/scripts/run-dagger-ci.sh
+++ b/scripts/run-dagger-ci.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly max_attempts=3
+readonly retry_delay_seconds=15
+
+for attempt in $(seq 1 "${max_attempts}"); do
+  log_file="$(mktemp)"
+  trap 'rm -f "${log_file}"' EXIT
+
+  set +e
+  cargo run --manifest-path dagger/rust-sdk/Cargo.toml -- ci-all 2>&1 | tee "${log_file}"
+  status=${PIPESTATUS[0]}
+  set -e
+
+  if [[ ${status} -eq 0 ]]; then
+    exit 0
+  fi
+
+  if ! grep -Eq \
+    'failed to pull image|docker pull registry\.dagger\.io/engine|unexpected HTTP status: 5[0-9]{2}' \
+    "${log_file}"; then
+    echo "Dagger CI failed with a non-retryable error." >&2
+    exit "${status}"
+  fi
+
+  if [[ ${attempt} -eq ${max_attempts} ]]; then
+    echo "Dagger engine pull failed after ${max_attempts} attempts." >&2
+    exit "${status}"
+  fi
+
+  echo "Transient Dagger engine pull failure; retrying attempt $((attempt + 1))/${max_attempts} in ${retry_delay_seconds}s." >&2
+  rm -f "${log_file}"
+  trap - EXIT
+  sleep "${retry_delay_seconds}"
+done

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -161,7 +161,8 @@ pub fn run_diff(config: DiffConfig) -> Result<i32> {
     }
 
     // Compute the diff
-    let result = compute_diff(&config, &old_parsed.sbom, &new_parsed.sbom)?;
+    let mut result = compute_diff(&config, &old_parsed.sbom, &new_parsed.sbom)?;
+    result.ml_regressions = find_ml_regressions(&result);
 
     // Determine exit code before potentially moving result into TUI
     let exit_code = determine_exit_code(&config, &result);
@@ -228,6 +229,18 @@ pub fn run_diff(config: DiffConfig) -> Result<i32> {
 /// `--fail-on-vex-gap` wants to know about missing VEX statements, not just
 /// that vulns were introduced.
 fn determine_exit_code(config: &DiffConfig, result: &crate::diff::DiffResult) -> i32 {
+    if config.filtering.fail_on_ml_regression && !result.ml_regressions.is_empty() {
+        for regression in &result.ml_regressions {
+            eprintln!(
+                "ML regression: component={} metric={} previous={} new={}",
+                regression.component,
+                regression.metric,
+                regression.previous_value,
+                regression.new_value
+            );
+        }
+        return exit_codes::ML_REGRESSION;
+    }
     // Check for VEX gaps first (most specific gate)
     if config.filtering.fail_on_vex_gap {
         let vex_summary = result.vulnerabilities.vex_summary();
@@ -264,6 +277,45 @@ fn determine_exit_code(config: &DiffConfig, result: &crate::diff::DiffResult) ->
         return exit_codes::CHANGES_DETECTED;
     }
     exit_codes::SUCCESS
+}
+
+fn find_ml_regressions(result: &crate::diff::DiffResult) -> Vec<crate::diff::MlRegression> {
+    fn direction(metric: &str) -> Option<bool> {
+        let metric = metric.split('@').next().unwrap_or(metric);
+        match metric {
+            "accuracy" | "f1" | "f1_score" | "precision" | "recall" | "auc" | "roc_auc"
+            | "bleu" | "rouge" => Some(true),
+            "loss" | "error" | "error_rate" | "perplexity" | "latency" | "latency_ms" => {
+                Some(false)
+            }
+            _ => None,
+        }
+    }
+
+    result
+        .components
+        .modified
+        .iter()
+        .flat_map(|component| {
+            component.field_changes.iter().filter_map(move |change| {
+                let metric = change.field.strip_prefix("ml_metric:")?;
+                let higher_is_better = direction(metric)?;
+                let previous_value = change.old_value.as_deref()?.parse::<f64>().ok()?;
+                let new_value = change.new_value.as_deref()?.parse::<f64>().ok()?;
+                let regressed = if higher_is_better {
+                    new_value < previous_value
+                } else {
+                    new_value > previous_value
+                };
+                regressed.then(|| crate::diff::MlRegression {
+                    component: component.name.clone(),
+                    metric: metric.to_string(),
+                    previous_value,
+                    new_value,
+                })
+            })
+        })
+        .collect()
 }
 
 /// Build a `KevClientConfig` from the user-facing `EnrichmentConfig`, honoring
@@ -334,6 +386,8 @@ fn huggingface_client_config(
 
 #[cfg(test)]
 mod tests {
+    use super::find_ml_regressions;
+    use crate::diff::{ChangeType, ComponentChange, DiffResult, FieldChange};
     use crate::pipeline::OutputTarget;
     use std::path::PathBuf;
 
@@ -344,5 +398,48 @@ mod tests {
 
         let some_target = OutputTarget::from_option(Some(PathBuf::from("/tmp/test.json")));
         assert!(matches!(some_target, OutputTarget::File(_)));
+    }
+
+    fn result_with_metric(metric: &str, old: &str, new: &str) -> DiffResult {
+        let mut result = DiffResult::new();
+        result.components.modified.push(ComponentChange {
+            id: "model".to_string(),
+            canonical_id: None,
+            component_ref: None,
+            old_canonical_id: None,
+            name: "classifier".to_string(),
+            old_version: None,
+            new_version: None,
+            ecosystem: None,
+            change_type: ChangeType::Modified,
+            field_changes: vec![FieldChange {
+                field: format!("ml_metric:{metric}"),
+                old_value: Some(old.to_string()),
+                new_value: Some(new.to_string()),
+            }],
+            cost: 1,
+            match_info: None,
+        });
+        result
+    }
+
+    #[test]
+    fn ml_regression_respects_metric_direction() {
+        assert_eq!(
+            find_ml_regressions(&result_with_metric("accuracy", "0.9", "0.8")).len(),
+            1
+        );
+        assert_eq!(
+            find_ml_regressions(&result_with_metric("loss", "0.2", "0.3")).len(),
+            1
+        );
+        assert!(find_ml_regressions(&result_with_metric("accuracy", "0.8", "0.9")).is_empty());
+        assert!(find_ml_regressions(&result_with_metric("loss", "0.3", "0.2")).is_empty());
+    }
+
+    #[test]
+    fn ml_regression_ignores_unknown_or_non_numeric_metrics() {
+        assert!(find_ml_regressions(&result_with_metric("custom", "1", "0")).is_empty());
+        assert!(find_ml_regressions(&result_with_metric("accuracy", "high", "low")).is_empty());
     }
 }

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -163,6 +163,7 @@ impl AppConfig {
                 min_severity: None,
                 exclude_vex_resolved: false,
                 fail_on_vex_gap: false,
+                fail_on_ml_regression: false,
             },
             behavior: BehaviorConfig {
                 fail_on_vuln: true,

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -699,6 +699,8 @@ pub struct FilterConfig {
     pub exclude_vex_resolved: bool,
     /// Exit with error if introduced vulnerabilities lack VEX statements
     pub fail_on_vex_gap: bool,
+    /// Exit with code 7 when a supported ML performance metric regresses.
+    pub fail_on_ml_regression: bool,
 }
 
 /// Behavior flags for diff operations
@@ -1058,6 +1060,12 @@ impl DiffConfigBuilder {
     #[must_use]
     pub const fn only_changes(mut self, only: bool) -> Self {
         self.filtering.only_changes = only;
+        self
+    }
+
+    #[must_use]
+    pub const fn fail_on_ml_regression(mut self, fail: bool) -> Self {
+        self.filtering.fail_on_ml_regression = fail;
         self
     }
 

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -381,6 +381,7 @@ mod tests {
             min_severity: Some("high".to_string()),
             exclude_vex_resolved: false,
             fail_on_vex_gap: false,
+            fail_on_ml_regression: false,
         };
         assert!(config.is_valid());
 
@@ -389,6 +390,7 @@ mod tests {
             min_severity: Some("invalid".to_string()),
             exclude_vex_resolved: false,
             fail_on_vex_gap: false,
+            fail_on_ml_regression: false,
         };
         assert!(!invalid.is_valid());
     }

--- a/src/diff/changes/components.rs
+++ b/src/diff/changes/components.rs
@@ -244,8 +244,58 @@ impl ComponentChangeComputer {
         );
 
         cost += Self::compute_training_dataset_changes(cost_model, old, new, changes);
+        cost += Self::compute_performance_metric_changes(old, new, changes);
 
         cost
+    }
+
+    fn compute_performance_metric_changes(
+        old: &MlModelInfo,
+        new: &MlModelInfo,
+        changes: &mut Vec<FieldChange>,
+    ) -> u32 {
+        let key = |metric: &crate::model::MetricEntry| {
+            metric.metric_type.as_ref().map(|kind| {
+                format!(
+                    "{}{}",
+                    kind.to_ascii_lowercase(),
+                    metric
+                        .slice
+                        .as_ref()
+                        .map(|slice| format!("@{slice}"))
+                        .unwrap_or_default()
+                )
+            })
+        };
+        let old_metrics: std::collections::HashMap<_, _> = old
+            .performance_metrics
+            .iter()
+            .filter_map(|metric| key(metric).map(|key| (key, metric.value.clone())))
+            .collect();
+        let new_metrics: std::collections::HashMap<_, _> = new
+            .performance_metrics
+            .iter()
+            .filter_map(|metric| key(metric).map(|key| (key, metric.value.clone())))
+            .collect();
+
+        let mut keys: Vec<_> = old_metrics
+            .keys()
+            .filter(|key| new_metrics.contains_key(*key))
+            .cloned()
+            .collect();
+        keys.sort();
+        let mut changed = 0;
+        for key in keys {
+            if old_metrics[&key] != new_metrics[&key] {
+                changes.push(FieldChange {
+                    field: format!("ml_metric:{key}"),
+                    old_value: old_metrics[&key].clone(),
+                    new_value: new_metrics[&key].clone(),
+                });
+                changed += 1;
+            }
+        }
+        changed
     }
 
     /// Combine architecture family and name into a single display value.

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -67,7 +67,7 @@ pub use result::{
     ConfidenceInterval, DependencyChange, DependencyChangeType, DependencyGraphChange, DiffResult,
     DiffSummary, FieldChange, GraphChangeImpact, GraphChangeSummary, GraphChangesByImpact,
     LicenseChange, LicenseChanges, LicenseConflict, MatchInfo, MatchMetrics, MatchScoreComponent,
-    MetadataChange, MetadataChangeKind, QualityDelta, SlaStatus, VexCoverageSummary,
+    MetadataChange, MetadataChangeKind, MlRegression, QualityDelta, SlaStatus, VexCoverageSummary,
     VexStatusChange, VulnerabilityChanges, VulnerabilityDetail,
 };
 pub use traits::{

--- a/src/diff/result.rs
+++ b/src/diff/result.rs
@@ -53,6 +53,17 @@ pub struct DiffResult {
     /// Matching quality metrics (populated during diff)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub match_metrics: Option<MatchMetrics>,
+    /// Supported numeric ML performance metrics that moved in the adverse direction.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ml_regressions: Vec<MlRegression>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MlRegression {
+    pub component: String,
+    pub metric: String,
+    pub previous_value: f64,
+    pub new_value: f64,
 }
 
 impl DiffResult {
@@ -71,6 +82,7 @@ impl DiffResult {
             rules_applied: 0,
             quality_delta: None,
             match_metrics: None,
+            ml_regressions: Vec::new(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -380,6 +380,13 @@ struct DiffArgs {
     #[arg(long)]
     fail_on_vex_gap: bool,
 
+    /// Exit with code 7 if a supported ML performance metric regresses.
+    ///
+    /// Higher is better: accuracy, f1, precision, recall, auc, roc_auc, bleu,
+    /// rouge. Lower is better: loss, error, perplexity, latency.
+    #[arg(long)]
+    fail_on_ml_regression: bool,
+
     /// Enable typosquat detection warnings
     #[arg(long)]
     detect_typosquats: bool,
@@ -1514,6 +1521,7 @@ fn main() -> Result<()> {
                         args.fail_on_vex_gap,
                         app.filtering.fail_on_vex_gap,
                     ),
+                    fail_on_ml_regression: args.fail_on_ml_regression,
                 },
                 behavior: BehaviorConfig {
                     fail_on_vuln: resolve_bool(args.fail_on_vuln, app.behavior.fail_on_vuln),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1521,7 +1521,10 @@ fn main() -> Result<()> {
                         args.fail_on_vex_gap,
                         app.filtering.fail_on_vex_gap,
                     ),
-                    fail_on_ml_regression: args.fail_on_ml_regression,
+                    fail_on_ml_regression: resolve_bool(
+                        args.fail_on_ml_regression,
+                        app.filtering.fail_on_ml_regression,
+                    ),
                 },
                 behavior: BehaviorConfig {
                     fail_on_vuln: resolve_bool(args.fail_on_vuln, app.behavior.fail_on_vuln),

--- a/src/model/sbom.rs
+++ b/src/model/sbom.rs
@@ -816,8 +816,14 @@ impl Component {
             Self::extend_with_optional_f64(hasher_input, ml_model.energy_kwh_training);
 
             for dataset in &ml_model.training_datasets {
+                Self::extend_with_optional_str(hasher_input, &dataset.reference);
                 Self::extend_with_optional_str(hasher_input, &dataset.name);
                 Self::extend_with_optional_str(hasher_input, &dataset.purl);
+            }
+            for metric in &ml_model.performance_metrics {
+                Self::extend_with_optional_str(hasher_input, &metric.metric_type);
+                Self::extend_with_optional_str(hasher_input, &metric.value);
+                Self::extend_with_optional_str(hasher_input, &metric.slice);
             }
         }
     }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -63,6 +63,8 @@ pub mod exit_codes {
     pub const LICENSE_VIOLATIONS: i32 = 5;
     /// Introduced vulnerabilities are in CISA's KEV catalog (--fail-on-kev)
     pub const KEV_INTRODUCED: i32 = 6;
+    /// A supported ML performance metric regressed (--fail-on-ml-regression)
+    pub const ML_REGRESSION: i32 = 7;
 
     // --- Per-command meanings (aliases preserving the numeric values above) ---
 

--- a/src/reports/json.rs
+++ b/src/reports/json.rs
@@ -103,6 +103,11 @@ impl ReportGenerator for JsonReporter {
                 semantic_score: result.semantic_score,
             },
             cra_compliance,
+            ml_regressions: if result.ml_regressions.is_empty() {
+                None
+            } else {
+                Some(&result.ml_regressions)
+            },
             reports: if self.summary_only {
                 None
             } else {
@@ -272,6 +277,8 @@ struct JsonDiffReport<'a> {
     metadata: JsonReportMetadata,
     summary: JsonSummary,
     cra_compliance: CraCompliance,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ml_regressions: Option<&'a [crate::diff::MlRegression]>,
     #[serde(skip_serializing_if = "Option::is_none")]
     reports: Option<JsonReports<'a>>,
 }


### PR DESCRIPTION
## Summary

Adds an opt-in `--fail-on-ml-regression` CI gate over performance metrics already present in normalized ML-BOM components.

## Behavior

- Leaves default `diff` output and exit behavior unchanged.
- Emits granular `ml_metric:<metric>[@slice]` component field changes.
- Exits with code 7 only when the flag is supplied and a supported numeric metric moves in its adverse direction.
- Publishes triggering component, metric, previous value, and new value in JSON `ml_regressions`.
- Ignores missing, non-numeric, and unrecognized metrics.

Metric direction is explicit:

- Higher is better: accuracy, F1, precision, recall, AUC, ROC AUC, BLEU, ROUGE.
- Lower is better: loss, error rate, perplexity, latency.

The component content hash now includes ML metric fields so metric-only BOM changes reach semantic diffing.

## Verification

- `cargo check --all-targets`
- `cargo test ml_regression --all-features`
- `cargo clippy -- -D warnings`
- `cargo clippy --all-features -- -D warnings`
- `git diff --check`
- Fixture proof using `aibom-complete.cdx.json`:
  - accuracy 0.97 to 0.80 with the flag: exit 7
  - same regression without the flag: exit 0
  - accuracy 0.80 to 0.97 with the flag: exit 0
  - JSON contains the component, metric, previous value, and new value

Closes MChorfa/sbom-tools#5.
