### PR TITLE
feat(reports): export OSCAL assessment results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2804,6 +2804,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-width",
+ "uuid",
  "xxhash-rust",
 ]
 
@@ -3658,6 +3659,7 @@ dependencies = [
  "atomic",
  "getrandom 0.4.1",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ sha2 = "0.11"
 
 # Utilities
 chrono = { version = "0.4.44", features = ["serde"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 rayon = "1.12"
 thiserror = "2.0"
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ Select with `-o` / `--output`:
 | TUI | `tui` | Interactive exploration |
 | JSON | `json` | Programmatic integration |
 | SARIF | `sarif` | CI/CD security dashboards (SARIF 2.1.0) |
+| OSCAL assessment results | `oscal-json` | OSCAL 1.1.2 validation findings for assessment tooling |
 | Markdown | `markdown` | Documentation, PR comments |
 | HTML | `html` | Stakeholder reports |
 | CSV | `csv` | Spreadsheet analysis |
@@ -714,6 +715,10 @@ sbom-tools quality sbom.json --profile security --min-score 80 -o json
 
 # Validate CRA compliance
 sbom-tools validate sbom.json --standard cra -o sarif -O compliance.sarif
+
+# Export existing validation findings as OSCAL assessment results
+sbom-tools validate sbom.json --standard ntia \
+  -o oscal-json -O validation-results.oscal.json
 
 # Check for vulnerable Log4j versions across all SBOMs (exits 1 if found)
 sbom-tools query "log4j" --version "<2.17.0" fleet/*.json -o json

--- a/docs/USER_JOURNEYS.md
+++ b/docs/USER_JOURNEYS.md
@@ -120,6 +120,25 @@ jq '.summary' /tmp/release-diff.json
 ```
 
 Use `-o sarif` when the result will be uploaded to a code-scanning system.
+Use `-o oscal-json` when assessment tooling needs the same validation findings
+as an OSCAL 1.1.2 `assessment-results` document:
+
+```sh
+cargo run --release -- validate \
+  tests/fixtures/cyclonedx/minimal.cdx.json \
+  --standard ntia \
+  -o oscal-json \
+  -O /tmp/validation-results.oscal.json
+
+jq '."assessment-results" | {
+  oscal_version: .metadata."oscal-version",
+  result_count: (.results | length),
+  finding_count: (.results[0].findings | length)
+}' /tmp/validation-results.oscal.json
+```
+
+The export maps existing findings; it does not generate an assessment plan,
+SSP, authorization package, attestation, or evidence absent from the BOM.
 
 ### 3. Apply explicit CI gates
 

--- a/src/cli/validate.rs
+++ b/src/cli/validate.rs
@@ -179,6 +179,9 @@ fn write_compliance_output(
         ReportFormat::Json => serde_json::to_string_pretty(result)
             .map_err(|e| anyhow::anyhow!("Failed to serialize compliance JSON: {e}"))?,
         ReportFormat::Sarif => generate_compliance_sarif(result)?,
+        ReportFormat::OscalJson => {
+            crate::reports::oscal::generate_assessment_results(std::slice::from_ref(result))?
+        }
         _ => format_compliance_text(result),
     };
 
@@ -233,6 +236,7 @@ fn write_multi_compliance_output(
         ReportFormat::Json => serde_json::to_string_pretty(results)
             .map_err(|e| anyhow::anyhow!("Failed to serialize compliance JSON: {e}"))?,
         ReportFormat::Sarif => crate::reports::generate_multi_compliance_sarif(results)?,
+        ReportFormat::OscalJson => crate::reports::oscal::generate_assessment_results(results)?,
         _ => {
             let mut parts = Vec::new();
             for result in results {

--- a/src/main.rs
+++ b/src/main.rs
@@ -471,6 +471,7 @@ EXAMPLES:
     sbom-tools validate app.cdx.json                              # NTIA minimum
     sbom-tools validate app.cdx.json --standard cra,eo14028       # Multi-standard
     sbom-tools validate app.cdx.json --standard ntia -o sarif     # SARIF for CI
+    sbom-tools validate app.cdx.json --standard ntia -o oscal-json # OSCAL assessment results
     sbom-tools validate app.cdx.json --fail-on-warning            # Strict CI gate")]
 struct ValidateArgs {
     /// Path to the SBOM file

--- a/src/reports/mod.rs
+++ b/src/reports/mod.rs
@@ -22,6 +22,7 @@ pub mod escape;
 mod html;
 mod json;
 mod markdown;
+pub mod oscal;
 mod sarif;
 mod sidebyside;
 pub mod streaming;
@@ -219,6 +220,7 @@ pub fn create_reporter_with_options(
         }
         ReportFormat::Json | ReportFormat::Tui => Box::new(JsonReporter::new()), // TUI uses JSON internally
         ReportFormat::Sarif => Box::new(SarifReporter::new()),
+        ReportFormat::OscalJson => Box::new(JsonReporter::new()),
         ReportFormat::Markdown => Box::new(MarkdownReporter::new()),
         ReportFormat::Html => Box::new(HtmlReporter::new()),
         ReportFormat::SideBySide => Box::new(SideBySideReporter::new()),

--- a/src/reports/oscal.rs
+++ b/src/reports/oscal.rs
@@ -1,0 +1,202 @@
+//! OSCAL assessment-results export for compliance validation findings.
+
+use crate::quality::{ComplianceResult, Violation, ViolationSeverity};
+use anyhow::Result;
+use chrono::{DateTime, SecondsFormat, Utc};
+use serde_json::{Value, json};
+use uuid::Uuid;
+
+const OSCAL_VERSION: &str = "1.1.2";
+const ASSESSMENT_PLAN_URN: &str = "urn:sbom-tools:assessment-plan:validation";
+
+/// Generate an OSCAL 1.1.2 assessment-results JSON document.
+pub fn generate_assessment_results(results: &[ComplianceResult]) -> Result<String> {
+    build_assessment_results(results, Utc::now(), &mut Uuid::new_v4)
+}
+
+fn build_assessment_results(
+    results: &[ComplianceResult],
+    timestamp: DateTime<Utc>,
+    uuid: &mut impl FnMut() -> Uuid,
+) -> Result<String> {
+    let collected = timestamp.to_rfc3339_opts(SecondsFormat::Secs, true);
+    let mut observations = Vec::new();
+    let mut findings = Vec::new();
+    for result in results {
+        for violation in &result.violations {
+            let observation_uuid = uuid();
+            observations.push(observation(violation, observation_uuid, &collected));
+            findings.push(finding(violation, observation_uuid, uuid()));
+        }
+    }
+
+    let mut assessment = json!({
+        "uuid": uuid(),
+        "title": "sbom-tools validation assessment",
+        "description": "Validation results derived only from the supplied SBOM.",
+        "start": collected,
+        "reviewed-controls": {
+            "control-selections": [{
+                "description": "Controls represented by the selected sbom-tools validation standards.",
+                "include-all": {}
+            }]
+        }
+    });
+    if !observations.is_empty() {
+        assessment["observations"] = Value::Array(observations);
+        assessment["findings"] = Value::Array(findings);
+    }
+
+    Ok(serde_json::to_string_pretty(&json!({
+        "assessment-results": {
+            "uuid": uuid(),
+            "metadata": {
+                "title": "sbom-tools validation assessment results",
+                "last-modified": collected,
+                "version": env!("CARGO_PKG_VERSION"),
+                "oscal-version": OSCAL_VERSION
+            },
+            "import-ap": { "href": ASSESSMENT_PLAN_URN },
+            "results": [assessment]
+        }
+    }))?)
+}
+
+fn observation(violation: &Violation, uuid: Uuid, collected: &str) -> Value {
+    let mut props = vec![
+        json!({
+            "name": "severity",
+            "ns": "https://sbom.tools/ns/oscal",
+            "value": severity(violation.severity)
+        }),
+        json!({
+            "name": "standard-reference",
+            "ns": "https://sbom.tools/ns/oscal",
+            "value": violation.requirement
+        }),
+    ];
+    if let Some(element) = &violation.element {
+        props.push(json!({
+            "name": "sbom-element",
+            "ns": "https://sbom.tools/ns/oscal",
+            "value": element
+        }));
+    }
+    json!({
+        "uuid": uuid,
+        "title": violation.rule_id,
+        "description": violation.message,
+        "methods": ["EXAMINE"],
+        "types": ["finding"],
+        "collected": collected,
+        "props": props
+    })
+}
+
+fn finding(violation: &Violation, observation_uuid: Uuid, uuid: Uuid) -> Value {
+    json!({
+        "uuid": uuid,
+        "title": violation.rule_id,
+        "description": violation.message,
+        "target": {
+            "type": "objective-id",
+            "target-id": violation.rule_id.to_ascii_lowercase(),
+            "status": {
+                "state": match violation.severity {
+                    ViolationSeverity::Info => "other-than-satisfied",
+                    ViolationSeverity::Warning | ViolationSeverity::Error => "not-satisfied"
+                }
+            }
+        },
+        "related-observations": [{ "observation-uuid": observation_uuid }]
+    })
+}
+
+const fn severity(value: ViolationSeverity) -> &'static str {
+    match value {
+        ViolationSeverity::Error => "error",
+        ViolationSeverity::Warning => "warning",
+        ViolationSeverity::Info => "info",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_assessment_results;
+    use crate::quality::{
+        ComplianceLevel, ComplianceResult, Violation, ViolationCategory, ViolationSeverity,
+    };
+    use chrono::{TimeZone, Utc};
+    use uuid::Uuid;
+
+    fn violation(message: &str) -> Violation {
+        Violation {
+            severity: ViolationSeverity::Error,
+            category: ViolationCategory::DocumentMetadata,
+            message: message.to_string(),
+            element: Some("metadata".to_string()),
+            requirement: "NTIA minimum elements".to_string(),
+            rule_id: "SBOM-NTIA-METADATA",
+            standard_refs: Vec::new(),
+        }
+    }
+
+    fn result(violations: Vec<Violation>) -> ComplianceResult {
+        ComplianceResult {
+            is_compliant: violations.is_empty(),
+            level: ComplianceLevel::NtiaMinimum,
+            error_count: violations.len(),
+            warning_count: 0,
+            info_count: 0,
+            violations,
+            conformity_summary: None,
+        }
+    }
+
+    fn build(results: &[ComplianceResult]) -> serde_json::Value {
+        let timestamp = Utc
+            .with_ymd_and_hms(2026, 7, 1, 12, 0, 0)
+            .single()
+            .expect("valid timestamp");
+        let mut next = 0u128;
+        let json = build_assessment_results(results, timestamp, &mut || {
+            next += 1;
+            Uuid::from_u128(next)
+        })
+        .expect("OSCAL serialization");
+        serde_json::from_str(&json).expect("valid JSON")
+    }
+
+    #[test]
+    fn empty_result_omits_observations_and_findings() {
+        let document = build(&[result(Vec::new())]);
+        let assessment = &document["assessment-results"]["results"][0];
+        assert!(assessment.get("observations").is_none());
+        assert!(assessment.get("findings").is_none());
+    }
+
+    #[test]
+    fn single_finding_links_to_its_observation() {
+        let document = build(&[result(vec![violation("missing metadata")])]);
+        let assessment = &document["assessment-results"]["results"][0];
+        assert_eq!(assessment["observations"].as_array().map(Vec::len), Some(1));
+        assert_eq!(assessment["findings"].as_array().map(Vec::len), Some(1));
+        assert_eq!(
+            assessment["findings"][0]["related-observations"][0]["observation-uuid"],
+            assessment["observations"][0]["uuid"]
+        );
+    }
+
+    #[test]
+    fn multiple_findings_are_emitted_in_input_order() {
+        let document = build(&[result(vec![violation("first"), violation("second")])]);
+        let assessment = &document["assessment-results"]["results"][0];
+        assert_eq!(assessment["observations"].as_array().map(Vec::len), Some(2));
+        assert_eq!(assessment["findings"][0]["description"], "first");
+        assert_eq!(assessment["findings"][1]["description"], "second");
+        assert_eq!(
+            document["assessment-results"]["metadata"]["last-modified"],
+            "2026-07-01T12:00:00Z"
+        );
+    }
+}

--- a/src/reports/oscal.rs
+++ b/src/reports/oscal.rs
@@ -102,10 +102,12 @@ fn finding(violation: &Violation, observation_uuid: Uuid, uuid: Uuid) -> Value {
             "type": "objective-id",
             "target-id": violation.rule_id.to_ascii_lowercase(),
             "status": {
-                "state": match violation.severity {
-                    ViolationSeverity::Info => "other-than-satisfied",
-                    ViolationSeverity::Warning | ViolationSeverity::Error => "not-satisfied"
-                }
+                // OSCAL 1.1.2 finding-target status `state` is a closed enum
+                // (satisfied | not-satisfied, no allow-other). Any violation —
+                // regardless of severity — is a non-satisfied objective; the
+                // severity detail is carried separately in the observation's
+                // custom `severity` property.
+                "state": "not-satisfied"
             }
         },
         "related-observations": [{ "observation-uuid": observation_uuid }]
@@ -198,5 +200,34 @@ mod tests {
             document["assessment-results"]["metadata"]["last-modified"],
             "2026-07-01T12:00:00Z"
         );
+    }
+
+    #[test]
+    fn finding_status_state_is_valid_oscal_token_for_every_severity() {
+        // OSCAL 1.1.2 finding-target status `state` is a CLOSED enum:
+        // only "satisfied" / "not-satisfied" (no allow-other). Every violation
+        // is a non-satisfied objective regardless of severity. This guards the
+        // Info/Warning branches that the other tests (Error-only) never reach.
+        let with_severity = |message: &str, severity: ViolationSeverity| Violation {
+            severity,
+            category: ViolationCategory::DocumentMetadata,
+            message: message.to_string(),
+            element: Some("metadata".to_string()),
+            requirement: "NTIA minimum elements".to_string(),
+            rule_id: "SBOM-NTIA-METADATA",
+            standard_refs: Vec::new(),
+        };
+        let document = build(&[result(vec![
+            with_severity("info finding", ViolationSeverity::Info),
+            with_severity("warning finding", ViolationSeverity::Warning),
+            with_severity("error finding", ViolationSeverity::Error),
+        ])]);
+        let findings = document["assessment-results"]["results"][0]["findings"]
+            .as_array()
+            .expect("findings array");
+        assert_eq!(findings.len(), 3);
+        for finding in findings {
+            assert_eq!(finding["target"]["status"]["state"], "not-satisfied");
+        }
     }
 }

--- a/src/reports/types.rs
+++ b/src/reports/types.rs
@@ -22,6 +22,8 @@ pub enum ReportFormat {
     Json,
     /// SARIF 2.1.0 for CI/CD
     Sarif,
+    /// OSCAL 1.1.2 assessment-results JSON
+    OscalJson,
     /// Human-readable Markdown
     Markdown,
     /// Interactive HTML report
@@ -44,6 +46,7 @@ impl std::fmt::Display for ReportFormat {
             Self::SideBySide => write!(f, "side-by-side"),
             Self::Json => write!(f, "json"),
             Self::Sarif => write!(f, "sarif"),
+            Self::OscalJson => write!(f, "oscal-json"),
             Self::Markdown => write!(f, "markdown"),
             Self::Html => write!(f, "html"),
             Self::Summary => write!(f, "summary"),


### PR DESCRIPTION
## Summary

Adds `oscal-json` output for existing `sbom-tools validate` findings as an OSCAL 1.1.2 `assessment-results` document.

## Behavior

- Preserves all existing validation rules and exit behavior.
- Maps each violation to an `EXAMINE` observation and a linked finding.
- Carries rule ID, message, severity, standard requirement, and SBOM element when available.
- Uses custom namespaced properties instead of extending the OSCAL schema.
- Emits empty assessment results without inventing findings.
- Supports single- and multi-standard validation output.
- Does not generate an SSP, assessment plan, authorization package, attestation, risk, or evidence absent from the BOM.

## Documentation

- Adds `oscal-json` to the output-format reference.
- Adds a runnable assessment-results export to the developer journey.
- Documents the neutral upstream responsibility boundary.

## Verification

- `cargo fmt --all -- --check`
- `cargo test --locked reports::oscal --all-features`
- `cargo clippy -- -D warnings`
- `cargo clippy --all-features -- -D warnings`
- `cargo test --locked`
  - 1,017 library tests passed
  - all integration and doc-test targets passed
  - one pre-existing large-fixture test remained explicitly ignored
- Documented CLI command run against `minimal.cdx.json`
- Generated document validated against NIST OSCAL 1.1.2 `oscal_assessment-results_schema.json`
- `markdownlint-cli2 docs/USER_JOURNEYS.md` — 0 errors
- `git diff --check`

Closes MChorfa/sbom-tools#3.
