### PR TITLE
fix(tui): restore terminal on all exits; harden clipboard + export

### DIFF
--- a/src/tui/clipboard.rs
+++ b/src/tui/clipboard.rs
@@ -5,31 +5,121 @@ use std::process::{Command, Stdio};
 
 /// Copy text to the system clipboard.
 ///
-/// Uses `pbcopy` on macOS and `xclip` on Linux.
-/// Returns `true` on success.
+/// Tries platform clipboard commands first (`pbcopy` on macOS; `wl-copy`, `xclip`,
+/// then `xsel` on Linux), and falls back to an OSC 52 escape sequence so copy also
+/// works over SSH and inside tmux where no local clipboard tool is reachable. Returns
+/// `true` if a backend accepted the text.
 pub fn copy_to_clipboard(text: &str) -> bool {
-    let result = if cfg!(target_os = "macos") {
-        Command::new("pbcopy")
-            .stdin(Stdio::piped())
-            .spawn()
-            .and_then(|mut child| {
-                if let Some(ref mut stdin) = child.stdin {
-                    stdin.write_all(text.as_bytes())?;
-                }
-                child.wait()
-            })
-    } else {
-        Command::new("xclip")
-            .args(["-selection", "clipboard"])
-            .stdin(Stdio::piped())
-            .spawn()
-            .and_then(|mut child| {
-                if let Some(ref mut stdin) = child.stdin {
-                    stdin.write_all(text.as_bytes())?;
-                }
-                child.wait()
-            })
-    };
+    try_command_backends(text) || osc52_copy(text)
+}
 
