### PR TITLE
fix(tui): keep the selected row visible in crypto/AI list tabs

### DIFF
--- a/src/tui/test_support.rs
+++ b/src/tui/test_support.rs
@@ -87,3 +87,14 @@ fn buffer_to_text(buffer: &ratatui::buffer::Buffer) -> String {
     }
     out
 }
+
+/// A CycloneDX CBOM fixture with many cryptographic assets (11 algorithms),
+/// used to exercise crypto/AI list scrolling.
+pub(crate) const CBOM: &str = include_str!("../../tests/fixtures/cyclonedx/cbom-1.7.cdx.json");
+
+/// Parse the CBOM fixture as a single SBOM for crypto-tab `ViewApp` tests.
+pub(crate) fn cbom_single() -> (NormalizedSbom, BomProfile) {
+    let sbom = parse_sbom_str(CBOM).expect("cbom fixture must parse");
+    let profile = BomProfile::detect(&sbom);
+    (sbom, profile)
+}

--- a/src/tui/view/ui/render_snapshot_tests.rs
+++ b/src/tui/view/ui/render_snapshot_tests.rs
@@ -276,3 +276,25 @@ fn compliance_selector_exposes_every_standard() {
     assert!(levels.iter().any(|l| l.short_name() == "AI-Act"));
     assert!(levels.iter().any(|l| l.short_name() == "BSI-AI"));
 }
+
+#[test]
+fn crypto_list_scrolls_the_selection_into_view() {
+    let (sbom, profile) = crate::tui::test_support::cbom_single();
+    let mut app = ViewApp::new(sbom, crate::tui::test_support::CBOM, profile);
+    // The Crypto tab lists every cryptographic asset (16 here), which overflows the
+    // list panel at the minimum 80x24 terminal size.
+    app.active_tab = ViewTab::Crypto;
+
+    app.crypto_list_selected = 0;
+    let top = render_to_text(80, 24, |frame| render(frame, &mut app));
+    app.crypto_list_selected = usize::MAX; // clamps to the last asset
+    let scrolled = render_to_text(80, 24, |frame| render(frame, &mut app));
+
+    // render_to_text strips styling, so any difference must come from the list
+    // window scrolling to reveal the selected (last) row — which the previous
+    // stateless render_widget never did (it always showed the top of the list).
+    assert_ne!(
+        top, scrolled,
+        "selecting the last algorithm in a short panel must scroll it into view"
+    );
+}

--- a/src/tui/view/views/algorithms.rs
+++ b/src/tui/view/views/algorithms.rs
@@ -146,7 +146,11 @@ pub fn render_algorithms(frame: &mut Frame, area: Rect, app: &ViewApp) {
         algorithms.len(),
         app.algorithm_sort_by.label()
     )));
-    frame.render_widget(list, panels[0]);
+    let mut list_state = ratatui::widgets::ListState::default();
+    if !algorithms.is_empty() {
+        list_state.select(Some(app.algorithms_selected.min(algorithms.len() - 1)));
+    }
+    frame.render_stateful_widget(list, panels[0], &mut list_state);
 
     // ── Right: detail panel ──
     let selected = app

--- a/src/tui/view/views/certificates.rs
+++ b/src/tui/view/views/certificates.rs
@@ -102,7 +102,11 @@ pub fn render_certificates(frame: &mut Frame, area: Rect, app: &ViewApp) {
             .borders(Borders::ALL)
             .title(format!(" Certificates ({}) ", certs.len())),
     );
-    frame.render_widget(list, panels[0]);
+    let mut list_state = ratatui::widgets::ListState::default();
+    if !certs.is_empty() {
+        list_state.select(Some(app.certificates_selected.min(certs.len() - 1)));
+    }
+    frame.render_stateful_widget(list, panels[0], &mut list_state);
 
     // ── Right: detail panel ──
     let selected = app

--- a/src/tui/view/views/crypto.rs
+++ b/src/tui/view/views/crypto.rs
@@ -170,7 +170,13 @@ fn render_list(
             .borders(Borders::ALL)
             .title(format!(" Assets ({}) ", crypto_components.len())),
     );
