### PR TITLE
fix(tui): correct view list-click hit-testing; gate un-verifiable tabs

### DIFF
--- a/src/tui/view/events.rs
+++ b/src/tui/view/events.rs
@@ -1135,12 +1135,16 @@ pub fn handle_mouse_event(app: &mut ViewApp, mouse: event::MouseEvent) {
                 return;
             }
 
-            // Calculate which list item was clicked
-            // Assuming list content starts around row 4 (after header + tabs + list header)
-            let list_start_row = 4;
-            if y >= list_start_row {
-                let clicked_index = (y - list_start_row) as usize;
-                handle_list_click(app, clicked_index, x);
+            // Map the click to a list-item selection using the tab's *actual* list
+            // origin. Tabs with a variable origin or non-render-exact scroll offset
+            // return None and are left as no-ops — a no-op is safer than selecting the
+            // wrong row (which is what the old fixed `list_start_row = 4` did on every
+            // tab, since content starts at row 5 and each list body is lower still).
+            if let Some(body_start) = view_list_body_start(app.active_tab) {
+                if y >= body_start {
+                    let row = (y - body_start) as usize;
+                    handle_list_click(app, row, x);
+                }
             }
         }
         MouseEventKind::ScrollDown => {
@@ -1187,82 +1191,67 @@ fn handle_tab_click(app: &mut ViewApp, x: u16) {
     }
 }
 
