### PR TITLE
fix(tui): derive mouse tab-click regions from the real rendered tab set

### DIFF
--- a/src/tui/events/mouse.rs
+++ b/src/tui/events/mouse.rs
@@ -32,22 +32,18 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent) {
                 return;
             }
 
-            // Tab bar is typically in the first 2 rows
+            // Tab bar is in the first rows. Derive the clicked tab from the real
+            // rendered tab set + geometry so every profile/mode tab is reachable
+            // (the old fixed-13-col estimate mis-selected once Compliance/Graph/
+            // Source were present).
             if y <= 2 {
-                // Estimate tab positions based on typical widths
-                let tab_width = 13;
-                let tab_index = (x as usize) / tab_width;
-                match tab_index {
-                    0 => app.select_tab(crate::tui::TabKind::Summary),
-                    1 => app.select_tab(crate::tui::TabKind::Components),
-                    2 => app.select_tab(crate::tui::TabKind::Dependencies),
-                    3 => app.select_tab(crate::tui::TabKind::Licenses),
-                    4 => app.select_tab(crate::tui::TabKind::Vulnerabilities),
-                    5 => app.select_tab(crate::tui::TabKind::Quality),
-                    6 if app.mode == AppMode::Diff => {
-                        app.select_tab(crate::tui::TabKind::SideBySide);
-                    }
-                    _ => {}
+                let entries = crate::tui::ui::diff_tab_entries(app);
+                let labels: Vec<String> = entries
+                    .iter()
+                    .map(|(_, key, title)| crate::tui::ui::diff_tab_label(key, title))
+                    .collect();
+                if let Some(idx) = crate::tui::shared::tab_bar_hit(&labels, 0, 3, x) {
+                    app.select_tab(entries[idx].0);
                 }
                 return;
             }

--- a/src/tui/shared/mod.rs
+++ b/src/tui/shared/mod.rs
@@ -73,7 +73,12 @@ pub(crate) const fn floor_char_boundary(s: &str, index: usize) -> usize {
 /// last — so callers derive hit regions from the real tab set instead of guessing a
 /// fixed width.
 #[must_use]
-pub fn tab_bar_hit(labels: &[String], left: u16, divider_width: u16, click_x: u16) -> Option<usize> {
+pub fn tab_bar_hit(
+    labels: &[String],
+    left: u16,
+    divider_width: u16,
+    click_x: u16,
+) -> Option<usize> {
     use unicode_width::UnicodeWidthStr;
 
     if click_x < left {

--- a/src/tui/shared/mod.rs
+++ b/src/tui/shared/mod.rs
@@ -61,3 +61,75 @@ pub(crate) const fn floor_char_boundary(s: &str, index: usize) -> usize {
         i
     }
 }
+
+/// Map a click column to a tab index for a `ratatui` `Tabs` bar.
+///
+/// `Tabs` renders each tab as `left_pad(1) + title + right_pad(1)` starting at column
+/// `left`, joining consecutive tabs with a `divider_width`-column divider (the default
+/// padding is a single space on each side — see `ratatui`'s `Tabs`). `labels` are the
+/// tab-title strings exactly as rendered, with brackets and inner spaces baked in
+/// (e.g. `"[1] Summary "`). Returns the index of the tab whose rendered span contains
+/// `click_x`, or `None` for a click on a divider, before the first tab, or past the
+/// last — so callers derive hit regions from the real tab set instead of guessing a
+/// fixed width.
+#[must_use]
+pub fn tab_bar_hit(labels: &[String], left: u16, divider_width: u16, click_x: u16) -> Option<usize> {
+    use unicode_width::UnicodeWidthStr;
+
+    if click_x < left {
+        return None;
+    }
+    let last = labels.len().saturating_sub(1);
+    let mut cursor = left;
+    for (i, label) in labels.iter().enumerate() {
+        // 1-column left pad + title + 1-column right pad.
+        let span = (UnicodeWidthStr::width(label.as_str()) as u16).saturating_add(2);
+        if click_x >= cursor && click_x < cursor.saturating_add(span) {
+            return Some(i);
+        }
+        cursor = cursor.saturating_add(span);
+        if i != last {
+            cursor = cursor.saturating_add(divider_width);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tab_bar_hit_tests {
+    use super::tab_bar_hit;
+
+    #[test]
+    fn maps_clicks_to_tabs_and_rejects_dividers() {
+        // "[1] Summary " => width 12 => span 14 ([0,14)); divider [14,17);
+        // "[2] Components " => width 15 => span 17 ([17,34)).
+        let labels = vec!["[1] Summary ".to_string(), "[2] Components ".to_string()];
+        assert_eq!(tab_bar_hit(&labels, 0, 3, 0), Some(0));
+        assert_eq!(tab_bar_hit(&labels, 0, 3, 13), Some(0));
+        assert_eq!(tab_bar_hit(&labels, 0, 3, 14), None); // divider
+        assert_eq!(tab_bar_hit(&labels, 0, 3, 16), None);
+        assert_eq!(tab_bar_hit(&labels, 0, 3, 17), Some(1));
+        assert_eq!(tab_bar_hit(&labels, 0, 3, 33), Some(1));
+        assert_eq!(tab_bar_hit(&labels, 0, 3, 34), None); // past end
+        assert_eq!(tab_bar_hit(&labels, 0, 3, 200), None);
+    }
+
+    #[test]
+    fn respects_left_offset() {
+        let labels = vec!["[1] A ".to_string()]; // width 6 => span 8
+        assert_eq!(tab_bar_hit(&labels, 5, 3, 4), None); // before left
+        assert_eq!(tab_bar_hit(&labels, 5, 3, 5), Some(0));
+        assert_eq!(tab_bar_hit(&labels, 5, 3, 12), Some(0));
+        assert_eq!(tab_bar_hit(&labels, 5, 3, 13), None);
+    }
+
+    #[test]
+    fn counts_double_width_glyphs() {
+        // "[1] 字 " => width 7 (字 is 2 cells) => span 9 ([0,9)); divider [9,12);
+        // "[2] B " => span 8 ([12,20)).
+        let labels = vec!["[1] 字 ".to_string(), "[2] B ".to_string()];
+        assert_eq!(tab_bar_hit(&labels, 0, 3, 8), Some(0));
+        assert_eq!(tab_bar_hit(&labels, 0, 3, 9), None); // divider
+        assert_eq!(tab_bar_hit(&labels, 0, 3, 12), Some(1));
+    }
+}

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -296,9 +296,13 @@ fn render_header(frame: &mut Frame, area: Rect, app: &App) {
     frame.render_widget(header, area);
 }
 
-fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
-    // Build tabs dynamically based on mode
-    let mut tabs_data: Vec<(TabKind, &str, &str)> = vec![
+/// The ordered `(kind, key, title)` entries shown in the diff-mode tab bar.
+///
+/// Single source of truth for the tab set so rendering ([`render_tabs`]) and mouse
+/// hit-testing (`events::mouse`) cannot drift — the previous hit-test hardcoded a
+/// separate 8-label list and mis-selected in modes with Compliance/Graph/Source.
+pub(crate) fn diff_tab_entries(app: &App) -> Vec<(TabKind, &'static str, &'static str)> {
+    let mut tabs_data: Vec<(TabKind, &'static str, &'static str)> = vec![
         (TabKind::Summary, "1", "Summary"),
         (TabKind::Components, "2", "Components"),
         (TabKind::Dependencies, "3", "Dependencies"),
@@ -307,13 +311,13 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
         (TabKind::Quality, "6", "Quality"),
     ];
 
-    // Add compliance and side-by-side tabs only in diff/view mode
+    // Compliance and side-by-side tabs only in diff/view mode
     if matches!(app.mode, AppMode::Diff | AppMode::View) {
         tabs_data.push((TabKind::Compliance, "7", "Compliance"));
         tabs_data.push((TabKind::SideBySide, "8", "Diff"));
     }
 
-    // Add graph changes tab if graph diff data is available
+    // Graph changes tab only when graph diff data is available
     let has_graph_changes = app
         .data
         .diff_result
@@ -323,12 +327,24 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
         tabs_data.push((TabKind::GraphChanges, "9", "Graph"));
     }
 
-    // Source tab always available in diff/view mode
-    // Use [9] when it's the 9th tab (no graph changes), [0] when it's the 10th
+    // Source tab always available in diff/view mode.
+    // Uses [9] when it's the 9th tab (no graph changes), [0] when it's the 10th.
     if matches!(app.mode, AppMode::Diff | AppMode::View) {
         let source_key = if has_graph_changes { "0" } else { "9" };
         tabs_data.push((TabKind::Source, source_key, "Source"));
     }
+
+    tabs_data
+}
+
+/// The tab-title string as rendered in the bar (`"[key] title "`), used for mouse
+/// hit-testing. Must match the `Line` built in [`render_tabs`].
+pub(crate) fn diff_tab_label(key: &str, title: &str) -> String {
+    format!("[{key}] {title} ")
+}
+
+fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
+    let tabs_data = diff_tab_entries(app);
 
     let titles: Vec<Line> = tabs_data
         .iter()
@@ -352,28 +368,12 @@ fn render_tabs(frame: &mut Frame, area: Rect, app: &App) {
         })
         .collect();
 
-    let selected_idx = match app.active_tab {
-        TabKind::Summary => 0,
-        TabKind::Overview | TabKind::Tree => 0, // Not shown in tab bar yet
-        TabKind::Components => 1,
-        TabKind::Dependencies => 2,
-        TabKind::Licenses => 3,
-        TabKind::Vulnerabilities => 4,
-        TabKind::Quality => 5,
-        TabKind::Compliance => 6,
-        TabKind::SideBySide => 7,
-        TabKind::GraphChanges => {
-            if has_graph_changes {
-                8
-            } else {
-                0
-            }
-        }
-        TabKind::Source => {
-            // Source is after GraphChanges (if present) or SideBySide
-            if has_graph_changes { 9 } else { 8 }
-        }
-    };
+    // Derive selection from the actual entry order (handles the variable
+    // GraphChanges/Source positions without a parallel index table).
+    let selected_idx = tabs_data
+        .iter()
+        .position(|(kind, _, _)| *kind == app.active_tab)
+        .unwrap_or(0);
 
     let tabs = Tabs::new(titles)
         .block(

--- a/src/tui/ui/render_snapshot_tests.rs
+++ b/src/tui/ui/render_snapshot_tests.rs
@@ -411,3 +411,42 @@ mod diff_alignment {
         );
     }
 }
+
+#[test]
+fn diff_tab_click_selects_the_rendered_tab_including_source() {
+    use crate::tui::events::mouse::handle_mouse_event;
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+    use unicode_width::UnicodeWidthStr;
+
+    let mut app = demo_app(TabKind::Summary);
+    // Wide enough that every tab (incl. the rightmost Source) is on-screen.
+    // Tab titles render on row 2 (header Length(2) + Tabs' top row).
+    let text = render_to_text(240, 40, |frame| {
+        app.prepare_render();
+        render(frame, &mut app);
+    });
+    let tab_row = text.lines().nth(2).expect("tab bar row").to_string();
+
+    // Both sit past where the old fixed-13-col estimate placed them; "Source"
+    // (rightmost) was entirely unreachable before this fix.
+    for (needle, expected) in [
+        ("Vulnerabilities", TabKind::Vulnerabilities),
+        ("Source", TabKind::Source),
+    ] {
+        let byte = tab_row
+            .find(needle)
+            .unwrap_or_else(|| panic!("{needle} not in tab row: {tab_row:?}"));
+        let col = UnicodeWidthStr::width(&tab_row[..byte]) as u16; // display col, not byte
+        app.active_tab = TabKind::Summary;
+        handle_mouse_event(
+            &mut app,
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: col,
+                row: 2,
+                modifiers: KeyModifiers::empty(),
+            },
+        );
+        assert_eq!(app.active_tab, expected, "click on {needle} @col {col}");
+    }
+}

--- a/src/tui/view/events.rs
+++ b/src/tui/view/events.rs
@@ -1163,27 +1163,17 @@ pub fn handle_mouse_event(app: &mut ViewApp, mouse: event::MouseEvent) {
 
 /// Handle click on tab bar
 fn handle_tab_click(app: &mut ViewApp, x: u16) {
-    // Tab labels matching view/ui.rs render_tabs (format: "[N] Title " + " | " separator)
-    let tab_labels: &[(&str, ViewTab)] = &[
-        ("Overview", ViewTab::Overview),
-        ("Components", ViewTab::Tree),
-        ("Vulnerabilities", ViewTab::Vulnerabilities),
-        ("Licenses", ViewTab::Licenses),
-        ("Dependencies", ViewTab::Dependencies),
-        ("Quality", ViewTab::Quality),
-        ("Compliance", ViewTab::Compliance),
-        ("Source", ViewTab::Source),
-    ];
-
-    // Compute cumulative positions: each tab is "[N] Title " (4 + title.len + 1) + 3 for separator
-    let mut pos: u16 = 0;
-    for (label, tab) in tab_labels {
-        let width = 4 + label.len() as u16 + 1; // "[N] " + title + " "
-        if x >= pos && x < pos + width {
-            app.select_tab(*tab);
-            return;
-        }
-        pos += width + 3; // " | " separator
+    // Derive hit regions from the profile's actual rendered tabs (matches
+    // view/ui.rs render_tabs), rather than a hardcoded SBOM label list that
+    // mis-selected under the CBOM/AI-BOM profiles.
+    let tabs = ViewTab::tabs_for_profile(app.bom_profile);
+    let labels: Vec<String> = tabs
+        .iter()
+        .enumerate()
+        .map(|(i, tab)| format!("[{}] {} ", i + 1, tab.title()))
+        .collect();
+    if let Some(idx) = crate::tui::shared::tab_bar_hit(&labels, 0, 3, x) {
+        app.select_tab(tabs[idx]);
     }
 }
 

--- a/src/tui/view/ui/render_snapshot_tests.rs
+++ b/src/tui/view/ui/render_snapshot_tests.rs
@@ -276,3 +276,36 @@ fn compliance_selector_exposes_every_standard() {
     assert!(levels.iter().any(|l| l.short_name() == "AI-Act"));
     assert!(levels.iter().any(|l| l.short_name() == "BSI-AI"));
 }
+
+#[test]
+fn aibom_tab_click_selects_a_profile_specific_tab() {
+    use crate::tui::view::events::handle_mouse_event;
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+    use unicode_width::UnicodeWidthStr;
+
+    let tabs = ViewTab::tabs_for_profile(crate::model::BomProfile::AiBom);
+    let target = *tabs.last().expect("AI-BOM has tabs"); // rightmost: most drift-sensitive
+    let first = tabs[0];
+    let mut app = aibom_view_app(first);
+
+    let text = render_to_text(240, 40, |frame| {
+        render(frame, &mut app);
+    });
+    let tab_row = text.lines().nth(2).expect("tab bar row").to_string();
+    let needle = target.title();
+    let byte = tab_row
+        .rfind(needle)
+        .unwrap_or_else(|| panic!("{needle} not in tab row: {tab_row:?}"));
+    let col = UnicodeWidthStr::width(&tab_row[..byte]) as u16;
+
+    handle_mouse_event(
+        &mut app,
+        MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: col,
+            row: 2,
+            modifiers: KeyModifiers::empty(),
+        },
+    );
+    assert_eq!(app.active_tab, target, "click on {needle} @col {col}");
+}


### PR DESCRIPTION
## Summary

Mouse tab-clicks were hit-tested against a **hardcoded tab list + fixed width** instead of what was actually rendered, so clicks landed on the wrong tab:

- **diff** (`events/mouse.rs`) used `tab_width = 13` and only mapped indices `0..=6` → **Compliance / Graph / Source were unreachable** and every click drifted from the real tab positions.
- **view** (`view/events.rs`) hardcoded the 8 SBOM labels **and** omitted ratatui's 1-col padding per tab (used `4 + len + 1`), so selection progressively drifted right **and every CBOM / AI-BOM tab** (Algorithms, Certificates, Models, …) mapped to the wrong SBOM tab.

## Fix

New `shared::tab_bar_hit` reproduces ratatui's `Tabs` geometry **exactly** — 1-col left/right padding + the 3-col `" │ "` divider, unicode-width aware — and maps a click column to the correct tab index (or `None` on a divider). Both stacks now build labels from the **same source as rendering**:

- `ui.rs`: extracted `diff_tab_entries` + `diff_tab_label` as the single source of truth for the diff tab set, and derive `selected_idx` via `.position()` (removing the parallel `has_graph_changes` index table — also the compile-gap the plan flagged).
- `view/events.rs`: hit-test against `ViewTab::tabs_for_profile(app.bom_profile)`.

## Verification

- `cargo build --features tui` — clean (also *removes* a manual-division clippy lint by deleting `x / tab_width`).
- **`tab_bar_hit` unit tests** — span boundaries, divider gaps, left offset, double-width (CJK) glyphs.
- **render→click integration tests** (both stacks): render to a `TestBackend`, locate a tab's title column, dispatch a real `MouseEvent` there, assert the selection — covering diff **Source** (previously unreachable) and an **AI-BOM** profile tab.
- `cargo test --features tui --lib render_snapshot` — **27/27**; `render_tabs` output is byte-identical (behavior-preserving refactor).

TUI improvement plan item **P0-3** (with the validated `has_graph_changes` compile-gap fix and the "render a real MouseEvent" acceptance tightening applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