-    result.is_ok_and(|status| status.success())
+/// Try each platform clipboard command in order; returns `true` on the first success.
+fn try_command_backends(text: &str) -> bool {
+    let candidates: &[(&str, &[&str])] = if cfg!(target_os = "macos") {
+        &[("pbcopy", &[])]
+    } else {
+        &[
+            ("wl-copy", &[]),
+            ("xclip", &["-selection", "clipboard"]),
+            ("xsel", &["--clipboard", "--input"]),
+        ]
+    };
+    candidates
+        .iter()
+        .any(|(cmd, args)| run_clipboard_command(cmd, args, text))
+}
+
+/// Spawn a clipboard command, pipe `text` to its stdin, and report exit success.
+fn run_clipboard_command(cmd: &str, args: &[&str], text: &str) -> bool {
+    Command::new(cmd)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .and_then(|mut child| {
+            if let Some(mut stdin) = child.stdin.take() {
+                stdin.write_all(text.as_bytes())?;
+                // `stdin` drops here, signalling EOF before we wait.
+            }
+            child.wait()
+        })
+        .is_ok_and(|status| status.success())
+}
+
+/// Write an OSC 52 clipboard-set sequence to stdout. Best-effort: succeeds if the
+/// bytes are written; the terminal honours it if it supports OSC 52.
+fn osc52_copy(text: &str) -> bool {
+    let seq = osc52_sequence(text, std::env::var_os("TMUX").is_some());
+    let mut out = std::io::stdout();
+    out.write_all(seq.as_bytes())
+        .and_then(|()| out.flush())
+        .is_ok()
+}
+
+/// Build the OSC 52 set-clipboard escape sequence for `text`, wrapped for tmux
+/// passthrough when `in_tmux` is set (DCS-wrapped with inner `ESC`s doubled).
+fn osc52_sequence(text: &str, in_tmux: bool) -> String {
+    let seq = format!("\x1b]52;c;{}\x07", base64_encode(text.as_bytes()));
+    if in_tmux {
+        format!("\x1bPtmux;{}\x1b\\", seq.replace('\x1b', "\x1b\x1b"))
+    } else {
+        seq
+    }
+}
+
+/// Minimal standard-alphabet base64 encoder (avoids pulling in a dependency).
+fn base64_encode(input: &[u8]) -> String {
+    const ALPHABET: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let b0 = u32::from(chunk[0]);
+        let b1 = u32::from(*chunk.get(1).unwrap_or(&0));
+        let b2 = u32::from(*chunk.get(2).unwrap_or(&0));
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(ALPHABET[((n >> 18) & 0x3f) as usize] as char);
+        out.push(ALPHABET[((n >> 12) & 0x3f) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            ALPHABET[((n >> 6) & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            ALPHABET[(n & 0x3f) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{base64_encode, osc52_sequence};
+
+    #[test]
+    fn base64_matches_rfc4648_vectors() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn osc52_plain_sequence_is_well_formed() {
+        assert_eq!(osc52_sequence("foo", false), "\x1b]52;c;Zm9v\x07");
+    }
+
+    #[test]
+    fn osc52_tmux_wraps_and_doubles_esc() {
+        let s = osc52_sequence("foo", true);
+        assert!(s.starts_with("\x1bPtmux;"), "must open a tmux DCS passthrough");
+        assert!(s.ends_with("\x1b\\"), "must terminate the DCS with ST");
+        // Inner ESC (0x1b) doubled for tmux.
+        assert!(s.contains("\x1b\x1b]52;c;Zm9v"));
+    }
 }

--- a/src/tui/export.rs
+++ b/src/tui/export.rs
@@ -708,6 +708,10 @@ th { background: #313244; color: #89b4fa; font-weight: 600; }
 /// the original was renamed to avoid overwriting).
 fn write_to_file(path: &Path, content: &str) -> std::io::Result<PathBuf> {
     let actual_path = find_available_path(path);
+    // Create the parent directory so exports can target a new subdirectory.
+    if let Some(parent) = actual_path.parent().filter(|p| !p.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent)?;
+    }
     let mut file = File::create(&actual_path)?;
     file.write_all(content.as_bytes())?;
     Ok(actual_path)
@@ -759,5 +763,24 @@ fn display_path(path: &PathBuf) -> String {
             .unwrap_or_else(|_| path.to_path_buf())
             .display()
             .to_string()
+    }
+}
+
+#[cfg(test)]
+mod write_tests {
+    use super::write_to_file;
+
+    #[test]
+    fn creates_missing_parent_directories() {
+        let base = std::env::temp_dir().join(format!("sbom-tools-export-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&base); // clean slate
+        let path = base.join("nested").join("sub").join("report.txt");
+        assert!(!path.parent().unwrap().exists());
+
+        let written = write_to_file(&path, "hello").expect("should create parents and write");
+
+        assert!(written.exists());
+        assert_eq!(std::fs::read_to_string(&written).unwrap(), "hello");
+        let _ = std::fs::remove_dir_all(&base);
     }
 }

--- a/src/tui/shared/mod.rs
+++ b/src/tui/shared/mod.rs
@@ -61,3 +61,41 @@ pub(crate) const fn floor_char_boundary(s: &str, index: usize) -> usize {
         i
     }
 }
+
+/// RAII guard that switches the terminal into raw + alternate-screen mode on
+/// construction and restores it on drop.
+///
+/// The run loop returns `io::Error` via `?` from `terminal.draw` / `events.next`,
+/// which previously skipped the manual teardown and left the shell in raw mode (the
+/// panic hook only covers unwinds). Because `Drop` runs on normal return, on the `?`
+/// early-return, and during panic unwinding, this restores the terminal on every exit
+/// path — and de-duplicates the enter/leave sequence shared by `run_tui` and
+/// `run_view_tui`.
+pub(crate) struct TerminalGuard;
+
+impl TerminalGuard {
+    /// Enter raw + alternate-screen mode with mouse capture.
+    pub(crate) fn enter() -> std::io::Result<Self> {
+        crossterm::terminal::enable_raw_mode()?;
+        crossterm::execute!(
+            std::io::stdout(),
+            crossterm::terminal::EnterAlternateScreen,
+            crossterm::event::EnableMouseCapture
+        )?;
+        Ok(Self)
+    }
+}
+
+impl Drop for TerminalGuard {
+    fn drop(&mut self) {
+        // Best-effort restore; ignore errors (nothing useful to do on failure, and
+        // Drop must not panic).
+        let _ = crossterm::terminal::disable_raw_mode();
+        let _ = crossterm::execute!(
+            std::io::stdout(),
+            crossterm::terminal::LeaveAlternateScreen,
+            crossterm::event::DisableMouseCapture,
+            crossterm::cursor::Show
+        );
+    }
+}

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -11,11 +11,6 @@ use super::widgets::{
     MIN_HEIGHT, MIN_WIDTH, check_terminal_size, render_mode_indicator, render_size_warning,
 };
 use crate::config::TuiPreferences;
-use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture},
-    execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
-};
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Clear, Paragraph, Tabs},
@@ -31,12 +26,12 @@ pub fn run_tui(app: &mut App) -> io::Result<()> {
     let prefs = TuiPreferences::load();
     set_theme(Theme::from_name(prefs.theme.as_str()));
 
-    // Setup terminal
+    // Setup terminal. The guard restores it on drop — covering normal exit, the
+    // `?` early-return from the render loop, and panic unwinding. Declared before
+    // `terminal` so it is dropped last (after the backend releases stdout).
     super::shared::install_panic_hook();
-    enable_raw_mode()?;
-    let mut stdout = stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+    let _terminal_guard = super::shared::TerminalGuard::enter()?;
+    let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::new(backend)?;
 
     // Event handler
@@ -66,15 +61,7 @@ pub fn run_tui(app: &mut App) -> io::Result<()> {
         }
     }
 
-    // Restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
+    // Terminal is restored by `_terminal_guard` on drop.
     Ok(())
 }
 

--- a/src/tui/view/ui.rs
+++ b/src/tui/view/ui.rs
@@ -7,11 +7,6 @@ use crate::tui::theme::{FooterHints, Theme, colors, render_footer_hints, set_the
 use crate::tui::widgets::{
     self, MIN_HEIGHT, MIN_WIDTH, check_terminal_size, render_mode_indicator, render_size_warning,
 };
-use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture},
-    execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
-};
 use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Clear, Paragraph, Tabs},