-/// Handle click on list items
-fn handle_list_click(app: &mut ViewApp, clicked_index: usize, _x: u16) {
+/// Absolute frame row of the first selectable list item, for tabs whose list origin
+/// is fixed *and* whose scroll offset is persisted render-exact. Returns `None` for
+/// tabs where mouse selection is intentionally gated as a no-op.
+///
+/// Content starts at row 5 (header `Length(2)` + tabs `Length(3)`, see `view/ui.rs`);
+/// each value below adds that tab's fixed chrome (verified against the `view_*`
+/// render snapshots). Gated tabs: Source (origin varies with the breadcrumb row),
+/// Quality (line-scrolled `Paragraph`, no 1:1 row→item), Vulnerabilities/Compliance
+/// and the crypto/AI list tabs (offset not persisted render-exact / flat-filter index
+/// mismatch) — tracked as follow-ups; a no-op beats selecting the wrong row.
+fn view_list_body_start(tab: ViewTab) -> Option<u16> {
+    match tab {
+        ViewTab::Tree => Some(8),         // + filter bar (2) + block top border (1)
+        ViewTab::Licenses => Some(10),    // + filter/stats (3) + border (1) + table header (1)
+        ViewTab::Dependencies => Some(8), // + toolbar (2) + block top border (1)
+        ViewTab::Overview
+        | ViewTab::Vulnerabilities
+        | ViewTab::Quality
+        | ViewTab::Compliance
+        | ViewTab::Source
+        | ViewTab::Crypto
+        | ViewTab::Algorithms
+        | ViewTab::Certificates
+        | ViewTab::Keys
+        | ViewTab::Protocols
+        | ViewTab::Models
+        | ViewTab::Datasets
+        | ViewTab::PqcCompliance
+        | ViewTab::AiReadiness => None,
+    }
+}
+
+/// Select the list item under a click. `row` is the click's row within the list body;
+/// the tab's scroll offset is added to get the absolute item index. Only the tabs
+/// whitelisted by [`view_list_body_start`] reach here.
+fn handle_list_click(app: &mut ViewApp, row: usize, _x: u16) {
     match app.active_tab {
         ViewTab::Tree => {
-            // For tree view, just select the item
             let nodes = app.build_tree_nodes();
             let mut flat_count = 0;
             count_visible_tree_nodes(nodes, &app.tree_state, &mut flat_count);
-            if clicked_index < flat_count {
-                app.tree_state.selected = clicked_index;
-            }
-        }
-        ViewTab::Vulnerabilities => {
-            if clicked_index < app.vuln_state.total {
-                app.vuln_state.selected = clicked_index;
+            let idx = app.tree_state.offset + row;
+            if idx < flat_count {
+                app.tree_state.selected = idx;
             }
         }
         ViewTab::Licenses => {
-            if clicked_index < app.license_state.total {
-                app.license_state.selected = clicked_index;
+            let idx = app.license_state.scroll_offset + row;
+            if idx < app.license_state.total {
+                app.license_state.selected = idx;
                 app.license_state.reset_component_scroll();
             }
         }
         ViewTab::Dependencies => {
-            if clicked_index < app.dependency_state.total {
-                app.dependency_state.selected = clicked_index;
+            let idx = app.dependency_state.scroll_offset + row;
+            if idx < app.dependency_state.total {
+                app.dependency_state.selected = idx;
             }
         }
-        ViewTab::Quality => {
-            if clicked_index < app.quality_state.total_recommendations {
-                app.quality_state.selected_recommendation = clicked_index;
-            }
-        }
-        ViewTab::Compliance => {
-            app.ensure_compliance_results();
-            let max = app.filtered_compliance_violation_count();
-            if clicked_index < max {
-                app.compliance_state.selected_violation = clicked_index;
-            }
-        }
-        ViewTab::Source => {
-            let max = match app.source_state.view_mode {
-                SourceViewMode::Tree => {
-                    app.source_state.ensure_flat_cache();
-                    app.source_state.cached_flat_items.len()
-                }
-                SourceViewMode::Raw => app.source_state.raw_lines.len(),
-            };
-            let idx = app.source_state.scroll_offset + clicked_index;
-            if idx < max {
-                app.source_state.selected = idx;
-            }
-        }
-        ViewTab::Overview | ViewTab::PqcCompliance | ViewTab::AiReadiness => {
-            // No list navigation
-        }
-        ViewTab::Crypto
-        | ViewTab::Algorithms
-        | ViewTab::Certificates
-        | ViewTab::Keys
-        | ViewTab::Protocols => {
-            let max = app.crypto_count_for_tab();
-            if clicked_index < max {
-                *app.active_crypto_selected_mut() = clicked_index;
-            }
-        }
-        ViewTab::Models => {
-            if clicked_index < app.ml_model_count() {
-                app.models_selected = clicked_index;
-            }
-        }
-        ViewTab::Datasets => {
-            if clicked_index < app.dataset_count() {
-                app.datasets_selected = clicked_index;
-            }
-        }
+        // All other tabs are gated at `view_list_body_start` (unreachable here).
+        _ => {}
     }
 }
 

--- a/src/tui/view/ui/render_snapshot_tests.rs
+++ b/src/tui/view/ui/render_snapshot_tests.rs
@@ -276,3 +276,46 @@ fn compliance_selector_exposes_every_standard() {
     assert!(levels.iter().any(|l| l.short_name() == "AI-Act"));
     assert!(levels.iter().any(|l| l.short_name() == "BSI-AI"));
 }
+
+#[test]
+fn view_list_click_selects_the_item_under_the_cursor() {
+    use crate::tui::view::events::handle_mouse_event;
+    use crossterm::event::{KeyModifiers, MouseButton, MouseEvent, MouseEventKind};
+
+    // (tab, a distinctive item in the LEFT list, its selected index by the demo
+    // fixture's rendered order — see the view_{tree,licenses,dependencies} snapshots).
+    let cases = [
+        (ViewTab::Tree, "axios@1.4.0", 1usize), // "npm (8)" group is flat index 0
+        (ViewTab::Licenses, "Apache-2.0", 1usize), // MIT(0), Apache-2.0(1), Unknown(2)
+        (ViewTab::Dependencies, "axios@1.4.0", 1usize), // acme-webapp(0), axios(1)
+    ];
+    for (tab, needle, expected) in cases {
+        let mut app = demo_view_app(tab);
+        // Render first so the list totals are populated, then find the item's real
+        // row from the buffer and click it — a wrong body_start would select a
+        // different (or no) item and fail the assertion.
+        let text = render_to_text(80, 24, |frame| {
+            render(frame, &mut app);
+        });
+        let row = text
+            .lines()
+            .position(|line| line.contains(needle))
+            .unwrap_or_else(|| panic!("{needle} not rendered on {tab:?}")) as u16;
+        handle_mouse_event(
+            &mut app,
+            MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: 5,
+                row,
+                modifiers: KeyModifiers::empty(),
+            },
+        );
+        let selected = match tab {
+            ViewTab::Tree => app.tree_state.selected,
+            ViewTab::Licenses => app.license_state.selected,
+            ViewTab::Dependencies => app.dependency_state.selected,
+            _ => unreachable!(),
+        };
+        assert_eq!(selected, expected, "click {needle:?} on {tab:?} @row {row}");
+    }
+}


### PR DESCRIPTION
## Summary

Mouse list-clicks in the single-SBOM **view** used a fixed origin of `list_start_row = 4`, but content starts at row 5 and every tab's list body is lower still — so **a click selected the wrong row on every tab**, and the arms ignored each list's scroll offset (only Source added it, and even that was mis-origined).

## Fix (view stack)

Replace the fixed origin with `view_list_body_start(tab)`, which returns each tab's real first-data row (derived from the layout and **verified against the `view_*` render snapshots**) and adds the tab's persisted scroll offset, clamped to the item count:

| Tab | offset field | `body_start` |
|-----|-----------|:---:|
| Tree | `tree_state.offset` | 8 |
| Licenses | `license_state.scroll_offset` | 10 |
| Dependencies | `dependency_state.scroll_offset` | 8 |

## Gated as no-ops (tracked follow-ups)

Tabs whose list origin is **runtime-variable** (Source — the breadcrumb row shifts it), **line-scrolled** (Quality — no 1:1 row→item), or whose offset **isn't persisted render-exact** (Vulnerabilities/Compliance, crypto/AI list tabs) return `None` and are left as no-ops. A no-op is strictly better than today's *wrong* selection. Un-gating them — and the **diff-stack** handler (whose demo fixtures don't populate the lists, and whose per-frame `TableState`/offsets aren't render-exact) — is best done by recording the rendered list rect at draw time, and is a separate follow-up.

> This is why the analytically-derived per-tab constants were kept to only the tabs a test can verify: the plan's own re-verify caught the first-cut redesign getting Source's origin wrong, so only empirically-confirmed origins ship here.

## Verification

- `cargo build --features tui` — clean, 0 warnings.
- **Render→click test**: renders each supported tab, finds a distinctive item's *real* row in the buffer (`axios@1.4.0`, `Apache-2.0`), clicks it, and asserts the selected index matches the rendered order — a wrong `body_start` fails the test.
- `cargo test --features tui --lib render_snapshot` — 26/26; **no render change, snapshots unchanged**.

TUI improvement plan item **P0-4** (with the validated corrections: Source gated, tests drive real `MouseEvent`s against populated lists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
