### PR TITLE
fix(tui): make high-contrast selection visible (was white-on-white)

### DIFF
--- a/src/tui/theme.rs
+++ b/src/tui/theme.rs
@@ -277,7 +277,10 @@ impl ColorScheme {
             background_alt: Color::Rgb(20, 20, 20),
             text: Color::White,
             text_muted: Color::Gray,
-            selection: Color::White,
+            // `selection` is used as a row *background* (with `.fg(text)`), and text is
+            // White here — so a White selection made selected rows invisible. Use a
+            // distinct dark blue-grey that stays readable under White text.
+            selection: Color::Rgb(80, 80, 120),
             highlight: Color::LightYellow,
 
             // Status
@@ -972,4 +975,32 @@ pub fn render_footer_hints(hints: &[(&str, &str)]) -> Vec<Span<'static>> {
     }
 
     spans
+}
+
+#[cfg(test)]
+mod selection_contrast_tests {
+    use super::ColorScheme;
+
+    /// `selection` is always applied as a row *background* (paired with `.fg(text)`),
+    /// so in every theme it must differ from both `text` (else the selected row's text
+    /// is invisible) and `background` (else the selection bar itself is invisible).
+    /// Regression guard for the high-contrast White-on-White selection bug.
+    fn assert_selection_visible(name: &str, s: &ColorScheme) {
+        assert_ne!(
+            s.selection, s.text,
+            "{name}: selection == text — selected rows would be invisible"
+        );
+        assert_ne!(
+            s.selection, s.background,
+            "{name}: selection == background — the selection bar would be invisible"
+        );
+    }
+
+    #[test]
+    fn selection_is_visible_in_every_theme() {
+        assert_selection_visible("default", &ColorScheme::default());
+        assert_selection_visible("dark", &ColorScheme::dark());
+        assert_selection_visible("light", &ColorScheme::light());
+        assert_selection_visible("high_contrast", &ColorScheme::high_contrast());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes an accessibility bug: `ColorScheme::high_contrast()` set `selection: Color::White` while `text` is also `Color::White`. Since `selection` is applied as a **row background** (paired with `.fg(text)`) at ~30 render sites, the **selected row was invisible in the high-contrast theme** — the one theme intended for accessibility.

## Change

- `src/tui/theme.rs` — `high_contrast().selection`: `Color::White` → `Color::Rgb(80, 80, 120)` (a distinct dark blue-grey, readable under White text; consistent with the dark theme's `Rgb(50,50,70)`).
- Adds a regression test asserting `selection != text` **and** `selection != background` for every theme (default/dark/light/high-contrast), so this class of bug can't recur.

## Verification

- `cargo test --features tui --lib theme::` — passes (fails if reverted to White).
- `cargo test --features tui --lib render_snapshot` — **25/25 unchanged** (snapshots render under the default theme; this touches only high-contrast).

Part of the TUI improvement plan (item **P0-2**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