@@ -29,12 +24,12 @@ pub fn run_view_tui(app: &mut ViewApp) -> io::Result<()> {
     let prefs = TuiPreferences::load();
     set_theme(Theme::from_name(prefs.theme.as_str()));
 
-    // Setup terminal
+    // Setup terminal. The guard restores it on drop — covering normal exit, the
+    // `?` early-return from the render loop, and panic unwinding. Declared before
+    // `terminal` so it is dropped last (after the backend releases stdout).
     crate::tui::shared::install_panic_hook();
-    enable_raw_mode()?;
-    let mut stdout = stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
-    let backend = CrosstermBackend::new(stdout);
+    let _terminal_guard = crate::tui::shared::TerminalGuard::enter()?;
+    let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::new(backend)?;
 
     // Event handler
@@ -62,15 +57,7 @@ pub fn run_view_tui(app: &mut ViewApp) -> io::Result<()> {
         }
     }
 
-    // Restore terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
-    terminal.show_cursor()?;
-
+    // Terminal is restored by `_terminal_guard` on drop.
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Three self-contained robustness fixes for the TUI.

### 1. Terminal restored on every exit path
The render loop returns `io::Error` via `?` from `terminal.draw` / `events.next`, which skipped the manual teardown and **left the shell in raw + alternate-screen mode** (the panic hook only covers unwinds). New `shared::TerminalGuard` — an RAII guard whose `Drop` restores raw mode, the main screen, mouse capture, and the cursor — so the terminal is restored on **normal exit, the `?` early-return, and panic** alike. Used in both `run_tui` and `run_view_tui`, de-duplicating the enter/leave sequence (and removing the now-unused crossterm setup imports).

### 2. Clipboard works on Wayland / SSH / tmux
`pbcopy`/`xclip` only, before. Now tries `pbcopy` (macOS) or `wl-copy` → `xclip` → `xsel` (Linux) in order, then falls back to an **OSC 52** escape sequence (tmux-wrapped when `$TMUX` is set) so yank also works over SSH and inside tmux where no local clipboard tool is reachable. Includes a tiny dependency-free base64 encoder.

### 3. Export creates missing parent directories
`write_to_file` now `create_dir_all(parent)` before `File::create`, so exports can target a not-yet-existing subdirectory instead of erroring.

## Verification

- `cargo build --features tui` — clean, **0 warnings**; clippy clean on touched files.
- Tests: base64 RFC 4648 vectors; OSC 52 sequence (plain + tmux passthrough with doubled `ESC`); export creating missing parent dirs.
- `cargo test --features tui --lib render_snapshot` — 25/25 unchanged (no render change).

TUI improvement plan item **P1-8**. Follow-up (noted): a second clipboard path (`security.rs::copy_to_clipboard`, used by crypto-tab copy) still bypasses these backends — routing it through `clipboard.rs` is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
