### PR TITLE
fix(tui): single-dispatch diff key handler (tab-first precedence)

### DIFF
--- a/src/tui/events/compliance.rs
+++ b/src/tui/events/compliance.rs
@@ -5,7 +5,7 @@ use crate::tui::render_context::RenderContext;
 use crate::tui::traits::{EventResult, TabTarget, ViewContext, ViewMode, ViewState};
 use crossterm::event::KeyEvent;
 
-pub(super) fn handle_diff_compliance_keys(app: &mut App, key: KeyEvent) {
+pub(super) fn handle_diff_compliance_keys(app: &mut App, key: KeyEvent) -> bool {
     // Compute max violations before borrowing view mutably
     let max_violations = {
         let ctx = RenderContext::from_app(app);
@@ -40,6 +40,7 @@ pub(super) fn handle_diff_compliance_keys(app: &mut App, key: KeyEvent) {
         )
     };
     // `view` borrow is now dropped — safe to use `app` freely
+    let consumed = !matches!(result, EventResult::Ignored);
 
     if wants_export {
         app.export_compliance(crate::tui::export::ExportFormat::Json);
@@ -47,7 +48,7 @@ pub(super) fn handle_diff_compliance_keys(app: &mut App, key: KeyEvent) {
 
     if wants_toggle_group {
         toggle_selected_group(app);
-        return;
+        return true;
     }
 
     if wants_go_to_component {
@@ -58,10 +59,11 @@ pub(super) fn handle_diff_compliance_keys(app: &mut App, key: KeyEvent) {
         } else {
             app.set_status_message("No component associated with this violation");
         }
-        return;
+        return true;
     }
 
     app.handle_event_result(result);
+    consumed
 }
 
 /// Toggle the expand/collapse state of the group at the currently selected position.

--- a/src/tui/events/components.rs
+++ b/src/tui/events/components.rs
@@ -4,7 +4,7 @@ use crate::tui::traits::{EventResult, ViewContext, ViewMode, ViewState};
 use crate::tui::{App, AppMode};
 use crossterm::event::{KeyCode, KeyEvent};
 
-pub(super) fn handle_components_keys(app: &mut App, key: KeyEvent) {
+pub(super) fn handle_components_keys(app: &mut App, key: KeyEvent) -> bool {
     let view = &mut app.components_view;
 
     let mut ctx = ViewContext {
@@ -19,10 +19,9 @@ pub(super) fn handle_components_keys(app: &mut App, key: KeyEvent) {
     let result = view.handle_key(key, &mut ctx);
 
     match result {
-        EventResult::Ignored => {
-            // Handle data-dependent keys that the ViewState can't process
-            handle_data_dependent_keys(app, key);
-        }
+        // The view ignored the key: give the data-dependent handler a chance.
+        // Its return value is the final "consumed" verdict for this tab.
+        EventResult::Ignored => handle_data_dependent_keys(app, key),
         EventResult::NavigateTo(ref target) => {
             // For Dependencies navigation, set a status message
             if matches!(target, crate::tui::traits::TabTarget::Dependencies) {
@@ -32,15 +31,19 @@ pub(super) fn handle_components_keys(app: &mut App, key: KeyEvent) {
                 }
             }
             app.handle_event_result(result);
+            true
         }
         _ => {
             app.handle_event_result(result);
+            true
         }
     }
 }
 
 /// Handle keys that need access to App data (clipboard, browser, security cache).
-fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) {
+///
+/// Returns `true` if the key matched one of the data-dependent actions.
+fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) -> bool {
     match key.code {
         KeyCode::Char('y') => {
             if let Some(comp_name) = get_components_tab_selected_name(app) {
@@ -96,7 +99,7 @@ fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) {
                                 _ => {
                                     app.security_cache.add_note(&comp_name, "");
                                     app.status_message = Some("Note cleared".to_string());
-                                    return;
+                                    return true;
                                 }
                             }
                         }
@@ -108,8 +111,9 @@ fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) {
                 }
             }
         }
-        _ => {}
+        _ => return false,
     }
+    true
 }
 
 /// Get the name of the currently selected component (for Components tab quick actions)

--- a/src/tui/events/dependencies.rs
+++ b/src/tui/events/dependencies.rs
@@ -5,7 +5,7 @@ use crate::tui::state::ListNavigation;
 use crate::tui::traits::{EventResult, ViewContext, ViewMode, ViewState};
 use crossterm::event::{KeyCode, KeyEvent};
 
-pub(super) fn handle_dependencies_keys(app: &mut App, key: KeyEvent) {
+pub(super) fn handle_dependencies_keys(app: &mut App, key: KeyEvent) -> bool {
     let view = &mut app.dependencies_view;
 
     let mut ctx = ViewContext {
@@ -35,17 +35,17 @@ pub(super) fn handle_dependencies_keys(app: &mut App, key: KeyEvent) {
     match result {
         EventResult::StatusMessage(msg) => {
             app.status_message = Some(msg);
+            true
         }
-        EventResult::Ignored => {
-            // Handle data-dependent keys
-            handle_data_dependent_keys(app, key);
-        }
-        _ => {}
+        EventResult::Ignored => handle_data_dependent_keys(app, key),
+        _ => true,
     }
 }
 
 /// Handle keys that need access to App data.
-fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) {
+///
+/// Returns `true` if the key is a data-dependent Dependencies binding.
+fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) -> bool {
     if key.code == KeyCode::Char('c') {
         // Navigate to component (cross-tab)
         if let Some(node_id) = app
@@ -55,6 +55,9 @@ fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) {
         {
             app.navigate_dep_to_component(&node_id);
         }
+        true
+    } else {
+        false
     }
 }
 

--- a/src/tui/events/graph_changes.rs
+++ b/src/tui/events/graph_changes.rs
@@ -4,7 +4,7 @@ use crate::tui::App;
 use crate::tui::traits::{EventResult, ViewContext, ViewMode, ViewState};
 use crossterm::event::KeyEvent;
 
-pub(super) fn handle_graph_changes_keys(app: &mut App, key: KeyEvent) {
+pub(super) fn handle_graph_changes_keys(app: &mut App, key: KeyEvent) -> bool {
     let view = &mut app.graph_changes_view;
 
     let mut ctx = ViewContext {
@@ -17,8 +17,10 @@ pub(super) fn handle_graph_changes_keys(app: &mut App, key: KeyEvent) {
     };
 
     let result = view.handle_key(key, &mut ctx);
+    let consumed = !matches!(result, EventResult::Ignored);
 
     if let EventResult::StatusMessage(msg) = result {
         app.status_message = Some(msg);
     }
+    consumed
 }

--- a/src/tui/events/licenses.rs
+++ b/src/tui/events/licenses.rs
@@ -4,7 +4,7 @@ use crate::tui::App;
 use crate::tui::traits::{EventResult, TabTarget, ViewContext, ViewMode, ViewState};
 use crossterm::event::KeyEvent;
 
-pub(super) fn handle_licenses_keys(app: &mut App, key: KeyEvent) {
+pub(super) fn handle_licenses_keys(app: &mut App, key: KeyEvent) -> bool {
     let view = &mut app.licenses_view;
 
     let mut ctx = ViewContext {
@@ -19,6 +19,7 @@ pub(super) fn handle_licenses_keys(app: &mut App, key: KeyEvent) {
     let result = view.handle_key(key, &mut ctx);
 
     match result {
+        EventResult::Ignored => false,
         EventResult::NavigateTo(TabTarget::Components) => {
             // Enrich the navigation with the selected license name
             let license_name = get_selected_license_name(app);
@@ -28,8 +29,12 @@ pub(super) fn handle_licenses_keys(app: &mut App, key: KeyEvent) {
                 TabTarget::Components
             };
             app.handle_event_result(EventResult::NavigateTo(target));
+            true
         }
-        _ => app.handle_event_result(result),
+        _ => {
+            app.handle_event_result(result);
+            true
+        }
     }
 }
 

--- a/src/tui/events/matrix.rs
+++ b/src/tui/events/matrix.rs
@@ -3,11 +3,11 @@
 use crate::tui::App;
 use crossterm::event::{KeyCode, KeyEvent};
 
-pub(super) fn handle_matrix_keys(app: &mut App, key: KeyEvent) {
+pub(super) fn handle_matrix_keys(app: &mut App, key: KeyEvent) -> bool {
     // Handle search input mode
     if app.tabs.matrix.search.active {
         handle_matrix_search(app, key);
-        return;
+        return true;
     }
 
     // Handle pair diff modal
@@ -18,7 +18,8 @@ pub(super) fn handle_matrix_keys(app: &mut App, key: KeyEvent) {
             }
             _ => {}
         }
-        return;
+        // Modal swallows all keys so none leak to the global fallback.
+        return true;
     }
 
     // Handle export options
@@ -41,7 +42,7 @@ pub(super) fn handle_matrix_keys(app: &mut App, key: KeyEvent) {
             }
             _ => {}
         }
-        return;
+        return true;
     }
 
     // Handle clustering details
@@ -58,7 +59,7 @@ pub(super) fn handle_matrix_keys(app: &mut App, key: KeyEvent) {
             }
             _ => {}
         }
-        return;
+        return true;
     }
 
     match key.code {
@@ -160,8 +161,9 @@ pub(super) fn handle_matrix_keys(app: &mut App, key: KeyEvent) {
             app.tabs.matrix.toggle_clustering_details();
         }
 
-        _ => {}
+        _ => return false,
     }
+    true
 }
 
 pub(super) fn handle_matrix_search(app: &mut App, key: KeyEvent) {

--- a/src/tui/events/mod.rs
+++ b/src/tui/events/mod.rs
@@ -245,7 +245,57 @@ pub fn handle_key_event(app: &mut super::App, key: KeyEvent) {
         return;
     }
 
-    // Global key bindings
+    // Tab- and mode-specific handlers get first crack at the key. Whatever they
+    // consume never reaches the global fallback below, so a tab-local binding
+    // (Components' `1`-`8` quick filters, SideBySide's `/` search, `p` panel
+    // focus, …) wins over a colliding global binding instead of both firing.
+    let consumed_by_tab = dispatch_tab_key(app, key);
+    let consumed_by_mode = dispatch_mode_key(app, key);
+
+    if !consumed_by_tab && !consumed_by_mode {
+        handle_global_fallback(app, key);
+    }
+}
+
+/// Dispatch a key to the active tab's handler.
+///
+/// Returns `true` if the tab consumed the key, meaning it must not fall through
+/// to [`handle_global_fallback`]. Tabs without a dedicated handler
+/// (Summary/Overview/Tree) never consume, so global bindings and list
+/// navigation still apply on them.
+fn dispatch_tab_key(app: &mut super::App, key: KeyEvent) -> bool {
+    match app.active_tab {
+        super::TabKind::Components => components::handle_components_keys(app, key),
+        super::TabKind::Dependencies => dependencies::handle_dependencies_keys(app, key),
+        super::TabKind::Licenses => licenses::handle_licenses_keys(app, key),
+        super::TabKind::Vulnerabilities => vulnerabilities::handle_vulnerabilities_keys(app, key),
+        super::TabKind::Quality => quality::handle_quality_keys(app, key),
+        super::TabKind::Compliance => compliance::handle_diff_compliance_keys(app, key),
+        super::TabKind::GraphChanges => graph_changes::handle_graph_changes_keys(app, key),
+        super::TabKind::SideBySide => sidebyside::handle_sidebyside_keys(app, key),
+        super::TabKind::Source => source::handle_source_keys(app, key),
+        super::TabKind::Summary | super::TabKind::Overview | super::TabKind::Tree => false,
+    }
+}
+
+/// Dispatch a key to the active multi-comparison mode handler.
+///
+/// Returns `true` if the mode consumed the key. Single-pair modes (Diff/View)
+/// have no mode handler and never consume here.
+fn dispatch_mode_key(app: &mut super::App, key: KeyEvent) -> bool {
+    match app.mode {
+        super::AppMode::MultiDiff => multi_diff::handle_multi_diff_keys(app, key),
+        super::AppMode::Timeline => timeline::handle_timeline_keys(app, key),
+        super::AppMode::Matrix => matrix::handle_matrix_keys(app, key),
+        super::AppMode::Diff | super::AppMode::View => false,
+    }
+}
+
+/// Global key bindings — the fallback layer.
+///
+/// Invoked only for keys that no active tab or mode handler consumed, so a
+/// tab-local binding always takes precedence over a colliding global one.
+fn handle_global_fallback(app: &mut super::App, key: KeyEvent) {
     match key.code {
         KeyCode::Char('q') => {
             // Save last active tab before quitting
@@ -374,28 +424,6 @@ pub fn handle_key_event(app: &mut super::App, key: KeyEvent) {
         KeyCode::End | KeyCode::Char('G') => app.select_last(),
         _ => {}
     }
-
-    // Tab-specific key bindings
-    match app.active_tab {
-        super::TabKind::Components => components::handle_components_keys(app, key),
-        super::TabKind::Dependencies => dependencies::handle_dependencies_keys(app, key),
-        super::TabKind::Licenses => licenses::handle_licenses_keys(app, key),
-        super::TabKind::Vulnerabilities => vulnerabilities::handle_vulnerabilities_keys(app, key),
-        super::TabKind::Quality => quality::handle_quality_keys(app, key),
-        super::TabKind::Compliance => compliance::handle_diff_compliance_keys(app, key),
-        super::TabKind::GraphChanges => graph_changes::handle_graph_changes_keys(app, key),
-        super::TabKind::SideBySide => sidebyside::handle_sidebyside_keys(app, key),
-        super::TabKind::Source => source::handle_source_keys(app, key),
-        super::TabKind::Summary | super::TabKind::Overview | super::TabKind::Tree => {}
-    }
-
-    // Mode-specific key bindings for multi-diff, timeline, and matrix
-    match app.mode {
-        super::AppMode::MultiDiff => multi_diff::handle_multi_diff_keys(app, key),
-        super::AppMode::Timeline => timeline::handle_timeline_keys(app, key),
-        super::AppMode::Matrix => matrix::handle_matrix_keys(app, key),
-        _ => {}
-    }
 }
 
 /// Get the text that would be copied for the current selection in diff mode.
@@ -521,5 +549,181 @@ fn dispatch_export(app: &mut super::App, format: crate::tui::export::ExportForma
         app.export_compliance(format);
     } else {
         app.export(format);
+    }
+}
+
+#[cfg(test)]
+mod dispatch_precedence_tests {
+    //! Single-dispatch precedence contract for the diff key handler.
+    //!
+    //! The dispatcher gives the active tab (and multi-comparison mode) first
+    //! crack at every key via [`dispatch_tab_key`]/[`dispatch_mode_key`]; only
+    //! keys they *don't* consume reach [`handle_global_fallback`]. These tests
+    //! lock that contract per-tab: a tab-local binding always wins over a
+    //! colliding global one, universal chrome keys are never shadowed, and
+    //! navigation is never starved on the tabs whose global `select_*` is a
+    //! no-op.
+    //!
+    //! Routing is asserted directly on the `bool` returned by `dispatch_tab_key`
+    //! (data-independent — it does not depend on how many rows the demo fixture
+    //! happens to have); the individual views' navigation *effects* are covered
+    //! by each view's own unit tests.
+
+    use super::{dispatch_tab_key, handle_key_event};
+    use crate::tui::test_support::{DEMO_NEW, DEMO_OLD, demo_diff, pin_theme};
+    use crate::tui::{App, TabKind};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn diff_app(active_tab: TabKind) -> App {
+        pin_theme();
+        let (diff, old, new) = demo_diff();
+        let mut app = App::new_diff(diff, old, new, DEMO_OLD, DEMO_NEW);
+        app.active_tab = active_tab;
+        app
+    }
+
+    fn k(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    /// Navigation must reach every list-bearing tab. Tabs whose global
+    /// `select_*` is a no-op (SideBySide/Quality/Compliance/GraphChanges) — plus
+    /// Licenses/Dependencies, whose views own navigation — MUST consume `j`/`k`
+    /// locally. Tabs that navigate through the global list handler
+    /// (Components/Vulnerabilities/Source) MUST let `j`/`k` fall through. Either
+    /// way navigation is never starved.
+    #[test]
+    fn nav_keys_route_to_the_correct_layer() {
+        for tab in [
+            TabKind::SideBySide,
+            TabKind::Quality,
+            TabKind::Compliance,
+            TabKind::GraphChanges,
+            TabKind::Licenses,
+            TabKind::Dependencies,
+        ] {
+            let mut app = diff_app(tab);
+            assert!(
+                dispatch_tab_key(&mut app, k(KeyCode::Char('j'))),
+                "{tab:?} must consume 'j' locally (global select_down is a no-op there)"
+            );
+            assert!(
+                dispatch_tab_key(&mut app, k(KeyCode::Char('k'))),
+                "{tab:?} must consume 'k' locally"
+            );
+        }
+
+        for tab in [
+            TabKind::Components,
+            TabKind::Vulnerabilities,
+            TabKind::Source,
+        ] {
+            let mut app = diff_app(tab);
+            assert!(
+                !dispatch_tab_key(&mut app, k(KeyCode::Char('j'))),
+                "{tab:?} must defer 'j' to the global list navigation"
+            );
+            assert!(
+                !dispatch_tab_key(&mut app, k(KeyCode::Char('k'))),
+                "{tab:?} must defer 'k' to the global list navigation"
+            );
+        }
+    }
+
+    /// The confirmed global/tab key collisions resolve tab-first: the tab owns
+    /// the key and the colliding global binding never fires.
+    #[test]
+    fn tab_bindings_win_over_colliding_global_bindings() {
+        // '/': SideBySide has its own search; Components has none and defers to
+        // the global search overlay.
+        assert!(
+            dispatch_tab_key(&mut diff_app(TabKind::SideBySide), k(KeyCode::Char('/'))),
+            "SideBySide consumes '/' for its own search"
+        );
+        assert!(
+            !dispatch_tab_key(&mut diff_app(TabKind::Components), k(KeyCode::Char('/'))),
+            "Components has no '/'; it falls through to the global search overlay"
+        );
+
+        // '1'-'8': Components quick filters vs. the global tab-select.
+        assert!(
+            dispatch_tab_key(&mut diff_app(TabKind::Components), k(KeyCode::Char('1'))),
+            "Components consumes '1' as a quick filter"
+        );
+        assert!(
+            !dispatch_tab_key(&mut diff_app(TabKind::Summary), k(KeyCode::Char('1'))),
+            "Summary has no handler; '1' falls through to the global tab-select"
+        );
+
+        // 'p': panel focus toggle vs. the global next-policy binding.
+        for tab in [TabKind::Components, TabKind::SideBySide] {
+            assert!(
+                dispatch_tab_key(&mut diff_app(tab), k(KeyCode::Char('p'))),
+                "{tab:?} consumes 'p' for panel focus, not global next-policy"
+            );
+        }
+    }
+
+    /// Universal chrome keys must never be shadowed by a tab: `Tab` (tab
+    /// switching) and `q` (quit) fall through on *every* tab — including the
+    /// tabs that used to bind `Tab` to panel focus.
+    #[test]
+    fn universal_keys_are_never_consumed_by_a_tab() {
+        for tab in [
+            TabKind::Components,
+            TabKind::Licenses,
+            TabKind::SideBySide,
+            TabKind::Vulnerabilities,
+            TabKind::Dependencies,
+            TabKind::Source,
+            TabKind::Quality,
+            TabKind::Compliance,
+            TabKind::GraphChanges,
+        ] {
+            assert!(
+                !dispatch_tab_key(&mut diff_app(tab), k(KeyCode::Tab)),
+                "'Tab' must fall through to global tab-switching on {tab:?}"
+            );
+            assert!(
+                !dispatch_tab_key(&mut diff_app(tab), k(KeyCode::Char('q'))),
+                "'q' (quit) must fall through to the global fallback on {tab:?}"
+            );
+        }
+    }
+
+    /// End-to-end through the real dispatcher: the global fallback applies only
+    /// to keys the active tab did not consume.
+    #[test]
+    fn global_fallback_only_fires_for_unconsumed_keys() {
+        // '1' on Components toggles a filter, so the global tab-select must NOT
+        // fire and the tab stays put.
+        let mut app = diff_app(TabKind::Components);
+        handle_key_event(&mut app, k(KeyCode::Char('1')));
+        assert_eq!(
+            app.active_tab,
+            TabKind::Components,
+            "'1' on Components toggles a filter; the global tab-select must not fire"
+        );
+
+        // '/' on SideBySide opens the tab-local search, not the global overlay.
+        let mut app = diff_app(TabKind::SideBySide);
+        handle_key_event(&mut app, k(KeyCode::Char('/')));
+        assert!(
+            !app.overlays.search.active,
+            "SideBySide '/' must not open the global search overlay"
+        );
+        assert!(
+            app.side_by_side_state().search_active,
+            "SideBySide '/' activates the tab-local search"
+        );
+
+        // 'Tab' switches tabs from Components (the view no longer steals it).
+        let mut app = diff_app(TabKind::Components);
+        handle_key_event(&mut app, k(KeyCode::Tab));
+        assert_ne!(
+            app.active_tab,
+            TabKind::Components,
+            "Tab must switch tabs from Components, not toggle panel focus"
+        );
     }
 }

--- a/src/tui/events/multi_diff.rs
+++ b/src/tui/events/multi_diff.rs
@@ -3,11 +3,11 @@
 use crate::tui::App;
 use crossterm::event::{KeyCode, KeyEvent};
 
-pub(super) fn handle_multi_diff_keys(app: &mut App, key: KeyEvent) {
+pub(super) fn handle_multi_diff_keys(app: &mut App, key: KeyEvent) -> bool {
     // Handle search input mode
     if app.tabs.multi_diff.search.active {
         handle_multi_diff_search(app, key);
-        return;
+        return true;
     }
 
     // Handle detail modal
@@ -18,7 +18,8 @@ pub(super) fn handle_multi_diff_keys(app: &mut App, key: KeyEvent) {
             }
             _ => {}
         }
-        return;
+        // Modal swallows all keys so none leak to the global fallback.
+        return true;
     }
 
     // Handle variable component drill-down
@@ -35,7 +36,8 @@ pub(super) fn handle_multi_diff_keys(app: &mut App, key: KeyEvent) {
             }
             _ => {}
         }
-        return;
+        // Drill-down overlay swallows all keys.
+        return true;
     }
 
     match key.code {
@@ -117,8 +119,9 @@ pub(super) fn handle_multi_diff_keys(app: &mut App, key: KeyEvent) {
             app.set_status_message(status.to_string());
         }
 
-        _ => {}
+        _ => return false,
     }
+    true
 }
 
 pub(super) fn handle_multi_diff_search(app: &mut App, key: KeyEvent) {

--- a/src/tui/events/quality.rs
+++ b/src/tui/events/quality.rs
@@ -5,7 +5,7 @@ use crate::tui::App;
 use crate::tui::traits::{EventResult, TabTarget, ViewContext, ViewMode, ViewState};
 use crossterm::event::KeyEvent;
 
-pub(super) fn handle_quality_keys(app: &mut App, key: KeyEvent) {
+pub(super) fn handle_quality_keys(app: &mut App, key: KeyEvent) -> bool {
     let quality_view = &mut app.quality_view;
 
     let mut ctx = ViewContext {
@@ -18,6 +18,7 @@ pub(super) fn handle_quality_keys(app: &mut App, key: KeyEvent) {
     };
 
     let result = quality_view.handle_key(key, &mut ctx);
+    let consumed = !matches!(result, EventResult::Ignored);
 
     // Handle Enter on recommendation → navigate to related tab
     if quality_view.enter_requested {
@@ -49,11 +50,12 @@ pub(super) fn handle_quality_keys(app: &mut App, key: KeyEvent) {
                 target.to_tab_kind().map_or("tab", |k| k.title())
             ));
             app.handle_event_result(EventResult::NavigateTo(target));
-            return;
+            return true;
         }
     }
 
     if let EventResult::StatusMessage(msg) = result {
         app.status_message = Some(msg);
     }
+    consumed
 }

--- a/src/tui/events/sidebyside.rs
+++ b/src/tui/events/sidebyside.rs
@@ -4,7 +4,7 @@ use crate::tui::App;
 use crate::tui::traits::{EventResult, ViewContext, ViewMode, ViewState};
 use crossterm::event::{KeyCode, KeyEvent};
 
-pub(super) fn handle_sidebyside_keys(app: &mut App, key: KeyEvent) {
+pub(super) fn handle_sidebyside_keys(app: &mut App, key: KeyEvent) -> bool {
     let view = &mut app.sidebyside_view;
 
     let mut ctx = ViewContext {
@@ -28,17 +28,17 @@ pub(super) fn handle_sidebyside_keys(app: &mut App, key: KeyEvent) {
     match result {
         EventResult::StatusMessage(msg) => {
             app.status_message = Some(msg);
+            true
         }
-        EventResult::Ignored => {
-            // Handle data-dependent keys
-            handle_data_dependent_keys(app, key);
-        }
-        _ => {}
+        EventResult::Ignored => handle_data_dependent_keys(app, key),
+        _ => true,
     }
 }
 
 /// Handle keys that need access to App data.
-fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) {
+///
+/// Returns `true` if the key is a data-dependent side-by-side binding.
+fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) -> bool {
     if key.code == KeyCode::Char('y') {
         let info = get_current_row_info(app);
         if let Some(text) = info {
@@ -47,6 +47,9 @@ fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) {
                 text.chars().take(50).collect::<String>()
             ));
         }
+        true
+    } else {
+        false
     }
 }
 

--- a/src/tui/events/source.rs
+++ b/src/tui/events/source.rs
@@ -4,8 +4,8 @@ use crate::tui::App;
 use crate::tui::traits::{EventResult, ViewContext, ViewMode, ViewState};
 use crossterm::event::{KeyCode, KeyEvent};
 
-/// Handle source-tab-specific key events.
-pub fn handle_source_keys(app: &mut App, key: KeyEvent) {
+/// Handle source-tab-specific key events. Returns whether the key was consumed.
+pub fn handle_source_keys(app: &mut App, key: KeyEvent) -> bool {
     let view = &mut app.source_view;
 
     let mut ctx = ViewContext {
@@ -22,17 +22,17 @@ pub fn handle_source_keys(app: &mut App, key: KeyEvent) {
     match result {
         EventResult::StatusMessage(msg) => {
             app.status_message = Some(msg);
+            true
         }
-        EventResult::Ignored => {
-            // Handle data-dependent keys
-            handle_data_dependent_keys(app, key);
-        }
-        _ => {}
+        EventResult::Ignored => handle_data_dependent_keys(app, key),
+        _ => true,
     }
 }
 
 /// Handle keys that need access to App data (clipboard, export).
-fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) {
+///
+/// Returns `true` if the key is a data-dependent Source binding.
+fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) -> bool {
     match key.code {
         KeyCode::Char('c') => {
             // Copy JSON path
@@ -56,6 +56,7 @@ fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) {
             let result = crate::tui::export::export_source_content(&content, label);
             app.set_status_message(result.message);
         }
-        _ => {}
+        _ => return false,
     }
+    true
 }

--- a/src/tui/events/timeline.rs
+++ b/src/tui/events/timeline.rs
@@ -3,17 +3,17 @@
 use crate::tui::App;
 use crossterm::event::{KeyCode, KeyEvent};
 
-pub(super) fn handle_timeline_keys(app: &mut App, key: KeyEvent) {
+pub(super) fn handle_timeline_keys(app: &mut App, key: KeyEvent) -> bool {
     // Handle search input mode
     if app.tabs.timeline.search.active {
         handle_timeline_search(app, key);
-        return;
+        return true;
     }
 
     // Handle jump mode
     if app.tabs.timeline.jump_mode {
         handle_timeline_jump(app, key);
-        return;
+        return true;
     }
 
     // Handle version diff modal
@@ -42,7 +42,8 @@ pub(super) fn handle_timeline_keys(app: &mut App, key: KeyEvent) {
             }
             _ => {}
         }
-        return;
+        // Modal swallows all keys so none leak to the global fallback.
+        return true;
     }
 
     // Handle component history modal
@@ -53,7 +54,7 @@ pub(super) fn handle_timeline_keys(app: &mut App, key: KeyEvent) {
             }
             _ => {}
         }
-        return;
+        return true;
     }
 
     match key.code {
@@ -131,8 +132,9 @@ pub(super) fn handle_timeline_keys(app: &mut App, key: KeyEvent) {
             app.tabs.timeline.scroll_chart_right();
         }
 
-        _ => {}
+        _ => return false,
     }
+    true
 }
 
 pub(super) fn handle_timeline_search(app: &mut App, key: KeyEvent) {

--- a/src/tui/events/vulnerabilities.rs
+++ b/src/tui/events/vulnerabilities.rs
@@ -5,7 +5,7 @@ use crate::tui::app::AppMode;
 use crate::tui::traits::{EventResult, ViewContext, ViewMode, ViewState};
 use crossterm::event::{KeyCode, KeyEvent};
 
-pub(super) fn handle_vulnerabilities_keys(app: &mut App, key: KeyEvent) {
+pub(super) fn handle_vulnerabilities_keys(app: &mut App, key: KeyEvent) -> bool {
     let view = &mut app.vulnerabilities_view;
 
     let mut ctx = ViewContext {
@@ -22,17 +22,17 @@ pub(super) fn handle_vulnerabilities_keys(app: &mut App, key: KeyEvent) {
     match result {
         EventResult::StatusMessage(msg) => {
             app.status_message = Some(msg);
+            true
         }
-        EventResult::Ignored => {
-            // Handle data-dependent keys
-            handle_data_dependent_keys(app, key);
-        }
-        _ => {}
+        EventResult::Ignored => handle_data_dependent_keys(app, key),
+        _ => true,
     }
 }
 
 /// Handle keys that need access to App data.
-fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) {
+///
+/// Returns `true` if the key is a data-dependent Vulnerabilities binding.
+fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) -> bool {
     match key.code {
         KeyCode::Char('E') => {
             if app.vulnerabilities_state().group_by_component {
@@ -55,8 +55,9 @@ fn handle_data_dependent_keys(app: &mut App, key: KeyEvent) {
                 handle_flat_enter(app);
             }
         }
-        _ => {}
+        _ => return false,
     }
+    true
 }
 
 /// Handle Enter key in flat (non-grouped) mode: navigate to affected component.

--- a/src/tui/view_states/components.rs
+++ b/src/tui/view_states/components.rs
@@ -52,7 +52,8 @@ impl ViewState for ComponentsView {
                 self.inner.toggle_multi_select_mode();
                 EventResult::Consumed
             }
-            KeyCode::Char('p') | KeyCode::Tab => {
+            // `p` toggles panel focus; `Tab` is reserved for global tab switching.
+            KeyCode::Char('p') => {
                 self.inner.toggle_focus();
                 EventResult::Consumed
             }

--- a/src/tui/view_states/licenses.rs
+++ b/src/tui/view_states/licenses.rs
@@ -55,7 +55,8 @@ impl ViewState for LicensesView {
                 self.inner.toggle_compatibility();
                 EventResult::Consumed
             }
-            KeyCode::Tab | KeyCode::Char('p') => {
+            // `p` toggles panel focus; `Tab` is reserved for global tab switching.
+            KeyCode::Char('p') => {
                 if ctx.mode == ViewMode::Diff {
                     self.inner.toggle_focus();
                 }

--- a/src/tui/view_states/sidebyside.rs
+++ b/src/tui/view_states/sidebyside.rs
@@ -56,8 +56,9 @@ impl ViewState for SideBySideView {
         }
 
         match key.code {
-            // Toggle focus between panels
-            KeyCode::Tab | KeyCode::Char('p') | KeyCode::Left | KeyCode::Right => {
+            // Toggle focus between panels. `Tab` is reserved for global tab
+            // switching; `p`/arrows toggle panel focus here.
+            KeyCode::Char('p') | KeyCode::Left | KeyCode::Right => {
                 self.inner.toggle_focus();
                 EventResult::Consumed
             }
@@ -260,9 +261,19 @@ mod tests {
         let mut view = SideBySideView::new();
         let mut ctx = make_ctx();
 
+        // `p` toggles panel focus. `Tab` is intentionally NOT handled here — it
+        // is reserved for global tab switching in the diff dispatcher.
         assert!(!view.inner().focus_right);
-        view.handle_key(make_key(KeyCode::Tab), &mut ctx);
+        view.handle_key(make_key(KeyCode::Char('p')), &mut ctx);
         assert!(view.inner().focus_right);
+
+        // `Tab` must be ignored by the view so it falls through to the global
+        // fallback (next-tab) instead of toggling focus.
+        assert_eq!(
+            view.handle_key(make_key(KeyCode::Tab), &mut ctx),
+            EventResult::Ignored
+        );
+        assert!(view.inner().focus_right, "Tab must not toggle panel focus");
     }
 
     #[test]


### PR DESCRIPTION
## What & why

The diff key dispatcher (`src/tui/events/mod.rs`) ran three matches **unconditionally, in series** — global bindings → active-tab handler → mode handler — so any key bound by *both* the global layer and a tab/mode handler fired **twice**. Confirmed collisions:

| key | global | tab | old (buggy) result |
|-----|--------|-----|--------------------|
| `/` | open search overlay | SideBySide's own search | both fire |
| `p` | cycle policy preset | panel focus toggle | both fire |
| `1`-`8` | switch tab | Components quick filters | tab-select preempts the filters (filters unreachable) |

## The fix — tab-first single dispatch

```
overlay guards (unchanged)
  → dispatch_tab_key(app, key) -> bool     // active tab first
  → dispatch_mode_key(app, key) -> bool    // then multi/timeline/matrix
  → handle_global_fallback(app, key)       // only if neither consumed
```

- All **9 tab bridges** and **3 mode handlers** now return `bool` (derived from `EventResult != Ignored`, plus their data-dependent fallback). A tab-local binding wins over a colliding global one instead of both firing.
- **Load-bearing guard:** the four tabs whose global `select_*` is a no-op (SideBySide / Quality / Compliance / GraphChanges) consume `j`/`k`/PageUp/PageDown **locally**, so navigation is never starved; list tabs (Components/Vulnerabilities/Source) still defer nav to the global handler.
- `Tab` is stripped from the Components/Licenses/SideBySide **views** (panel focus stays on `p`/arrows) so it always reaches global tab-switching. `q` is consumed by no normal-mode tab. Quit and tab-cycling therefore can never be shadowed — **no reserved-key phase needed**.

## Tests

New `dispatch_precedence_tests` in `events/mod.rs` assert the routing `bool` directly (data-independent — not dependent on demo row counts):

- `nav_keys_route_to_the_correct_layer` — no-op-nav tabs + Licenses/Dependencies consume `j`/`k`; Components/Vulnerabilities/Source defer to global.
- `tab_bindings_win_over_colliding_global_bindings` — `/`, `1`-`8`, `p` resolve tab-first.
- `universal_keys_are_never_consumed_by_a_tab` — `Tab` and `q` fall through on all 9 tabs.
- `global_fallback_only_fires_for_unconsumed_keys` — end-to-end through the real dispatcher.

`cargo test --features tui --lib` → **1033 passed** (incl. all 16 pre-existing key-event tests: `tab_switch`, `numeric_keys_jump_to_tab`, `search_entry_opens_overlay`, …). `cargo clippy --features tui` → no new warnings in touched files. One pre-existing view unit test (`test_panel_toggle`) updated to use `p` and to assert `Tab` is now `Ignored` by the view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)