### PR TITLE
fix(tui): consolidate truncation on width-aware helper; kill UTF-8 render panics

### DIFF
--- a/src/tui/view/ui/snapshots/sbom_tools__tui__view__ui__render_snapshot_tests__view_compliance_80x24.snap
+++ b/src/tui/view/ui/snapshots/sbom_tools__tui__view__ui__render_snapshot_tests__view_compliance_80x24.snap
@@ -1,5 +1,6 @@
 ---
 source: src/tui/view/ui/render_snapshot_tests.rs
+assertion_line: 71
 expression: text
 ---
 sbom-tools  VIEW  │ acme-webapp │ CycloneDX 1.5 │ [SBOM]
@@ -12,7 +13,7 @@ sbom-tools  VIEW  │ acme-webapp │ CycloneDX 1.5 │ [SBOM]
 ┌ NTIA Minimum Elements ───────────────────────────────┐┌ Summary ─────────────┐
 └──────────────────────────────────────────────────────┘└──────────────────────┘
 ┌ Violations (grouped: 4 patterns, 20 total┐┌ Affected (9) K/J scroll ─────────┐
-│Severi Catego Issue Pattern        Count  ││  Component  missing supplier/ma… █
+│Severi Catego Issue Pattern        Count  ││  Component  missing supplier/... █
 │                                          ││  9 named                         █
 │ERROR  Suppli Component  missing s 9      ││  ──────────────────────────────  █
 │ERROR  Doc Me SBOM must have creat 1      ││  zod                             █

--- a/src/tui/view/views/compliance.rs
+++ b/src/tui/view/views/compliance.rs
@@ -657,11 +657,7 @@ fn render_affected_elements(
     let mut content_lines: Vec<Line> = Vec::new();
 
     // --- Line 1: pattern header ---
-    let pattern_display = if group.pattern.len() > max_width {
-        format!("{}\u{2026}", &group.pattern[..max_width.saturating_sub(1)])
-    } else {
-        group.pattern.clone()
-    };
+    let pattern_display = crate::tui::widgets::truncate_str(&group.pattern, max_width);
     content_lines.push(Line::from(vec![Span::styled(
         format!("  {pattern_display}"),
         Style::default().fg(scheme.warning).italic(),
@@ -780,11 +776,7 @@ fn render_affected_elements(
         dir_sorted.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)));
 
         for (dir, file_count) in &dir_sorted {
-            let dir_display = if dir.len() > max_width.saturating_sub(12) {
-                format!("{}\u{2026}", &dir[..max_width.saturating_sub(13)])
-            } else {
-                dir.clone()
-            };
+            let dir_display = crate::tui::widgets::truncate_str(dir, max_width.saturating_sub(12));
             content_lines.push(Line::from(vec![
                 Span::styled(
                     format!("    {dir_display}"),

--- a/src/tui/view/views/tree.rs
+++ b/src/tui/view/views/tree.rs
@@ -624,11 +624,7 @@ fn render_identifiers_tab(
             Style::default().fg(scheme.accent).bold(),
         ));
         // Wrap long PURLs across multiple lines
-        let purl_display = if purl.len() > width - 6 {
-            format!("{}...", &purl[..width.saturating_sub(9)])
-        } else {
-            purl.clone()
-        };
+        let purl_display = crate::tui::widgets::truncate_str(purl, width.saturating_sub(6));
         lines.push(Line::from(vec![
             Span::styled("  ", Style::default()),
             Span::raw(purl_display),

--- a/src/tui/views/graph_changes.rs
+++ b/src/tui/views/graph_changes.rs
@@ -234,8 +234,11 @@ fn render_changes_table(
         .map(|change| {
             let impact_cell = impact_cell(change.impact);
             let type_cell = change_type_cell(&change.change);
-            let component_cell = Cell::from(crate::tui::widgets::truncate_str(&change.component_name, 30))
-                .style(Style::default().fg(colors().text));
+            let component_cell = Cell::from(crate::tui::widgets::truncate_str(
+                &change.component_name,
+                30,
+            ))
+            .style(Style::default().fg(colors().text));
             let details_cell = details_cell(&change.change);
 
             Row::new(vec![impact_cell, type_cell, component_cell, details_cell])
@@ -464,12 +467,18 @@ fn details_cell(change: &DependencyChangeType) -> Cell<'static> {
         DependencyChangeType::DependencyAdded {
             dependency_name, ..
         } => {
-            format!("Added dependency: {}", crate::tui::widgets::truncate_str(dependency_name, 40))
+            format!(
+                "Added dependency: {}",
+                crate::tui::widgets::truncate_str(dependency_name, 40)
+            )
         }
         DependencyChangeType::DependencyRemoved {
             dependency_name, ..
         } => {
-            format!("Removed dependency: {}", crate::tui::widgets::truncate_str(dependency_name, 40))
+            format!(
+                "Removed dependency: {}",
+                crate::tui::widgets::truncate_str(dependency_name, 40)
+            )
         }
         DependencyChangeType::RelationshipChanged {
             dependency_name,

--- a/src/tui/views/graph_changes.rs
+++ b/src/tui/views/graph_changes.rs
@@ -234,7 +234,7 @@ fn render_changes_table(
         .map(|change| {
             let impact_cell = impact_cell(change.impact);
             let type_cell = change_type_cell(&change.change);
-            let component_cell = Cell::from(truncate(&change.component_name, 30))
+            let component_cell = Cell::from(crate::tui::widgets::truncate_str(&change.component_name, 30))
                 .style(Style::default().fg(colors().text));
             let details_cell = details_cell(&change.change);
 
@@ -464,12 +464,12 @@ fn details_cell(change: &DependencyChangeType) -> Cell<'static> {
         DependencyChangeType::DependencyAdded {
             dependency_name, ..
         } => {
-            format!("Added dependency: {}", truncate(dependency_name, 40))
+            format!("Added dependency: {}", crate::tui::widgets::truncate_str(dependency_name, 40))
         }
         DependencyChangeType::DependencyRemoved {
             dependency_name, ..
         } => {
-            format!("Removed dependency: {}", truncate(dependency_name, 40))
+            format!("Removed dependency: {}", crate::tui::widgets::truncate_str(dependency_name, 40))
         }
         DependencyChangeType::RelationshipChanged {
             dependency_name,
@@ -479,9 +479,9 @@ fn details_cell(change: &DependencyChangeType) -> Cell<'static> {
         } => {
             format!(
                 "{}: {} \u{2192} {}",
-                truncate(dependency_name, 20),
-                truncate(old_relationship, 15),
-                truncate(new_relationship, 15)
+                crate::tui::widgets::truncate_str(dependency_name, 20),
+                crate::tui::widgets::truncate_str(old_relationship, 15),
+                crate::tui::widgets::truncate_str(new_relationship, 15)
             )
         }
         DependencyChangeType::Reparented {
@@ -491,8 +491,8 @@ fn details_cell(change: &DependencyChangeType) -> Cell<'static> {
         } => {
             format!(
                 "{} \u{2192} {}",
-                truncate(old_parent_name, 20),
-                truncate(new_parent_name, 20)
+                crate::tui::widgets::truncate_str(old_parent_name, 20),
+                crate::tui::widgets::truncate_str(new_parent_name, 20)
             )
         }
         DependencyChangeType::DepthChanged {
@@ -523,14 +523,4 @@ fn details_cell(change: &DependencyChangeType) -> Cell<'static> {
         }
     };
     Cell::from(text).style(Style::default().fg(colors().text))
-}
-
-fn truncate(s: &str, max_len: usize) -> String {
-    if s.chars().count() <= max_len {
-        s.to_string()
-    } else if max_len > 3 {
-        format!("{}...", s.chars().take(max_len - 3).collect::<String>())
-    } else {
-        s.chars().take(max_len).collect()
-    }
 }

--- a/src/tui/views/sidebyside.rs
+++ b/src/tui/views/sidebyside.rs
@@ -605,12 +605,8 @@ fn render_unified_mode(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
         let name_style = Style::default().fg(row_color);
         let version_style = Style::default().fg(scheme.text);
 
-        // Component name (truncated)
-        let name_display = if entry.name.len() > name_width as usize {
-            format!("{}..", &entry.name[..name_width as usize - 2])
-        } else {
-            format!("{:<width$}", entry.name, width = name_width as usize)
-        };
+        // Component name (truncated — width-aware, char-boundary-safe)
+        let name_display = crate::tui::widgets::truncate_str(&entry.name, name_width as usize);
         buf.set_string(x + col_name, y, &name_display, name_style);
 
         // Old version

--- a/src/tui/views/summary.rs
+++ b/src/tui/views/summary.rs
@@ -1344,7 +1344,7 @@ fn render_policy_compact(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
                 Style::default().fg(scheme.border),
             ));
             spans.push(Span::styled(
-                truncate(&violation.description, 50),
+                crate::tui::widgets::truncate_str(&violation.description, 50),
                 Style::default().fg(scheme.text_muted).italic(),
             ));
         }
@@ -1500,7 +1500,7 @@ fn render_ecosystem_breakdown_chart(
         .map(|(i, (name, count))| {
             Bar::default()
                 .value(*count)
-                .label(Line::from(truncate(name, 8).to_string()))
+                .label(Line::from(crate::tui::widgets::truncate_str(name, 8)))
                 .style(Style::default().fg(palette[i % palette.len()]))
         })
         .collect();
@@ -1767,7 +1767,7 @@ fn render_all_changes(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
                 Span::styled(
                     vuln.description
                         .as_ref()
-                        .map(|d| format!(" - {}", truncate(d, 40)))
+                        .map(|d| format!(" - {}", crate::tui::widgets::truncate_str(d, 40)))
                         .unwrap_or_default(),
                     Style::default().fg(scheme.muted),
                 ),
@@ -1989,13 +1989,6 @@ fn render_all_changes(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
     frame.render_widget(paragraph, area);
 }
 
-fn truncate(s: &str, max_len: usize) -> &str {
-    if s.len() <= max_len {
-        s
-    } else {
-        &s[..max_len.saturating_sub(3)]
-    }
-}
 
 enum VersionLevel {
     Patch,

--- a/src/tui/views/summary.rs
+++ b/src/tui/views/summary.rs
@@ -1989,7 +1989,6 @@ fn render_all_changes(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
     frame.render_widget(paragraph, area);
 }
 
-
 enum VersionLevel {
     Patch,
     Minor,

--- a/src/tui/widgets/mod.rs
+++ b/src/tui/widgets/mod.rs
@@ -303,3 +303,49 @@ pub fn render_size_warning(
 
     frame.render_widget(paragraph, area);
 }
+
+#[cfg(test)]
+mod truncate_str_tests {
+    use super::truncate_str;
+    use unicode_width::UnicodeWidthStr;
+
+    #[test]
+    fn shorter_than_max_is_unchanged() {
+        assert_eq!(truncate_str("hello", 10), "hello");
+        assert_eq!(truncate_str("hello", 5), "hello");
+    }
+
+    #[test]
+    fn longer_ascii_gets_ellipsis_at_exact_width() {
+        assert_eq!(truncate_str("abcdefghij", 8), "abcde..."); // 5 + "..." == 8
+    }
+
+    #[test]
+    fn multibyte_never_panics_and_stays_within_width() {
+        // Accented Latin: each char is 1 display col but 2 bytes — byte-slicing
+        // at a non-char boundary used to panic here.
+        let out = truncate_str("café-latté-münchen", 6);
+        assert!(UnicodeWidthStr::width(out.as_str()) <= 6);
+        assert!(out.ends_with("..."));
+    }
+
+    #[test]
+    fn cjk_double_width_is_counted_as_two_cells() {
+        let out = truncate_str("字符串截断测试", 7);
+        assert!(UnicodeWidthStr::width(out.as_str()) <= 7);
+    }
+
+    #[test]
+    fn emoji_stays_within_width() {
+        let out = truncate_str("🚀🚀🚀🚀🚀", 5);
+        assert!(UnicodeWidthStr::width(out.as_str()) <= 5);
+    }
+
+    #[test]
+    fn tiny_and_zero_max_width_do_not_panic_or_ellipsize() {
+        assert_eq!(truncate_str("hello", 0), "");
+        let out = truncate_str("hello", 2);
+        assert!(UnicodeWidthStr::width(out.as_str()) <= 2);
+        assert!(!out.contains("...")); // max_width <= 3 => no ellipsis
+    }
+}

--- a/src/tui/widgets/tree.rs
+++ b/src/tui/widgets/tree.rs
@@ -507,22 +507,12 @@ impl StatefulWidget for Tree<'_> {
             };
             let remaining = (area.x + area.width).saturating_sub(x + vuln_badge_width) as usize;
 
-            let display_label = if item.label.len() > remaining && remaining > 3 {
-                let max_chars = remaining.saturating_sub(3);
-                let truncated: String = item.label.chars().take(max_chars).collect();
-                format!("{truncated}...")
-            } else {
-                item.label.clone()
-            };
-
-            for ch in display_label.chars() {
-                if x < area.x + area.width {
-                    if let Some(cell) = buf.cell_mut((x, y)) {
-                        cell.set_char(ch).set_style(label_style);
-                    }
-                    x += 1;
-                }
-            }
+            // Width-aware truncation + placement: set_stringn caps at `remaining`
+            // display cells and correctly advances past double-width glyphs, so the
+            // vuln badge can no longer be overrun by CJK/emoji labels.
+            let display_label = super::truncate_str(&item.label, remaining);
+            let (new_x, _) = buf.set_stringn(x, y, &display_label, remaining, label_style);
+            x = new_x;
 
             // Vulnerability indicator with severity badge
             if item.vuln_count > 0 {


### PR DESCRIPTION
## Summary

Eliminates two crash bugs where the TUI sliced strings at **raw byte offsets inside `terminal.draw`**, panicking on multi-byte UTF-8 (accented / CJK / emoji text in CVE descriptions, component names, file paths — realistic SBOM content), and consolidates all TUI truncation onto the existing width-aware `widgets::truncate_str`.

## Confirmed panics fixed

- `views/summary.rs` — `truncate()` did `&s[..max_len-3]` (byte slice; also never appended the `...` ellipsis).
- `views/sidebyside.rs` — unified name column did `&entry.name[..name_width-2]` (byte slice; **also** underflowed to a huge index on terminals ≤42 columns wide).

## Changes

- Both panic sites now call `widgets::truncate_str` (char- + display-width aware, ellipsis-appending — already used at ~40 sites).
- `widgets/tree.rs`: replaced the byte-length truncate + per-char `x += 1` placement with `truncate_str` + `Buffer::set_stringn`, so **double-width CJK/emoji labels no longer overrun the vulnerability badge**.
- `views/graph_changes.rs`: dropped its char-count-only local `truncate()`, routed callers through `truncate_str` (display-width correct; ASCII-identical output).
- `view/views/{compliance,tree}.rs`: replaced the remaining `…` byte-slice truncations (pattern/dir/purl) — this also removes a **non-saturating `width - 6`** that could underflow/panic on very narrow panels.

## Verification

- `cargo build --features tui` — clean, no warnings.
- New `truncate_str` unit tests (multi-byte, CJK, emoji, zero/tiny width, boundary) — **6/6 pass**.
- `cargo test --features tui --lib render_snapshot` — **25/25 pass**. Only the `view_compliance_80x24` snapshot changed (`…` → `...` on `group.pattern`, width re-accounted); summary/sidebyside/tree/graph snapshots are byte-identical (ASCII fixtures don't truncate).

TUI improvement plan item **P0-1**. Follow-up (tracked): a render-level smoke test over a multi-byte fixture, and the effectively-ASCII `hash.value[..16]` slices left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
