### PR TITLE
fix(tui): unify multi-diff selection on one display-index space

### DIFF
--- a/src/tui/events/multi_diff.rs
+++ b/src/tui/events/multi_diff.rs
@@ -52,6 +52,19 @@ pub(super) fn handle_multi_diff_keys(app: &mut App, key: KeyEvent) {
         // Filter and sort
         KeyCode::Char('f') => {
             app.tabs.multi_diff.toggle_filter();
+            // The filter changes how many comparisons are visible; keep the navigation
+            // bound (`total_targets`) and the selection in sync with the filtered list.
+            if let Some(result) = app.data.multi_diff_result.as_ref() {
+                let visible = crate::tui::views::ordered_comparison_indices(
+                    result,
+                    &app.tabs.multi_diff,
+                )
+                .len();
+                app.tabs.multi_diff.total_targets = visible;
+                if visible > 0 && app.tabs.multi_diff.selected_target >= visible {
+                    app.tabs.multi_diff.selected_target = visible - 1;
+                }
+            }
             app.set_status_message(format!(
                 "Filter: {}",
                 app.tabs.multi_diff.filter_preset.label()
@@ -146,18 +159,29 @@ pub(super) fn update_multi_diff_search_matches(app: &mut App) {
         return;
     }
 
+    // Store matches as *display* indices (positions in the visible order) so they line
+    // up with how the list highlights matches and how `selected_target` is interpreted
+    // — jumping to a match then selects the right row.
     let matches: Vec<usize> = app
         .data
         .multi_diff_result
         .as_ref()
         .map_or_else(Vec::new, |result| {
-            result
-                .comparisons
-                .iter()
-                .enumerate()
-                .filter(|(_, comp)| comp.target.name.to_lowercase().contains(&query))
-                .map(|(i, _)| i)
-                .collect()
+            crate::tui::views::ordered_comparison_indices(
+                result,
+                &app.tabs.multi_diff,
+            )
+            .into_iter()
+            .enumerate()
+            .filter(|(_, raw)| {
+                result.comparisons[*raw]
+                    .target
+                    .name
+                    .to_lowercase()
+                    .contains(&query)
+            })
+            .map(|(display, _)| display)
+            .collect()
         });
 
     app.tabs.multi_diff.search.update_matches(matches);

--- a/src/tui/test_support.rs
+++ b/src/tui/test_support.rs
@@ -87,3 +87,19 @@ fn buffer_to_text(buffer: &ratatui::buffer::Buffer) -> String {
     }
     out
 }
+
+/// Build a multi-diff result — baseline vs. two distinctly-named targets — for
+/// dashboard tests. Uses the real `MultiDiffEngine` so every summary field is valid.
+pub(crate) fn demo_multi_diff() -> crate::diff::MultiDiffResult {
+    let baseline = parse_sbom_str(DEMO_OLD).expect("baseline fixture must parse");
+    let webapp = parse_sbom_str(DEMO_NEW).expect("webapp fixture must parse");
+    let ai = parse_sbom_str(AIBOM_BSI).expect("aibom fixture must parse");
+    let targets: [(&NormalizedSbom, &str, &str); 2] = [
+        (&webapp, "webapp", "demo-new.cdx.json"),
+        (&ai, "ai-service", "aibom.cdx.json"),
+    ];
+    let mut engine = crate::diff::MultiDiffEngine::new();
+    engine
+        .diff_multi(&baseline, "baseline", "demo-old.cdx.json", &targets)
+        .expect("multi diff must succeed")
+}

--- a/src/tui/views/mod.rs
+++ b/src/tui/views/mod.rs
@@ -25,6 +25,7 @@ pub use graph_changes::render_graph_changes;
 pub use licenses::render_licenses;
 pub use matrix::{MatrixPanel, render_matrix};
 pub use multi_dashboard::{MultiDashboardPanel, render_multi_dashboard};
+pub(crate) use multi_dashboard::ordered_comparison_indices;
 pub use overlays::{
     ThresholdTuningState, render_component_deep_dive, render_shortcuts_overlay,
     render_threshold_tuning, render_view_switcher,

--- a/src/tui/views/multi_dashboard.rs
+++ b/src/tui/views/multi_dashboard.rs
@@ -56,11 +56,19 @@ pub fn render_multi_dashboard(
 
     render_targets_list(f, main_chunks[0], result, state);
 
+    // Resolve the selected *display* index to a raw comparison index so the details
+    // panel shows the same comparison the Targets list highlights. `usize::MAX` (when
+    // the selection is past the filtered set) resolves to no comparison.
+    let selected_raw = ordered_comparison_indices(result, state)
+        .get(state.selected_target)
+        .copied()
+        .unwrap_or(usize::MAX);
+
     if state.show_cross_target && main_chunks.len() > 2 {
         render_cross_target_analysis(f, main_chunks[1], result, state);
-        render_details_panel(f, main_chunks[2], result, state.selected_target, state);
+        render_details_panel(f, main_chunks[2], result, selected_raw, state);
     } else if main_chunks.len() > 1 {
-        render_details_panel(f, main_chunks[1], result, state.selected_target, state);
+        render_details_panel(f, main_chunks[1], result, selected_raw, state);
     }
 
     // Status bar
@@ -176,6 +184,89 @@ fn render_baseline_info(f: &mut Frame, area: Rect, result: &MultiDiffResult) {
     f.render_widget(paragraph, area);
 }
 
+/// Raw `result.comparisons` indices in the order shown in the Targets list, after the
+/// active filter preset + sort key + direction. Display index `N` (what
+/// `selected_target` refers to, what the list highlights) maps to the returned vec's
+/// `N`th entry.
+///
+/// Single source of truth for the visible ordering: the list highlight, the details
+/// panel, the detail modal, and search all resolve the *same* comparison through this.
+/// Previously the highlight used `selected_target` as a display index while the details
+/// panel/modal used it as a raw `comparisons` index, so under any sort or filter they
+/// referred to different comparisons.
+pub(crate) fn ordered_comparison_indices(
+    result: &MultiDiffResult,
+    state: &MultiDiffState,
+) -> Vec<usize> {
+    let deviation = |name: &str| {
+        result
+            .summary
+            .deviation_scores
+            .get(name)
+            .copied()
+            .unwrap_or(0.0)
+    };
+
+    let mut idx: Vec<usize> = result
+        .comparisons
+        .iter()
+        .enumerate()
+        .filter(|(_, comp)| match state.filter_preset {
+            MultiViewFilterPreset::All => true,
+            MultiViewFilterPreset::HighDeviation => deviation(&comp.target.name) > 0.3,
+            MultiViewFilterPreset::ChangesOnly => comp.diff.summary.total_changes > 0,
+            MultiViewFilterPreset::WithVulnerabilities => {
+                comp.diff.summary.vulnerabilities_introduced > 0
+            }
+            MultiViewFilterPreset::AddedOnly => comp.diff.summary.components_added > 0,
+            MultiViewFilterPreset::RemovedOnly => comp.diff.summary.components_removed > 0,
+        })
+        .map(|(i, _)| i)
+        .collect();
+
+    // Every key uses a *descending* base order so the shared `Ascending` reverse below
+    // flips it to ascending. Name previously used an ascending base, which the reverse
+    // then inverted (Ascending showed Z→A); using a descending base fixes it.
+    match state.sort_by {
+        MultiViewSortBy::Name => idx.sort_by(|a, b| {
+            result.comparisons[*b]
+                .target
+                .name
+                .cmp(&result.comparisons[*a].target.name)
+        }),
+        MultiViewSortBy::Deviation => idx.sort_by(|a, b| {
+            deviation(&result.comparisons[*b].target.name)
+                .partial_cmp(&deviation(&result.comparisons[*a].target.name))
+                .unwrap_or(std::cmp::Ordering::Equal)
+        }),
+        MultiViewSortBy::Changes => idx.sort_by(|a, b| {
+            result.comparisons[*b]
+                .diff
+                .summary
+                .total_changes
+                .cmp(&result.comparisons[*a].diff.summary.total_changes)
+        }),
+        MultiViewSortBy::Components => idx.sort_by(|a, b| {
+            result.comparisons[*b]
+                .target
+                .component_count
+                .cmp(&result.comparisons[*a].target.component_count)
+        }),
+        MultiViewSortBy::Vulnerabilities => idx.sort_by(|a, b| {
+            result.comparisons[*b]
+                .diff
+                .summary
+                .vulnerabilities_introduced
+                .cmp(&result.comparisons[*a].diff.summary.vulnerabilities_introduced)
+        }),
+    }
+
+    if matches!(state.sort_direction, SortDirection::Ascending) {
+        idx.reverse();
+    }
+    idx
+}
+
 fn render_targets_list(
     f: &mut Frame,
     area: Rect,
@@ -186,82 +277,15 @@ fn render_targets_list(
     let is_active = matches!(state.active_panel, MultiDashboardPanel::Targets);
     let selected = state.selected_target;
 
-    // Filter and sort comparisons
-    let mut filtered_comparisons: Vec<(usize, &crate::diff::ComparisonResult)> = result
-        .comparisons
-        .iter()
-        .enumerate()
-        .filter(|(_, comp)| {
-            let deviation = result
-                .summary
-                .deviation_scores
-                .get(&comp.target.name)
-                .copied()
-                .unwrap_or(0.0);
-            let has_changes = comp.diff.summary.total_changes > 0;
-            let has_vulns = comp.diff.summary.vulnerabilities_introduced > 0;
-
-            match state.filter_preset {
-                MultiViewFilterPreset::All => true,
-                MultiViewFilterPreset::HighDeviation => deviation > 0.3,
-                MultiViewFilterPreset::ChangesOnly => has_changes,
-                MultiViewFilterPreset::WithVulnerabilities => has_vulns,
-                MultiViewFilterPreset::AddedOnly => comp.diff.summary.components_added > 0,
-                MultiViewFilterPreset::RemovedOnly => comp.diff.summary.components_removed > 0,
-            }
-        })
-        .collect();
-
-    // Sort
-    match state.sort_by {
-        MultiViewSortBy::Name => {
-            filtered_comparisons.sort_by(|a, b| a.1.target.name.cmp(&b.1.target.name));
-        }
-        MultiViewSortBy::Deviation => {
-            filtered_comparisons.sort_by(|a, b| {
-                let dev_a = result
-                    .summary
-                    .deviation_scores
-                    .get(&a.1.target.name)
-                    .copied()
-                    .unwrap_or(0.0);
-                let dev_b = result
-                    .summary
-                    .deviation_scores
-                    .get(&b.1.target.name)
-                    .copied()
-                    .unwrap_or(0.0);
-                dev_b
-                    .partial_cmp(&dev_a)
-                    .unwrap_or(std::cmp::Ordering::Equal)
-            });
-        }
-        MultiViewSortBy::Changes => {
-            filtered_comparisons.sort_by(|a, b| {
-                b.1.diff
-                    .summary
-                    .total_changes
-                    .cmp(&a.1.diff.summary.total_changes)
-            });
-        }
-        MultiViewSortBy::Components => {
-            filtered_comparisons
-                .sort_by(|a, b| b.1.target.component_count.cmp(&a.1.target.component_count));
-        }
-        MultiViewSortBy::Vulnerabilities => {
-            filtered_comparisons.sort_by(|a, b| {
-                b.1.diff
-                    .summary
-                    .vulnerabilities_introduced
-                    .cmp(&a.1.diff.summary.vulnerabilities_introduced)
-            });
-        }
-    }
-
-    // Reverse for ascending order
-    if matches!(state.sort_direction, SortDirection::Ascending) {
-        filtered_comparisons.reverse();
-    }
+    // Comparisons in display order (filter + sort + direction), paired with their raw
+    // index. Shared with the details panel, modal, and search via
+    // `ordered_comparison_indices` so the highlighted row and the details always
+    // resolve the same comparison.
+    let filtered_comparisons: Vec<(usize, &crate::diff::ComparisonResult)> =
+        ordered_comparison_indices(result, state)
+            .into_iter()
+            .map(|raw| (raw, &result.comparisons[raw]))
+            .collect();
 
     let rows: Vec<Row> = filtered_comparisons
         .iter()
@@ -737,7 +761,10 @@ fn render_detail_modal(
     // Clear the area
     f.render_widget(Clear, modal_area);
 
-    let Some(comp) = result.comparisons.get(state.selected_target) else {
+    let Some(comp) = ordered_comparison_indices(result, state)
+        .get(state.selected_target)
+        .and_then(|&raw| result.comparisons.get(raw))
+    else {
         return;
     };
 
@@ -1001,4 +1028,91 @@ fn render_search_overlay(f: &mut Frame, area: Rect, state: &MultiDiffState) {
 pub enum MultiDashboardPanel {
     Targets,
     Details,
+}
+
+#[cfg(test)]
+mod ordering_tests {
+    use super::*;
+    use crate::tui::test_support::demo_multi_diff;
+
+    fn state(
+        sort: MultiViewSortBy,
+        dir: SortDirection,
+        filter: MultiViewFilterPreset,
+    ) -> MultiDiffState {
+        let mut s = MultiDiffState::new();
+        s.sort_by = sort;
+        s.sort_direction = dir;
+        s.filter_preset = filter;
+        s
+    }
+
+    #[test]
+    fn name_ascending_is_a_to_z_and_reorders_raw_indices() {
+        let result = demo_multi_diff();
+        let order = ordered_comparison_indices(
+            &result,
+            &state(
+                MultiViewSortBy::Name,
+                SortDirection::Ascending,
+                MultiViewFilterPreset::All,
+            ),
+        );
+        // A→Z by name (the bug rendered Ascending as Z→A).
+        let names: Vec<&str> = order
+            .iter()
+            .map(|&i| result.comparisons[i].target.name.as_str())
+            .collect();
+        let mut sorted = names.clone();
+        sorted.sort_unstable();
+        assert_eq!(names, sorted, "Ascending Name sort should be A→Z");
+        // Display order differs from raw order, so resolving details by the raw
+        // `selected_target` (the old bug) would show a different comparison than the
+        // highlighted row. Guards that this fixture actually exercises the defect.
+        assert_ne!(order, (0..result.comparisons.len()).collect::<Vec<_>>());
+        // Still a permutation of every comparison (filter = All).
+        let mut perm = order.clone();
+        perm.sort_unstable();
+        assert_eq!(perm, (0..result.comparisons.len()).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn descending_name_is_the_reverse_of_ascending() {
+        let result = demo_multi_diff();
+        let asc = ordered_comparison_indices(
+            &result,
+            &state(
+                MultiViewSortBy::Name,
+                SortDirection::Ascending,
+                MultiViewFilterPreset::All,
+            ),
+        );
+        let mut desc = ordered_comparison_indices(
+            &result,
+            &state(
+                MultiViewSortBy::Name,
+                SortDirection::Descending,
+                MultiViewFilterPreset::All,
+            ),
+        );
+        desc.reverse();
+        assert_eq!(asc, desc);
+    }
+
+    #[test]
+    fn with_vulnerabilities_filter_keeps_only_matching() {
+        let result = demo_multi_diff();
+        let order = ordered_comparison_indices(
+            &result,
+            &state(
+                MultiViewSortBy::Name,
+                SortDirection::Ascending,
+                MultiViewFilterPreset::WithVulnerabilities,
+            ),
+        );
+        assert!(order.len() <= result.comparisons.len());
+        for &i in &order {
+            assert!(result.comparisons[i].diff.summary.vulnerabilities_introduced > 0);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes a **wrong-data** bug in the multi-comparison dashboard: `selected_target` was interpreted two ways at once. The Targets list highlighted by **display** index (position in the filtered+sorted list), but the details side-panel and the detail modal looked it up as a **raw** `result.comparisons` index — so under any sort or filter, **the details showed a different comparison than the highlighted row**. Search compounded it: matches were raw indices, so both the match highlight and jump-to-match hit the wrong rows.

## Fix

Introduce `ordered_comparison_indices(result, state)` — the raw indices in display order (filter + sort + direction) — as the **single source of truth**, and route everything through it:

- **Details panel / modal** resolve `order[selected_target]` (out-of-range → no comparison, safe under an active filter).
- **Search matches** are stored as display indices, fixing both the match highlight (`multi_dashboard.rs:306`) and jump-to-match.
- **Toggling the filter** resyncs the navigation bound (`total_targets`) to the visible count and clamps `selected_target`.
- **Name-sort inversion** fixed: every key now uses a descending base order so the shared `Ascending` reverse yields **A→Z** (Name previously used an ascending base and inverted, showing Z→A on Ascending).

The Targets list rows build from the same ordering, so **rendering is otherwise unchanged**.

## Verification

- `cargo build --features tui` — clean, 0 warnings.
- New `test_support::demo_multi_diff()` builds a real `MultiDiffEngine` result over two distinctly-named targets (no hand-rolled fixture).
- Unit tests: Ascending Name is **A→Z and reorders the raw indices** (proving raw-index details *would* be wrong — guards that the fixture exercises the bug); Descending is its reverse; the vulnerabilities filter keeps only matching targets.
- `cargo test --features tui --lib render_snapshot` — 25/25 unchanged.

TUI improvement plan item **P1-7**.

> Follow-up (noted): the diff dashboard has no render snapshots; adding some (now that `demo_multi_diff()` exists) would guard the visual output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