-    frame.render_widget(list, area);
+    // Stateful render so the selected asset scrolls into view on large CBOMs
+    // (a plain render_widget always shows the top of the list).
+    let mut list_state = ratatui::widgets::ListState::default();
+    if !crypto_components.is_empty() {
+        list_state.select(Some(app.crypto_list_selected.min(crypto_components.len() - 1)));
+    }
+    frame.render_stateful_widget(list, area, &mut list_state);
 }
 
 fn render_detail(

--- a/src/tui/view/views/datasets.rs
+++ b/src/tui/view/views/datasets.rs
@@ -64,7 +64,11 @@ pub fn render_datasets(frame: &mut Frame, area: Rect, app: &ViewApp) {
             .borders(Borders::ALL)
             .title(format!(" Datasets ({}) ", datasets.len())),
     );
-    frame.render_widget(list, panels[0]);
+    let mut list_state = ratatui::widgets::ListState::default();
+    if !datasets.is_empty() {
+        list_state.select(Some(selected));
+    }
+    frame.render_stateful_widget(list, panels[0], &mut list_state);
 
     // ── Right: detail panel ──
     let Some(comp) = datasets.get(selected) else {

--- a/src/tui/view/views/keys.rs
+++ b/src/tui/view/views/keys.rs
@@ -85,7 +85,11 @@ pub fn render_keys(frame: &mut Frame, area: Rect, app: &ViewApp) {
             .borders(Borders::ALL)
             .title(format!(" Key Material ({}) ", keys.len())),
     );
-    frame.render_widget(list, panels[0]);
+    let mut list_state = ratatui::widgets::ListState::default();
+    if !keys.is_empty() {
+        list_state.select(Some(app.keys_selected.min(keys.len() - 1)));
+    }
+    frame.render_stateful_widget(list, panels[0], &mut list_state);
 
     // ── Right: detail panel ──
     let selected = app

--- a/src/tui/view/views/models.rs
+++ b/src/tui/view/views/models.rs
@@ -64,7 +64,11 @@ pub fn render_models(frame: &mut Frame, area: Rect, app: &ViewApp) {
             .borders(Borders::ALL)
             .title(format!(" Models ({}) ", models.len())),
     );
-    frame.render_widget(list, panels[0]);
+    let mut list_state = ratatui::widgets::ListState::default();
+    if !models.is_empty() {
+        list_state.select(Some(selected));
+    }
+    frame.render_stateful_widget(list, panels[0], &mut list_state);
 
     // ── Right: detail panel ──
     let Some(comp) = models.get(selected) else {

--- a/src/tui/view/views/protocols.rs
+++ b/src/tui/view/views/protocols.rs
@@ -75,7 +75,11 @@ pub fn render_protocols(frame: &mut Frame, area: Rect, app: &ViewApp) {
             .borders(Borders::ALL)
             .title(format!(" Protocols ({}) ", protos.len())),
     );
-    frame.render_widget(list, panels[0]);
+    let mut list_state = ratatui::widgets::ListState::default();
+    if !protos.is_empty() {
+        list_state.select(Some(app.protocols_selected.min(protos.len() - 1)));
+    }
+    frame.render_stateful_widget(list, panels[0], &mut list_state);
 
     // ── Right: detail panel ──
     let selected = app


### PR DESCRIPTION
## Summary

The crypto and AI-BOM list tabs — **Crypto / Algorithms / Certificates / Keys / Protocols**, **Models**, **Datasets** — rendered their list with a plain `render_widget`, which always shows the top of the list. On a CBOM/AI-BOM larger than the panel, **the selected row scrolls off-screen and is invisible** (you can navigate to it, but can't see it).

## Fix

Render these lists with `render_stateful_widget` + a `ListState` seeded from each tab's existing selection index (clamped to the item count), so ratatui scrolls the selection into view.

No `highlight_symbol` / `highlight_style` is added — the existing per-item styling is untouched — so any list that already fits renders **byte-identically**.

## Verification

- `cargo build --features tui` — clean, 0 warnings; clippy clean on touched files.
- **Scroll test**: added `test_support::cbom_single()` and a test that renders the **Crypto** tab (16 assets, overflowing the minimum 80×24 panel). Selecting the last asset changes the **style-stripped** render — i.e. the window scrolled it into view; a stateless `render_widget` produced identical top-anchored text.
- `cargo test --features tui --lib render_snapshot` — 26/26 (25 existing **unchanged** + the new test), 0 pending.

TUI improvement plan item **P1-11**.

## Scope note

Scoped to the tabs that **already have a row selection**. The **PQC-compliance** table has no selection today; adding one is a distinct change (new state + nav + a visible highlight, which would alter its render) and is left for the crypto/AI scaffold work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
