### PR TITLE
fix(deps): bump quick-xml to 0.41 to fix RUSTSEC-2026-0194/0195

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2251,9 +2251,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml_ng = "0.10"
-quick-xml = { version = "0.40", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 
 # TUI (ratatui ecosystem) — gated behind the `tui` feature
 ratatui = { version = "0.30", features = ["crossterm"], optional = true }


### PR DESCRIPTION
## Summary

Bumps `quick-xml` **0.40.1 → 0.41.0** to remediate two advisories published 2026-07-02 that currently fail `cargo-deny (advisories)` / `Security audit` / the required `CI` gate on every open PR:

- **RUSTSEC-2026-0194** — quadratic run time when checking a start tag for duplicate attribute names.
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader` enabling a memory-exhaustion DoS.

Both are fixed in `0.41.0`.

## Impact

Source-compatible for our usage — no code changes required:
- `src/parsers/spdx.rs` (streaming `Reader` + `read_event_into`)
- `src/parsers/cyclonedx.rs` (`quick_xml::de::from_str`)
- `src/tui/app_states/source.rs` (streaming `Reader` + `read_event`)

## Verification

- `cargo check --all-features` — clean, 0 errors
- `cargo test --all-features --lib parsers` — 35 passed (all SPDX/CycloneDX XML paths)

Unblocks #279, #280, #281, #282, #283, #284 once merged (they must be rebased onto this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
