### PR TITLE
fix(tui): restore SideBySide change-jump and aligned/unified row selection

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -922,15 +922,33 @@ impl App {
         // 8. License totals (was inline in render_licenses)
         self.prepare_license_totals();
 
-        // 9. Side-by-side totals (was inline in render_sidebyside)
-        // Totals are set by set_totals in the render function, which is now
-        // hoisted here using cached aligned rows or diff data.
-        if matches!(self.mode, AppMode::Diff | AppMode::View)
-            && let Some(ref result) = self.data.diff_result
-        {
-            let left = result.components.removed.len() + result.components.modified.len();
-            let right = result.components.added.len() + result.components.modified.len();
-            self.side_by_side_state_mut().set_totals(left, right);
+        // 9. Side-by-side row model + panel totals (was inline in render_sidebyside).
+        // Build the aligned-rows / unified-entries lists and grouped panel counts
+        // into owned locals BEFORE taking a &mut on the side-by-side state, so the
+        // immutable `self.data.diff_result` borrow does not overlap the &mut borrow.
+        if matches!(self.mode, AppMode::Diff | AppMode::View) {
+            let filter = self.side_by_side_state().filter.clone();
+            let (aligned, unified, grouped_left, grouped_right) =
+                self.data.diff_result.as_ref().map_or_else(
+                    || (Vec::new(), Vec::new(), 0, 0),
+                    |result| {
+                        let grouped_left =
+                            result.components.removed.len() + result.components.modified.len();
+                        let grouped_right =
+                            result.components.added.len() + result.components.modified.len();
+                        (
+                            crate::tui::views::build_aligned_rows(result, &filter),
+                            crate::tui::views::build_unified_entries(result),
+                            grouped_left,
+                            grouped_right,
+                        )
+                    },
+                );
+            let st = self.side_by_side_state_mut();
+            st.aligned_rows = aligned;
+            st.unified_entries = unified;
+            st.set_totals(grouped_left, grouped_right);
+            st.recompute_row_model();
         }
 
         // 10. Quality recommendation totals

--- a/src/tui/app_states/mod.rs
+++ b/src/tui/app_states/mod.rs
@@ -43,8 +43,8 @@ pub use overlays::{
 pub use quality::{QualityState, QualityViewMode};
 pub use search::{ChangeType, DiffSearchResult, DiffSearchState, SearchMode, VulnChangeType};
 pub use sidebyside::{
-    AlignedRow, AlignmentMode, ChangeTypeFilter, ScrollSyncMode, SideBySideState, UnifiedChangeType,
-    UnifiedEntry,
+    AlignedRow, AlignmentMode, ChangeTypeFilter, ScrollSyncMode, SideBySideState,
+    UnifiedChangeType, UnifiedEntry,
 };
 pub use source::{SourceDiffState, SourcePanelState, SourceSide, SourceViewMode};
 pub use timeline::{TimelineComponentFilter, TimelineSortBy, TimelineState};

--- a/src/tui/app_states/mod.rs
+++ b/src/tui/app_states/mod.rs
@@ -42,7 +42,10 @@ pub use overlays::{
 };
 pub use quality::{QualityState, QualityViewMode};
 pub use search::{ChangeType, DiffSearchResult, DiffSearchState, SearchMode, VulnChangeType};
-pub use sidebyside::{AlignmentMode, ChangeTypeFilter, ScrollSyncMode, SideBySideState};
+pub use sidebyside::{
+    AlignedRow, AlignmentMode, ChangeTypeFilter, ScrollSyncMode, SideBySideState, UnifiedChangeType,
+    UnifiedEntry,
+};
 pub use source::{SourceDiffState, SourcePanelState, SourceSide, SourceViewMode};
 pub use timeline::{TimelineComponentFilter, TimelineSortBy, TimelineState};
 pub use vulnerabilities::{

--- a/src/tui/app_states/sidebyside.rs
+++ b/src/tui/app_states/sidebyside.rs
@@ -1,5 +1,41 @@
 //! Sidebyside state types.
 
+use crate::diff::ChangeType;
+
+/// An aligned row for side-by-side comparison
+#[derive(Debug, Clone)]
+pub struct AlignedRow {
+    /// Left side component (old SBOM)
+    pub left_name: Option<String>,
+    pub left_version: Option<String>,
+    /// Right side component (new SBOM)
+    pub right_name: Option<String>,
+    pub right_version: Option<String>,
+    /// Type of change
+    pub change_type: crate::diff::ChangeType,
+    /// Component ID for detail lookup
+    pub component_id: Option<String>,
+}
+
+/// Entry in the unified upgrade view
+#[derive(Debug, Clone)]
+pub struct UnifiedEntry {
+    pub name: String,
+    pub old_version: Option<String>,
+    pub new_version: Option<String>,
+    pub change_type: UnifiedChangeType,
+}
+
+/// Classification for unified view entries
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnifiedChangeType {
+    Upgrade,
+    Downgrade,
+    Modified,
+    Added,
+    Removed,
+}
+
 /// Alignment mode for side-by-side view
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AlignmentMode {
@@ -170,6 +206,10 @@ pub struct SideBySideState {
     pub detail_component_left: Option<String>,
     /// Selected component for detail modal (right side)
     pub detail_component_right: Option<String>,
+    /// Cached aligned rows (rebuilt each frame in `App::prepare_render`)
+    pub aligned_rows: Vec<AlignedRow>,
+    /// Cached unified entries (rebuilt each frame in `App::prepare_render`)
+    pub unified_entries: Vec<UnifiedEntry>,
 }
 
 impl SideBySideState {
@@ -194,6 +234,59 @@ impl SideBySideState {
             show_detail_modal: false,
             detail_component_left: None,
             detail_component_right: None,
+            aligned_rows: Vec::new(),
+            unified_entries: Vec::new(),
+        }
+    }
+
+    /// Recompute the row-navigation model (`total_rows`, `change_indices`) from
+    /// the cached row list for the active alignment mode, clamping any stale
+    /// selection/navigation indices. For row-selection modes, `left_total` /
+    /// `right_total` are synced to `total_rows` so panel scrolling can follow
+    /// the selected row across every row; Grouped keeps the counts set by
+    /// [`set_totals`](Self::set_totals).
+    pub fn recompute_row_model(&mut self) {
+        let (total, change_indices) = match self.alignment_mode {
+            AlignmentMode::Aligned => {
+                let indices = self
+                    .aligned_rows
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, row)| row.change_type != ChangeType::Unchanged)
+                    .map(|(i, _)| i)
+                    .collect();
+                (self.aligned_rows.len(), indices)
+            }
+            AlignmentMode::Unified => {
+                let total = self.unified_entries.len();
+                (total, (0..total).collect())
+            }
+            AlignmentMode::Grouped => (0, Vec::new()),
+        };
+
+        self.total_rows = total;
+        self.change_indices = change_indices;
+
+        // Clamp selection so it never points past the current row set.
+        if total == 0 {
+            self.selected_row = 0;
+        } else {
+            self.selected_row = self.selected_row.min(total - 1);
+        }
+
+        // Clamp the change cursor so next/prev_change can never index OOB.
+        if self.change_indices.is_empty() {
+            self.current_change_idx = None;
+        } else if let Some(i) = self.current_change_idx
+            && i >= self.change_indices.len()
+        {
+            self.current_change_idx = Some(self.change_indices.len() - 1);
+        }
+
+        // Row-selection modes drive both panels off the single row list.
+        if self.alignment_mode.uses_row_selection() {
+            self.left_total = total;
+            self.right_total = total;
         }
     }
 
@@ -512,5 +605,147 @@ impl SideBySideState {
 impl Default for SideBySideState {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn aligned_row(change_type: ChangeType) -> AlignedRow {
+        AlignedRow {
+            left_name: Some("pkg".to_string()),
+            left_version: Some("1.0".to_string()),
+            right_name: Some("pkg".to_string()),
+            right_version: Some("2.0".to_string()),
+            change_type,
+            component_id: Some("pkg".to_string()),
+        }
+    }
+
+    fn unified_entry() -> UnifiedEntry {
+        UnifiedEntry {
+            name: "pkg".to_string(),
+            old_version: Some("1.0".to_string()),
+            new_version: Some("2.0".to_string()),
+            change_type: UnifiedChangeType::Upgrade,
+        }
+    }
+
+    #[test]
+    fn recompute_row_model_aligned_populates_totals() {
+        let mut s = SideBySideState::new();
+        s.alignment_mode = AlignmentMode::Aligned;
+        s.aligned_rows = vec![
+            aligned_row(ChangeType::Removed),
+            aligned_row(ChangeType::Modified),
+            aligned_row(ChangeType::Added),
+        ];
+        s.recompute_row_model();
+        assert_eq!(s.total_rows, 3);
+        assert_eq!(s.change_indices, vec![0, 1, 2]);
+        assert_eq!(s.left_total, 3);
+        assert_eq!(s.right_total, 3);
+    }
+
+    #[test]
+    fn recompute_row_model_unified_populates_totals() {
+        let mut s = SideBySideState::new();
+        s.alignment_mode = AlignmentMode::Unified;
+        s.unified_entries = vec![unified_entry(), unified_entry(), unified_entry(), unified_entry()];
+        s.recompute_row_model();
+        assert_eq!(s.total_rows, 4);
+        assert_eq!(s.change_indices, vec![0, 1, 2, 3]);
+        assert_eq!(s.left_total, 4);
+        assert_eq!(s.right_total, 4);
+    }
+
+    #[test]
+    fn recompute_row_model_grouped_preserves_grouped_totals() {
+        let mut s = SideBySideState::new();
+        assert_eq!(s.alignment_mode, AlignmentMode::Grouped);
+        s.set_totals(5, 7);
+        s.recompute_row_model();
+        assert_eq!(s.total_rows, 0);
+        assert!(s.change_indices.is_empty());
+        assert_eq!(s.left_total, 5);
+        assert_eq!(s.right_total, 7);
+    }
+
+    #[test]
+    fn scroll_down_advances_selected_in_aligned_after_recompute() {
+        let mut s = SideBySideState::new();
+        s.alignment_mode = AlignmentMode::Aligned;
+        s.aligned_rows = vec![
+            aligned_row(ChangeType::Removed),
+            aligned_row(ChangeType::Modified),
+            aligned_row(ChangeType::Added),
+        ];
+        s.recompute_row_model();
+        assert_eq!(s.selected_row, 0);
+        s.scroll_down();
+        s.scroll_down();
+        s.scroll_down();
+        assert_eq!(s.selected_row, 2);
+    }
+
+    #[test]
+    fn next_change_cycles_and_wraps() {
+        let mut s = SideBySideState::new();
+        s.alignment_mode = AlignmentMode::Aligned;
+        s.aligned_rows = vec![
+            aligned_row(ChangeType::Removed),
+            aligned_row(ChangeType::Modified),
+            aligned_row(ChangeType::Added),
+        ];
+        s.recompute_row_model();
+        s.next_change();
+        assert_eq!(s.current_change_idx, Some(0));
+        assert_eq!(s.selected_row, 0);
+        assert_eq!(s.change_position(), "1/3");
+        s.next_change();
+        assert_eq!(s.current_change_idx, Some(1));
+        s.next_change();
+        assert_eq!(s.current_change_idx, Some(2));
+        s.next_change();
+        assert_eq!(s.current_change_idx, Some(0));
+    }
+
+    #[test]
+    fn recompute_clamps_stale_current_change_idx_no_panic() {
+        let mut s = SideBySideState::new();
+        s.alignment_mode = AlignmentMode::Aligned;
+        s.aligned_rows = (0..5).map(|_| aligned_row(ChangeType::Modified)).collect();
+        s.recompute_row_model();
+        s.current_change_idx = Some(4);
+        s.aligned_rows.truncate(2);
+        s.recompute_row_model();
+        assert_eq!(s.current_change_idx, Some(1));
+        // Must not panic indexing change_indices out of bounds.
+        s.prev_change();
+        assert_eq!(s.current_change_idx, Some(0));
+    }
+
+    #[test]
+    fn recompute_clamps_selected_row_when_rows_shrink() {
+        let mut s = SideBySideState::new();
+        s.alignment_mode = AlignmentMode::Aligned;
+        s.aligned_rows = (0..5).map(|_| aligned_row(ChangeType::Modified)).collect();
+        s.recompute_row_model();
+        s.selected_row = 4;
+        s.aligned_rows.truncate(2);
+        s.recompute_row_model();
+        assert_eq!(s.selected_row, 1);
+    }
+
+    #[test]
+    fn next_prev_change_noop_when_grouped_or_empty() {
+        let mut s = SideBySideState::new();
+        s.recompute_row_model();
+        s.next_change();
+        assert_eq!(s.current_change_idx, None);
+        s.prev_change();
+        assert_eq!(s.current_change_idx, None);
+        assert_eq!(s.change_position(), "0/0");
     }
 }

--- a/src/tui/app_states/sidebyside.rs
+++ b/src/tui/app_states/sidebyside.rs
@@ -652,7 +652,12 @@ mod tests {
     fn recompute_row_model_unified_populates_totals() {
         let mut s = SideBySideState::new();
         s.alignment_mode = AlignmentMode::Unified;
-        s.unified_entries = vec![unified_entry(), unified_entry(), unified_entry(), unified_entry()];
+        s.unified_entries = vec![
+            unified_entry(),
+            unified_entry(),
+            unified_entry(),
+            unified_entry(),
+        ];
         s.recompute_row_model();
         assert_eq!(s.total_rows, 4);
         assert_eq!(s.change_indices, vec![0, 1, 2, 3]);

--- a/src/tui/ui/render_snapshot_tests.rs
+++ b/src/tui/ui/render_snapshot_tests.rs
@@ -243,7 +243,10 @@ fn sidebyside_grouped_scroll_totals_unchanged() {
 
     let st = app.side_by_side_state();
     assert_eq!(st.alignment_mode, AlignmentMode::Grouped);
-    assert_eq!(st.total_rows, 0, "grouped mode uses panel scrolling, not rows");
+    assert_eq!(
+        st.total_rows, 0,
+        "grouped mode uses panel scrolling, not rows"
+    );
     assert!(st.change_indices.is_empty());
     assert_eq!(
         st.left_total, expected_left,

--- a/src/tui/ui/render_snapshot_tests.rs
+++ b/src/tui/ui/render_snapshot_tests.rs
@@ -195,6 +195,66 @@ fn help_overlay_toggles() {
     assert!(!app.overlays.show_help);
 }
 
+#[test]
+fn sidebyside_aligned_navigation_wired_via_prepare_render() {
+    use crate::tui::app_states::AlignmentMode;
+
+    let mut app = demo_app(TabKind::SideBySide);
+    app.side_by_side_state_mut().alignment_mode = AlignmentMode::Aligned;
+    // prepare_render must build the aligned-row cache AND populate the
+    // navigation model (total_rows / change_indices) it drives.
+    app.prepare_render();
+
+    {
+        let st = app.side_by_side_state();
+        assert!(st.total_rows > 0, "aligned mode must populate total_rows");
+        assert_eq!(
+            st.total_rows,
+            st.aligned_rows.len(),
+            "total_rows must track the cached row list"
+        );
+        assert_eq!(
+            st.change_indices.len(),
+            st.total_rows,
+            "every aligned row is a change row"
+        );
+    }
+
+    app.side_by_side_state_mut().next_change();
+    let st = app.side_by_side_state();
+    assert_eq!(st.current_change_idx, Some(0));
+    assert_eq!(
+        st.selected_row, st.change_indices[0],
+        "next_change must move the selected row onto the first change"
+    );
+}
+
+#[test]
+fn sidebyside_grouped_scroll_totals_unchanged() {
+    use crate::tui::app_states::AlignmentMode;
+
+    // demo_app leaves the side-by-side view in its default Grouped mode.
+    let mut app = demo_app(TabKind::SideBySide);
+    app.prepare_render();
+
+    let (diff, _, _) = demo_diff();
+    let expected_left = diff.components.removed.len() + diff.components.modified.len();
+    let expected_right = diff.components.added.len() + diff.components.modified.len();
+
+    let st = app.side_by_side_state();
+    assert_eq!(st.alignment_mode, AlignmentMode::Grouped);
+    assert_eq!(st.total_rows, 0, "grouped mode uses panel scrolling, not rows");
+    assert!(st.change_indices.is_empty());
+    assert_eq!(
+        st.left_total, expected_left,
+        "grouped left panel keeps removed+modified count"
+    );
+    assert_eq!(
+        st.right_total, expected_right,
+        "grouped right panel keeps added+modified count"
+    );
+}
+
 // ============================================================================
 // Diff-side alignment regression tests (PR-B): surface metadata changes,
 // the CRA sidecar compliance verdict, component license changes, and ML-risk

--- a/src/tui/views/mod.rs
+++ b/src/tui/views/mod.rs
@@ -31,6 +31,7 @@ pub use overlays::{
 };
 pub use quality::render_quality;
 pub use sidebyside::render_sidebyside;
+pub(crate) use sidebyside::{build_aligned_rows, build_unified_entries};
 pub use source::render_source;
 pub use summary::render_summary;
 pub use timeline::{TimelinePanel, render_timeline};

--- a/src/tui/views/sidebyside.rs
+++ b/src/tui/views/sidebyside.rs
@@ -7,6 +7,7 @@
 
 use crate::diff::{ChangeType, DiffResult};
 use crate::tui::app::{AlignmentMode, AppMode};
+use crate::tui::app_states::{AlignedRow, ChangeTypeFilter, UnifiedChangeType, UnifiedEntry};
 use crate::tui::render_context::RenderContext;
 use crate::tui::security::{VersionChange, detect_version_downgrade};
 use crate::tui::theme::colors;
@@ -14,21 +15,6 @@ use ratatui::{
     prelude::*,
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
-
-/// An aligned row for side-by-side comparison
-#[derive(Debug, Clone)]
-pub struct AlignedRow {
-    /// Left side component (old SBOM)
-    pub left_name: Option<String>,
-    pub left_version: Option<String>,
-    /// Right side component (new SBOM)
-    pub right_name: Option<String>,
-    pub right_version: Option<String>,
-    /// Type of change
-    pub change_type: ChangeType,
-    /// Component ID for detail lookup
-    pub component_id: Option<String>,
-}
 
 /// Inline diff span for character-level highlighting
 #[derive(Debug, Clone)]
@@ -42,25 +28,6 @@ pub enum DiffSpanStyle {
     Unchanged,
     Removed,
     Added,
-}
-
-/// Entry in the unified upgrade view
-#[derive(Debug, Clone)]
-struct UnifiedEntry {
-    name: String,
-    old_version: Option<String>,
-    new_version: Option<String>,
-    change_type: UnifiedChangeType,
-}
-
-/// Classification for unified view entries
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum UnifiedChangeType {
-    Upgrade,
-    Downgrade,
-    Modified,
-    Added,
-    Removed,
 }
 
 /// Semver bump level for sorting upgrades
@@ -190,8 +157,8 @@ fn render_aligned_mode(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
     let divider_area = chunks[1];
     let right_area = chunks[2];
 
-    // Build aligned rows from diff result (local computation, not cached in state)
-    let rows = build_aligned_rows(ctx);
+    // Aligned rows are built once per frame in `App::prepare_render` and cached.
+    let rows = &ctx.side_by_side.aligned_rows;
 
     // Calculate visible range based on scroll
     let scroll = ctx.side_by_side.left_scroll;
@@ -251,7 +218,7 @@ fn render_aligned_mode(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
     frame.render_widget(left_panel, left_area);
 
     // Render divider
-    render_aligned_divider(frame, divider_area, &rows, scroll, visible_height, &scheme);
+    render_aligned_divider(frame, divider_area, rows, scroll, visible_height, &scheme);
 
     // Render right panel
     let right_border_style = if focus_right {
@@ -270,51 +237,51 @@ fn render_aligned_mode(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
     frame.render_widget(right_panel, right_area);
 }
 
-fn build_aligned_rows(ctx: &RenderContext) -> Vec<AlignedRow> {
+pub(crate) fn build_aligned_rows(
+    result: &DiffResult,
+    filter: &ChangeTypeFilter,
+) -> Vec<AlignedRow> {
     let mut rows = Vec::new();
-    let filter = &ctx.side_by_side.filter;
 
-    if let Some(result) = ctx.diff_result {
-        // Add removed components
-        if filter.show_removed {
-            for comp in &result.components.removed {
-                rows.push(AlignedRow {
-                    left_name: Some(comp.name.clone()),
-                    left_version: comp.old_version.clone(),
-                    right_name: None,
-                    right_version: None,
-                    change_type: ChangeType::Removed,
-                    component_id: Some(comp.id.clone()), // Use ID, not name
-                });
-            }
+    // Add removed components
+    if filter.show_removed {
+        for comp in &result.components.removed {
+            rows.push(AlignedRow {
+                left_name: Some(comp.name.clone()),
+                left_version: comp.old_version.clone(),
+                right_name: None,
+                right_version: None,
+                change_type: ChangeType::Removed,
+                component_id: Some(comp.id.clone()), // Use ID, not name
+            });
         }
+    }
 
-        // Add modified components (aligned on same row)
-        if filter.show_modified {
-            for comp in &result.components.modified {
-                rows.push(AlignedRow {
-                    left_name: Some(comp.name.clone()),
-                    left_version: comp.old_version.clone(),
-                    right_name: Some(comp.name.clone()),
-                    right_version: comp.new_version.clone(),
-                    change_type: ChangeType::Modified,
-                    component_id: Some(comp.id.clone()), // Use ID, not name
-                });
-            }
+    // Add modified components (aligned on same row)
+    if filter.show_modified {
+        for comp in &result.components.modified {
+            rows.push(AlignedRow {
+                left_name: Some(comp.name.clone()),
+                left_version: comp.old_version.clone(),
+                right_name: Some(comp.name.clone()),
+                right_version: comp.new_version.clone(),
+                change_type: ChangeType::Modified,
+                component_id: Some(comp.id.clone()), // Use ID, not name
+            });
         }
+    }
 
-        // Add added components
-        if filter.show_added {
-            for comp in &result.components.added {
-                rows.push(AlignedRow {
-                    left_name: None,
-                    left_version: None,
-                    right_name: Some(comp.name.clone()),
-                    right_version: comp.new_version.clone(),
-                    change_type: ChangeType::Added,
-                    component_id: Some(comp.id.clone()), // Use ID, not name
-                });
-            }
+    // Add added components
+    if filter.show_added {
+        for comp in &result.components.added {
+            rows.push(AlignedRow {
+                left_name: None,
+                left_version: None,
+                right_name: Some(comp.name.clone()),
+                right_version: comp.new_version.clone(),
+                change_type: ChangeType::Added,
+                component_id: Some(comp.id.clone()), // Use ID, not name
+            });
         }
     }
 
@@ -322,7 +289,7 @@ fn build_aligned_rows(ctx: &RenderContext) -> Vec<AlignedRow> {
 }
 
 /// Build unified entries that match removed+added by name to show version upgrades.
-fn build_unified_entries(result: &DiffResult) -> Vec<UnifiedEntry> {
+pub(crate) fn build_unified_entries(result: &DiffResult) -> Vec<UnifiedEntry> {
     let mut entries = Vec::new();
 
     // 1. All modified components are Modified entries
@@ -509,7 +476,7 @@ fn render_unified_mode(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
 
     let content_area = main_chunks[1];
 
-    let Some(result) = ctx.diff_result else {
+    if ctx.diff_result.is_none() {
         let empty = Paragraph::new("No diff result available")
             .style(Style::default().fg(scheme.muted))
             .block(
@@ -520,9 +487,10 @@ fn render_unified_mode(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
             );
         frame.render_widget(empty, content_area);
         return;
-    };
+    }
 
-    let entries = build_unified_entries(result);
+    // Unified entries are built once per frame in `App::prepare_render` and cached.
+    let entries = &ctx.side_by_side.unified_entries;
 
     // Render border block first
     let block = Block::default()
@@ -1423,8 +1391,8 @@ fn render_with_detail_modal(frame: &mut Frame, area: Rect, ctx: &RenderContext) 
     // Get component details
     let mut content_lines: Vec<Line> = vec![];
 
-    // Build aligned rows to find the selected component
-    let rows = build_aligned_rows(ctx);
+    // Aligned rows are built once per frame in `App::prepare_render` and cached.
+    let rows = &ctx.side_by_side.aligned_rows;
     if let Some(row) = rows.get(ctx.side_by_side.selected_row) {
         // Extract owned data from row
         let component_name = row


### PR DESCRIPTION
## Summary

Restores dead navigation in the diff **SideBySide** view. `total_rows` and `change_indices` were set only in `SideBySideState::new()` and never updated, so:

- **`n` / `N` change-jump** was dead in every mode (`next_change`/`prev_change` early-return on the empty `change_indices`), and
- **down-selection** (`j` / PageDown / `G`) never moved in **Aligned** and **Unified** modes (their guards require `total_rows > 0`).

Default Grouped/Independent panel scrolling was unaffected (it uses `set_totals`).

## Fix

`App::prepare_render` now builds the aligned rows / unified entries **once per frame**, caches them on the state, and calls `recompute_row_model()` to derive `total_rows` + `change_indices` (clamping any stale `selected_row` / `current_change_idx`). The renderer reads the cached rows instead of rebuilding them every frame — so this also removes the per-frame rebuild.

## Verification

- `cargo build --features tui` — clean, 0 warnings.
- **19 sidebyside unit tests** pass, incl. `recompute_row_model_{aligned,unified}_populates_totals`, `recompute_row_model_grouped_preserves_grouped_totals`, `scroll_down_advances_selected_in_aligned_after_recompute`, and clamp-on-shrink / stale-change-index-no-panic.
- `cargo test --features tui --lib render_snapshot` — 27/27 (incl. new SideBySide snapshots), 0 pending.

TUI improvement plan item **P1-6**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
