### PR TITLE
fix(parsers): harden the untrusted-input parser layer (29 findings)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -39,6 +39,7 @@ jobs:
           - fuzz_spdx_tagvalue
           - fuzz_detect_format
           - fuzz_score_sbom
+          - fuzz_spdx3_json
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ memory/
 
 # Swift Package Manager build directories (all nested .build/ dirs)
 **/.build/
+.parsers-audit-findings.json

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -317,8 +317,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -516,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -538,6 +549,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rayon"
@@ -633,7 +650,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sbom-tools"
-version = "0.1.21"
+version = "0.1.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -655,6 +672,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unicode-width",
+ "uuid",
  "xxhash-rust",
 ]
 
@@ -945,6 +963,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -57,3 +57,8 @@ doc = false
 name = "fuzz_score_sbom"
 path = "fuzz_targets/fuzz_score_sbom.rs"
 doc = false
+
+[[bin]]
+name = "fuzz_spdx3_json"
+path = "fuzz_targets/fuzz_spdx3_json.rs"
+doc = false

--- a/fuzz/corpus/seed/cdx_vulnerabilities.json
+++ b/fuzz/corpus/seed/cdx_vulnerabilities.json
@@ -1,0 +1,66 @@
+{
+ "bomFormat": "CycloneDX",
+ "specVersion": "1.5",
+ "metadata": {
+  "timestamp": "2024-01-01T00:00:00Z"
+ },
+ "components": [
+  {
+   "type": "library",
+   "bom-ref": "pkg:npm/liba@1.0",
+   "name": "liba",
+   "version": "1.0",
+   "purl": "pkg:npm/liba@1.0"
+  }
+ ],
+ "vulnerabilities": [
+  {
+   "id": "CVE-2024-0001",
+   "description": "seed",
+   "source": {
+    "name": "NVD"
+   },
+   "ratings": [
+    {
+     "method": "CVSSv3",
+     "score": 9.8,
+     "severity": "critical",
+     "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    },
+    {
+     "severity": "low"
+    },
+    {
+     "method": "OWASP",
+     "score": 5.0
+    }
+   ],
+   "cwes": [
+    79,
+    89
+   ],
+   "recommendation": "upgrade",
+   "analysis": {
+    "state": "not_affected",
+    "justification": "code_not_reachable",
+    "response": [
+     "will_not_fix"
+    ],
+    "detail": "seed detail"
+   },
+   "affects": [
+    {
+     "ref": "pkg:npm/liba@1.0",
+     "versions": [
+      {
+       "version": "1.0"
+      },
+      {
+       "range": "vers:npm/>=1.0|<2.0"
+      }
+     ]
+    }
+   ]
+  }
+ ]
+}

--- a/fuzz/corpus/seed/spdx3_element.json
+++ b/fuzz/corpus/seed/spdx3_element.json
@@ -1,0 +1,77 @@
+{
+ "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+ "type": "SpdxDocument",
+ "spdxId": "urn:doc",
+ "name": "seed",
+ "creationInfo": {
+  "specVersion": "3.0.1",
+  "created": "2024-01-01T00:00:00Z"
+ },
+ "rootElement": [
+  "urn:app"
+ ],
+ "element": [
+  {
+   "type": "software_Package",
+   "spdxId": "urn:app",
+   "name": "app",
+   "software_packageVersion": "1.0",
+   "software_packageUrl": "pkg:npm/app@1.0"
+  },
+  {
+   "type": "software_Package",
+   "spdxId": "urn:lib",
+   "name": "lib",
+   "software_packageVersion": "2.0",
+   "software_packageUrl": "pkg:npm/lib@2.0"
+  },
+  {
+   "type": "Relationship",
+   "spdxId": "urn:r1",
+   "relationshipType": "dependsOn",
+   "from": "urn:app",
+   "to": [
+    "urn:lib"
+   ]
+  },
+  {
+   "type": "Relationship",
+   "spdxId": "urn:r2",
+   "relationshipType": "DEPENDENCY_OF",
+   "from": "urn:lib",
+   "to": [
+    "urn:app"
+   ]
+  },
+  {
+   "type": "security_Vulnerability",
+   "spdxId": "urn:v1",
+   "name": "CVE-2024-0001",
+   "description": "seed vuln"
+  },
+  {
+   "type": "Relationship",
+   "spdxId": "urn:r3",
+   "relationshipType": "AFFECTS",
+   "from": "urn:v1",
+   "to": [
+    "urn:lib"
+   ]
+  },
+  {
+   "type": "security_VexNotAffectedVulnAssessmentRelationship",
+   "spdxId": "urn:a1",
+   "from": "urn:v1",
+   "assessedElement": "urn:lib",
+   "security_justificationType": "vulnerableCodeNotPresent"
+  },
+  {
+   "type": "security_CvssV3VulnAssessmentRelationship",
+   "spdxId": "urn:a2",
+   "from": "urn:v1",
+   "assessedElement": "urn:lib",
+   "score": 7.5,
+   "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:N/A:N"
+  }
+ ]
+}

--- a/fuzz/corpus/seed/spdx3_graph.json
+++ b/fuzz/corpus/seed/spdx3_graph.json
@@ -1,0 +1,39 @@
+{
+ "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+ "@graph": [
+  {
+   "type": "SpdxDocument",
+   "spdxId": "urn:doc",
+   "name": "graph-seed",
+   "rootElement": [
+    "urn:app"
+   ],
+   "element": [
+    "urn:app",
+    "urn:lib",
+    "urn:r1"
+   ]
+  },
+  {
+   "type": "software_Package",
+   "spdxId": "urn:app",
+   "name": "app",
+   "software_packageUrl": "pkg:npm/app@1.0"
+  },
+  {
+   "type": "software_Package",
+   "spdxId": "urn:lib",
+   "name": "lib",
+   "software_packageUrl": "pkg:npm/lib@1.0"
+  },
+  {
+   "type": "Relationship",
+   "spdxId": "urn:r1",
+   "relationshipType": "dependsOn",
+   "from": "urn:app",
+   "to": [
+    "urn:lib"
+   ]
+  }
+ ]
+}

--- a/fuzz/corpus/seed/spdx3_security_profile.json
+++ b/fuzz/corpus/seed/spdx3_security_profile.json
@@ -1,0 +1,166 @@
+{
+  "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+  "type": "SpdxDocument",
+  "spdxId": "urn:spdx:doc:security-profile-test",
+  "name": "SPDX 3.0 Security Profile Test",
+  "creationInfo": {
+    "specVersion": "3.0.1",
+    "created": "2025-01-20T10:00:00Z",
+    "createdBy": ["urn:spdx:agent:scanner-tool"]
+  },
+  "profileConformance": ["core", "software", "security", "simpleLicensing"],
+  "rootElement": ["urn:spdx:pkg:webapp"],
+  "element": [
+    {
+      "type": "Tool",
+      "spdxId": "urn:spdx:agent:scanner-tool",
+      "name": "VulnScanner 3.0"
+    },
+    {
+      "type": "Organization",
+      "spdxId": "urn:spdx:agent:vendor-corp",
+      "name": "Vendor Corp"
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "urn:spdx:pkg:webapp",
+      "name": "webapp",
+      "packageVersion": "2.1.0",
+      "packageUrl": "pkg:npm/webapp@2.1.0",
+      "primaryPurpose": "application",
+      "suppliedBy": ["urn:spdx:agent:vendor-corp"],
+      "verifiedUsing": [
+        {
+          "type": "Hash",
+          "algorithm": "sha256",
+          "hashValue": "aabbccdd00112233445566778899aabbccddeeff00112233445566778899aabb"
+        }
+      ]
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "urn:spdx:pkg:logging-lib",
+      "name": "logging-lib",
+      "packageVersion": "1.5.2",
+      "packageUrl": "pkg:npm/logging-lib@1.5.2",
+      "primaryPurpose": "library"
+    },
+    {
+      "type": "software_Package",
+      "spdxId": "urn:spdx:pkg:crypto-lib",
+      "name": "crypto-lib",
+      "packageVersion": "3.0.1",
+      "packageUrl": "pkg:npm/crypto-lib@3.0.1",
+      "primaryPurpose": "library"
+    },
+    {
+      "type": "software_Snippet",
+      "spdxId": "urn:spdx:snippet:auth-handler",
+      "name": "auth-handler.js",
+      "byteRange": "1024:2048",
+      "lineRange": "45:89",
+      "snippetFromFile": "urn:spdx:file:main-js",
+      "copyrightText": "Copyright 2025 Vendor Corp"
+    },
+    {
+      "type": "Annotation",
+      "spdxId": "urn:spdx:annotation:review-note",
+      "subject": "urn:spdx:pkg:logging-lib",
+      "annotationType": "REVIEW",
+      "statement": "Reviewed for security compliance on 2025-01-18"
+    },
+    {
+      "type": "Annotation",
+      "spdxId": "urn:spdx:annotation:other-note",
+      "subject": "urn:spdx:pkg:webapp",
+      "annotationType": "OTHER",
+      "statement": "Primary application component"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "urn:spdx:rel:webapp-depends-logging",
+      "relationshipType": "DEPENDS_ON",
+      "from": "urn:spdx:pkg:webapp",
+      "to": ["urn:spdx:pkg:logging-lib"]
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "urn:spdx:rel:webapp-depends-crypto",
+      "relationshipType": "DEPENDS_ON",
+      "from": "urn:spdx:pkg:webapp",
+      "to": ["urn:spdx:pkg:crypto-lib"]
+    },
+    {
+      "type": "simplelicensing_LicenseExpression",
+      "spdxId": "urn:spdx:lic:mit",
+      "licenseExpression": "MIT"
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "urn:spdx:rel:webapp-license",
+      "relationshipType": "HAS_DECLARED_LICENSE",
+      "from": "urn:spdx:pkg:webapp",
+      "to": ["urn:spdx:lic:mit"]
+    },
+    {
+      "type": "security_Vulnerability",
+      "spdxId": "urn:spdx:vuln:cve-2025-0001",
+      "name": "CVE-2025-0001",
+      "description": "Remote code execution in logging-lib < 1.6.0",
+      "publishedTime": "2025-01-10T08:00:00Z",
+      "modifiedTime": "2025-01-12T10:00:00Z",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cve",
+          "identifier": "CVE-2025-0001"
+        }
+      ]
+    },
+    {
+      "type": "security_Vulnerability",
+      "spdxId": "urn:spdx:vuln:cve-2025-0002",
+      "name": "CVE-2025-0002",
+      "description": "Timing side-channel in crypto-lib < 3.1.0",
+      "publishedTime": "2025-01-15T12:00:00Z",
+      "externalIdentifier": [
+        {
+          "externalIdentifierType": "cve",
+          "identifier": "CVE-2025-0002"
+        }
+      ]
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "urn:spdx:rel:vuln1-affects-logging",
+      "relationshipType": "AFFECTS",
+      "from": "urn:spdx:vuln:cve-2025-0001",
+      "to": ["urn:spdx:pkg:logging-lib"]
+    },
+    {
+      "type": "Relationship",
+      "spdxId": "urn:spdx:rel:vuln2-affects-crypto",
+      "relationshipType": "AFFECTS",
+      "from": "urn:spdx:vuln:cve-2025-0002",
+      "to": ["urn:spdx:pkg:crypto-lib"]
+    },
+    {
+      "type": "security_CvssV3VulnAssessmentRelationship",
+      "spdxId": "urn:spdx:assessment:cvss-vuln1",
+      "from": "urn:spdx:vuln:cve-2025-0001",
+      "assessedElement": "urn:spdx:pkg:logging-lib",
+      "score": 9.8,
+      "severity": "critical",
+      "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "publishedTime": "2025-01-10T08:00:00Z"
+    },
+    {
+      "type": "security_VexNotAffectedVulnAssessmentRelationship",
+      "spdxId": "urn:spdx:assessment:vex-vuln2",
+      "from": "urn:spdx:vuln:cve-2025-0002",
+      "assessedElement": "urn:spdx:pkg:crypto-lib",
+      "justification": "vulnerable_code_not_in_execute_path",
+      "impactStatement": "The affected code path is not reachable in our configuration",
+      "statusNotes": "Verified by security team audit on 2025-01-16"
+    }
+  ]
+}

--- a/fuzz/fuzz_targets/fuzz_cyclonedx_json.rs
+++ b/fuzz/fuzz_targets/fuzz_cyclonedx_json.rs
@@ -22,6 +22,22 @@ fuzz_target!(|data: &[u8]| {
                 r#"{{"bomFormat":"CycloneDX","specVersion":"1.5","components":[{s}]}}"#,
             );
             let _ = parser.parse_str(&wrapped);
+
+            // Wrap as a vulnerability so apply_vulnerability — the most
+            // security-sensitive conversion path (ratings/severity, VEX
+            // analysis, affects fan-out) — is reachable. A fixed component
+            // gives affects[].ref a resolvable target.
+            let vuln_wrapped = format!(
+                r#"{{"bomFormat":"CycloneDX","specVersion":"1.5","components":[{{"type":"library","bom-ref":"c","name":"c","version":"1.0"}}],"vulnerabilities":[{s}]}}"#,
+            );
+            let _ = parser.parse_str(&vuln_wrapped);
+
+            // And as fields INSIDE a vulnerability object, so fuzz bytes
+            // land directly in ratings/analysis/affects structures.
+            let vuln_fields_wrapped = format!(
+                r#"{{"bomFormat":"CycloneDX","specVersion":"1.5","components":[{{"type":"library","bom-ref":"c","name":"c","version":"1.0"}}],"vulnerabilities":[{{"id":"CVE-0-0",{s}"affects":[{{"ref":"c"}}]}}]}}"#,
+            );
+            let _ = parser.parse_str(&vuln_fields_wrapped);
         }
     }
 });

--- a/fuzz/fuzz_targets/fuzz_spdx3_json.rs
+++ b/fuzz/fuzz_targets/fuzz_spdx3_json.rs
@@ -1,0 +1,38 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+use sbom_tools::parsers::{SbomParser, Spdx3Parser};
+
+const MAX_WRAPPED_INPUT_LEN: usize = 10_000;
+
+/// Fuzz the SPDX 3.0 JSON-LD parser directly.
+///
+/// The SPDX 3.0 parser is the loosest-deserializing parser (polymorphic
+/// element graph, untagged enums) and was previously unreachable by the
+/// envelope fuzzers: `fuzz_parse_sbom` only reaches it through detect(),
+/// which requires specific context markers raw fuzz input rarely produces.
+///
+/// Wraps input three ways to reach deep conversion logic:
+/// - raw (exercises detection/dispatch and top-level deserialization)
+/// - as an element inside an inline-`element` SpdxDocument envelope
+/// - as a node inside a JSON-LD `@graph` envelope (the canonical
+///   serialization, which exercises the graph-chaining path)
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let parser = Spdx3Parser::new();
+
+        // Try raw input first
+        let _ = parser.parse_str(s);
+
+        if s.len() < MAX_WRAPPED_INPUT_LEN {
+            let element_wrapped = format!(
+                r#"{{"@context":"https://spdx.org/rdf/3.0.1/spdx-context.jsonld","type":"SpdxDocument","spdxId":"urn:doc","element":[{s}]}}"#,
+            );
+            let _ = parser.parse_str(&element_wrapped);
+
+            let graph_wrapped = format!(
+                r#"{{"@context":"https://spdx.org/rdf/3.0.1/spdx-context.jsonld","@graph":[{{"type":"SpdxDocument","spdxId":"urn:doc"}},{s}]}}"#,
+            );
+            let _ = parser.parse_str(&graph_wrapped);
+        }
+    }
+});

--- a/src/model/metadata.rs
+++ b/src/model/metadata.rs
@@ -98,6 +98,21 @@ pub struct SignatureInfo {
     pub has_value: bool,
 }
 
+impl DocumentMetadata {
+    /// Whether the document carries a real creation timestamp.
+    ///
+    /// Parsers substitute [`DateTime::UNIX_EPOCH`] when the source document
+    /// has no (or an unparseable) timestamp, so the content hash stays
+    /// deterministic. Consumers that compute an AGE or gate on freshness
+    /// must use this to distinguish "no timestamp" from a document that
+    /// genuinely claims 1970 — otherwise a missing timestamp reads as a
+    /// ~55-year-old SBOM.
+    #[must_use]
+    pub fn has_known_timestamp(&self) -> bool {
+        self.created.timestamp() > 0
+    }
+}
+
 impl Default for DocumentMetadata {
     fn default() -> Self {
         Self {

--- a/src/parsers/cyclonedx.rs
+++ b/src/parsers/cyclonedx.rs
@@ -269,7 +269,13 @@ impl CycloneDxParser {
             .as_ref()
             .and_then(|m| m.timestamp.as_ref())
             .and_then(|t| DateTime::parse_from_rfc3339(t).ok())
-            .map_or_else(Utc::now, |dt| dt.with_timezone(&Utc));
+            // Deterministic fallback: a document with a missing/invalid
+            // timestamp must hash identically on every parse (created is
+            // folded into the content hash; Utc::now() here made every
+            // parse of such a document content-unique, defeating diff
+            // identity and the incremental cache). Epoch is an honest
+            // "unknown" sentinel rather than a fabricated parse time.
+            .map_or(DateTime::UNIX_EPOCH, |dt| dt.with_timezone(&Utc));
 
         let mut creators = Vec::new();
         if let Some(meta) = &cdx.metadata {

--- a/src/parsers/cyclonedx.rs
+++ b/src/parsers/cyclonedx.rs
@@ -1142,6 +1142,7 @@ impl Default for CycloneDxParser {
 
 impl SbomParser for CycloneDxParser {
     fn parse_str(&self, content: &str) -> Result<NormalizedSbom, ParseError> {
+        let content = super::strip_bom(content);
         let trimmed = content.trim();
         if trimmed.starts_with('{') {
             self.parse_json(content)
@@ -1163,17 +1164,22 @@ impl SbomParser for CycloneDxParser {
     }
 
     fn detect(&self, content: &str) -> crate::parsers::traits::FormatDetection {
+        use crate::parsers::contains_json_key;
         use crate::parsers::traits::{FormatConfidence, FormatDetection};
 
+        let content = super::strip_bom(content);
         let trimmed = content.trim();
 
         // Check for JSON CycloneDX
         if trimmed.starts_with('{') {
-            // Look for CycloneDX-specific markers
-            let has_bom_format = content.contains("\"bomFormat\"");
+            // Look for CycloneDX-specific markers. Marker keys (bomFormat,
+            // specVersion, $schema, components) must appear as actual JSON
+            // keys, not merely as a coincidental string VALUE elsewhere in
+            // the document (e.g. a component literally named "specVersion").
+            let has_bom_format = contains_json_key(content, "bomFormat");
             let has_cyclonedx = content.contains("CycloneDX") || content.contains("cyclonedx");
-            let has_spec_version = content.contains("\"specVersion\"");
-            let has_schema = content.contains("\"$schema\"") && content.contains("cyclonedx");
+            let has_spec_version = contains_json_key(content, "specVersion");
+            let has_schema = contains_json_key(content, "$schema") && content.contains("cyclonedx");
 
             // Extract version if possible
             let version = Self::extract_json_version(content);
@@ -1194,7 +1200,7 @@ impl SbomParser for CycloneDxParser {
                     detection = detection.version(&v);
                 }
                 return detection;
-            } else if has_spec_version && content.contains("\"components\"") {
+            } else if has_spec_version && contains_json_key(content, "components") {
                 // Might be CycloneDX JSON (missing bomFormat but has structure)
                 return FormatDetection::with_confidence(FormatConfidence::MEDIUM)
                     .variant("JSON")

--- a/src/parsers/cyclonedx.rs
+++ b/src/parsers/cyclonedx.rs
@@ -17,7 +17,7 @@ use crate::model::{
 use crate::parsers::traits::{ParseError, SbomParser};
 use chrono::{DateTime, Utc};
 use serde::Deserialize;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// Parser for `CycloneDX` SBOM format
 #[allow(dead_code)]
@@ -853,15 +853,18 @@ impl CycloneDxParser {
         mat.format.clone_from(&cdx.format);
 
         if let Some(state) = cdx.state.as_deref() {
-            mat.state = Some(match state {
-                "pre-activation" => CryptoMaterialState::PreActivation,
-                "active" => CryptoMaterialState::Active,
-                "suspended" => CryptoMaterialState::Suspended,
-                "deactivated" => CryptoMaterialState::Deactivated,
-                "compromised" => CryptoMaterialState::Compromised,
-                "destroyed" => CryptoMaterialState::Destroyed,
-                _ => CryptoMaterialState::Active,
-            });
+            // Unknown/unrecognized state stays None: defaulting to Active
+            // asserts key material is live/usable, a dangerous claim to
+            // fabricate from a typo or hostile value.
+            mat.state = match state {
+                "pre-activation" => Some(CryptoMaterialState::PreActivation),
+                "active" => Some(CryptoMaterialState::Active),
+                "suspended" => Some(CryptoMaterialState::Suspended),
+                "deactivated" => Some(CryptoMaterialState::Deactivated),
+                "compromised" => Some(CryptoMaterialState::Compromised),
+                "destroyed" => Some(CryptoMaterialState::Destroyed),
+                _ => None,
+            };
         }
 
         if let Some(sb) = &cdx.secured_by {
@@ -948,36 +951,57 @@ impl CycloneDxParser {
         });
 
         let mut vuln_ref = VulnerabilityRef::new(vuln.id.clone(), source);
-        vuln_ref.description.clone_from(&vuln.description);
+        vuln_ref.description = super::capped_description(&vuln.description);
 
         // Parse CVSS scores
         if let Some(ratings) = &vuln.ratings {
             for rating in ratings {
+                // Only CVSS methods produce a CVSS score; OWASP/SSVC/etc. are
+                // different scoring systems and must not be mislabeled as CVSS.
                 let version = match rating.method.as_deref() {
-                    Some("CVSSv2") => CvssVersion::V2,
-                    Some("CVSSv3") => CvssVersion::V3,
-                    Some("CVSSv4") => CvssVersion::V4,
-                    _ => CvssVersion::V31,
+                    Some("CVSSv2") => Some(CvssVersion::V2),
+                    Some("CVSSv3") => Some(CvssVersion::V3),
+                    Some("CVSSv31") => Some(CvssVersion::V31),
+                    Some("CVSSv4") => Some(CvssVersion::V4),
+                    // Unmethoded ratings historically defaulted to v3.1.
+                    None => Some(CvssVersion::V31),
+                    Some(_) => None,
                 };
-                if let Some(score) = rating.score {
+                if let (Some(version), Some(score)) = (version, rating.score)
+                    // The XML path parses score text with str::parse, which
+                    // accepts NaN/inf; reject non-finite so a hostile score
+                    // can't reach Severity::from_cvss and forge Critical.
+                    && score.is_finite()
+                {
                     let mut cvss = CvssScore::new(version, score);
                     cvss.vector.clone_from(&rating.vector);
                     vuln_ref.cvss.push(cvss);
                 }
-                if vuln_ref.severity.is_none() {
-                    vuln_ref.severity =
-                        rating
-                            .severity
-                            .as_ref()
-                            .map(|s| match s.to_lowercase().as_str() {
-                                "critical" => Severity::Critical,
-                                "high" => Severity::High,
-                                "medium" => Severity::Medium,
-                                "low" => Severity::Low,
-                                "info" | "informational" => Severity::Info,
-                                "none" => Severity::None,
-                                _ => Severity::Unknown,
-                            });
+                // Take the HIGHEST severity across ratings, not the first:
+                // otherwise a leading rating with severity "none"/"low" freezes
+                // the value and suppresses a higher CVSS score in a later one.
+                // (priority() is lower-is-more-severe.)
+                if let Some(sev) =
+                    rating
+                        .severity
+                        .as_ref()
+                        .map(|s| match s.to_lowercase().as_str() {
+                            "critical" => Severity::Critical,
+                            "high" => Severity::High,
+                            "medium" => Severity::Medium,
+                            "low" => Severity::Low,
+                            "info" | "informational" => Severity::Info,
+                            "none" => Severity::None,
+                            _ => Severity::Unknown,
+                        })
+                {
+                    let more_severe = vuln_ref
+                        .severity
+                        .as_ref()
+                        .is_none_or(|cur| sev.priority() < cur.priority());
+                    if more_severe {
+                        vuln_ref.severity = Some(sev);
+                    }
                 }
             }
         }
@@ -1005,24 +1029,36 @@ impl CycloneDxParser {
 
         // Parse analysis (VEX)
         let vex_status = vuln.analysis.as_ref().map(|analysis| {
+            // CycloneDX impactAnalysisState. "exploitable" must NOT collapse
+            // to UnderInvestigation (that would understate a live threat);
+            // unknown states stay UnderInvestigation (an honest "we don't
+            // know", not a fabricated safe claim).
             let status = match analysis.state.as_deref() {
-                Some("not_affected") => VexState::NotAffected,
-                Some("affected") => VexState::Affected,
-                Some("fixed") => VexState::Fixed,
+                Some("not_affected") | Some("false_positive") => VexState::NotAffected,
+                Some("affected") | Some("exploitable") => VexState::Affected,
+                Some("fixed") | Some("resolved") | Some("resolved_with_pedigree") => {
+                    VexState::Fixed
+                }
                 _ => VexState::UnderInvestigation,
             };
 
-            let justification = analysis.justification.as_ref().map(|j| match j.as_str() {
-                "code_not_present" => VexJustification::VulnerableCodeNotPresent,
-                "code_not_reachable" => VexJustification::VulnerableCodeNotInExecutePath,
-                "requires_configuration" | "requires_dependency" | "requires_environment" => {
-                    VexJustification::VulnerableCodeCannotBeControlledByAdversary
-                }
-                "protected_by_mitigating_control" => {
-                    VexJustification::InlineMitigationsAlreadyExist
-                }
-                _ => VexJustification::ComponentNotPresent,
-            });
+            // Unknown/unrecognized justification must NOT fabricate a
+            // not-affected claim: an unrecognized string yields None, never
+            // ComponentNotPresent (the strongest "it isn't even here" claim).
+            let justification = analysis
+                .justification
+                .as_ref()
+                .and_then(|j| match j.as_str() {
+                    "code_not_present" => Some(VexJustification::VulnerableCodeNotPresent),
+                    "code_not_reachable" => Some(VexJustification::VulnerableCodeNotInExecutePath),
+                    "requires_configuration" | "requires_dependency" | "requires_environment" => {
+                        Some(VexJustification::VulnerableCodeCannotBeControlledByAdversary)
+                    }
+                    "protected_by_mitigating_control" => {
+                        Some(VexJustification::InlineMitigationsAlreadyExist)
+                    }
+                    _ => None,
+                });
 
             let responses: Vec<VexResponse> = analysis
                 .response
@@ -1050,10 +1086,15 @@ impl CycloneDxParser {
             }
         });
 
-        // Apply vulnerability to affected components
+        // Apply vulnerability to affected components. Dedup targets by
+        // canonical id: the same component listed twice in affects[] must not
+        // receive the vulnerability twice (and, with a capped description,
+        // caps this vuln's total memory at O(distinct components)).
         if let Some(affects) = &vuln.affects {
+            let mut seen: HashSet<&CanonicalId> = HashSet::new();
             for affect in affects {
                 if let Some(canonical_id) = id_map.get(&affect.ref_field)
+                    && seen.insert(canonical_id)
                     && let Some(comp) = sbom.components.get_mut(canonical_id)
                 {
                     let mut v = vuln_ref.clone();
@@ -1065,14 +1106,31 @@ impl CycloneDxParser {
                     }
                     if let Some(vex) = &vex_status {
                         v.vex_status = Some(vex.clone());
+                        // Component-level VEX is a single slot: keep the
+                        // HIGHEST-risk status across all vulns, so a trailing
+                        // fabricated `not_affected` cannot erase a real
+                        // `affected` from an earlier vulnerability.
+                        if comp.vex_status.as_ref().is_none_or(|cur| {
+                            vex_state_risk(&vex.status) > vex_state_risk(&cur.status)
+                        }) {
+                            comp.vex_status = Some(vex.clone());
+                        }
                     }
                     comp.vulnerabilities.push(v);
-                    if let Some(vex) = &vex_status {
-                        comp.vex_status = Some(vex.clone());
-                    }
                 }
             }
         }
+    }
+}
+
+/// Risk ordering for component-level VEX resolution: higher = more actionable.
+/// Affected outranks the uncertain state, which outranks the not-actionable
+/// states, so a later low-risk claim never overwrites a higher-risk one.
+const fn vex_state_risk(state: &VexState) -> u8 {
+    match state {
+        VexState::Affected => 3,
+        VexState::UnderInvestigation => 2,
+        VexState::NotAffected | VexState::Fixed => 1,
     }
 }
 
@@ -2477,6 +2535,115 @@ mod tests {
             .values()
             .find(|c| c.name == name)
             .unwrap_or_else(|| panic!("component {name} not found"))
+    }
+
+    /// A hostile leading rating (severity "none") must not freeze severity and
+    /// suppress a later CVSS-10 rating — highest severity across ratings wins.
+    #[test]
+    fn severity_takes_max_across_ratings_not_first() {
+        let sbom = parse_json(
+            r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+                "components":[{"type":"library","bom-ref":"c","name":"libc","version":"1.0","purl":"pkg:npm/libc@1.0"}],
+                "vulnerabilities":[{"id":"CVE-1","affects":[{"ref":"c"}],
+                    "ratings":[{"severity":"none"},{"method":"CVSSv3","score":10.0,"severity":"critical"}]}]}"#,
+        );
+        let comp = component(&sbom, "libc");
+        assert_eq!(comp.vulnerabilities.len(), 1);
+        assert_eq!(comp.vulnerabilities[0].severity, Some(Severity::Critical));
+    }
+
+    /// An unknown/misspelled VEX justification must yield None, never fabricate
+    /// ComponentNotPresent (the strongest "it isn't even here" claim).
+    #[test]
+    fn unknown_vex_justification_is_none_not_component_not_present() {
+        let sbom = parse_json(
+            r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+                "components":[{"type":"library","bom-ref":"c","name":"libc","version":"1.0","purl":"pkg:npm/libc@1.0"}],
+                "vulnerabilities":[{"id":"CVE-1","affects":[{"ref":"c"}],
+                    "analysis":{"state":"not_affected","justification":"totally_made_up"}}]}"#,
+        );
+        let comp = component(&sbom, "libc");
+        let vex = comp.vulnerabilities[0].vex_status.as_ref().unwrap();
+        assert_eq!(vex.justification, None);
+    }
+
+    /// A trailing fabricated `not_affected` must not erase an earlier real
+    /// `affected` at the component-level VEX slot.
+    #[test]
+    fn component_vex_keeps_highest_risk_not_last_wins() {
+        let sbom = parse_json(
+            r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+                "components":[{"type":"library","bom-ref":"c","name":"libc","version":"1.0","purl":"pkg:npm/libc@1.0"}],
+                "vulnerabilities":[
+                    {"id":"CVE-REAL","affects":[{"ref":"c"}],"analysis":{"state":"affected"}},
+                    {"id":"CVE-FAKE","affects":[{"ref":"c"}],"analysis":{"state":"not_affected"}}]}"#,
+        );
+        let comp = component(&sbom, "libc");
+        assert_eq!(
+            comp.vex_status.as_ref().map(|v| &v.status),
+            Some(&VexState::Affected),
+            "a fabricated not_affected must not override a real affected"
+        );
+    }
+
+    /// `exploitable` must map to Affected, not collapse to UnderInvestigation.
+    #[test]
+    fn exploitable_state_maps_to_affected() {
+        let sbom = parse_json(
+            r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+                "components":[{"type":"library","bom-ref":"c","name":"libc","version":"1.0","purl":"pkg:npm/libc@1.0"}],
+                "vulnerabilities":[{"id":"CVE-1","affects":[{"ref":"c"}],"analysis":{"state":"exploitable"}}]}"#,
+        );
+        let comp = component(&sbom, "libc");
+        assert_eq!(
+            comp.vulnerabilities[0]
+                .vex_status
+                .as_ref()
+                .map(|v| &v.status),
+            Some(&VexState::Affected)
+        );
+    }
+
+    /// A huge vulnerability description must be capped, and repeated affects
+    /// targets deduped — bounding the memory-amplification fan-out.
+    #[test]
+    fn huge_description_is_capped_and_affects_deduped() {
+        let big = "A".repeat(2 * 1024 * 1024); // 2 MiB
+        let json = format!(
+            r#"{{"bomFormat":"CycloneDX","specVersion":"1.5",
+                "components":[{{"type":"library","bom-ref":"c","name":"libc","version":"1.0","purl":"pkg:npm/libc@1.0"}}],
+                "vulnerabilities":[{{"id":"CVE-1","description":"{big}",
+                    "affects":[{{"ref":"c"}},{{"ref":"c"}},{{"ref":"c"}}]}}]}}"#
+        );
+        let sbom = parse_json(&json);
+        let comp = component(&sbom, "libc");
+        assert_eq!(
+            comp.vulnerabilities.len(),
+            1,
+            "duplicate affects must dedup"
+        );
+        let desc = comp.vulnerabilities[0].description.as_ref().unwrap();
+        assert!(
+            desc.len() <= super::super::MAX_VULN_DESCRIPTION_BYTES + 32,
+            "description must be capped, got {} bytes",
+            desc.len()
+        );
+    }
+
+    /// Non-CVSS rating methods (OWASP/SSVC) must not be mislabeled as CVSS.
+    #[test]
+    fn non_cvss_rating_method_produces_no_cvss_score() {
+        let sbom = parse_json(
+            r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+                "components":[{"type":"library","bom-ref":"c","name":"libc","version":"1.0","purl":"pkg:npm/libc@1.0"}],
+                "vulnerabilities":[{"id":"CVE-1","affects":[{"ref":"c"}],
+                    "ratings":[{"method":"OWASP","score":5.0}]}]}"#,
+        );
+        let comp = component(&sbom, "libc");
+        assert!(
+            comp.vulnerabilities[0].cvss.is_empty(),
+            "an OWASP rating must not become a CVSS score"
+        );
     }
 
     #[test]

--- a/src/parsers/detection.rs
+++ b/src/parsers/detection.rs
@@ -7,7 +7,37 @@
 use super::traits::{FormatConfidence, FormatDetection, ParseError, SbomParser};
 use super::{CycloneDxParser, Spdx3Parser, SpdxParser};
 use crate::model::NormalizedSbom;
-use std::io::BufRead;
+use std::io::{BufRead, Read};
+
+/// Read a reader into a string, rejecting streams over
+/// [`MAX_SBOM_FILE_SIZE`](super::MAX_SBOM_FILE_SIZE).
+///
+/// Reads incrementally and bails the moment the accumulated length would
+/// exceed the cap, so a hostile multi-GB stream is rejected without buffering
+/// its tail, and a small input never over-allocates. Errors on the overrun
+/// rather than silently truncating.
+fn read_to_string_capped<R: Read>(reader: &mut R) -> Result<String, ParseError> {
+    let limit = super::MAX_SBOM_FILE_SIZE as usize;
+    let mut buf: Vec<u8> = Vec::new();
+    let mut chunk = [0u8; 64 * 1024];
+    loop {
+        let n = reader
+            .read(&mut chunk)
+            .map_err(|e| ParseError::IoError(e.to_string()))?;
+        if n == 0 {
+            break;
+        }
+        if buf.len() + n > limit {
+            return Err(ParseError::IoError(format!(
+                "SBOM stream exceeds the {} MB limit",
+                super::MAX_SBOM_FILE_SIZE / (1024 * 1024),
+            )));
+        }
+        buf.extend_from_slice(&chunk[..n]);
+    }
+    String::from_utf8(buf)
+        .map_err(|e| ParseError::IoError(format!("SBOM stream is not valid UTF-8: {e}")))
+}
 
 /// Minimum confidence threshold for accepting a format detection.
 /// This is LOW confidence (0.25) - the parser believes it might be able to handle the content.
@@ -291,7 +321,11 @@ impl FormatDetector {
     /// Parse from a reader using streaming JSON parsing.
     ///
     /// Peeks at the content to detect format, then uses the appropriate
-    /// reader-based parser for memory-efficient parsing.
+    /// reader-based parser for memory-efficient parsing. All reads are
+    /// bounded by [`MAX_SBOM_FILE_SIZE`](super::MAX_SBOM_FILE_SIZE): unlike
+    /// the path-based `parse_sbom`, this entry point (used by the streaming
+    /// parser) has no up-front `metadata().len()` check, so an unbounded
+    /// `read_to_string` here was an OOM vector for a hostile stream.
     pub fn parse_reader<R: BufRead>(&self, mut reader: R) -> Result<NormalizedSbom, ParseError> {
         // Peek at the buffer to detect format
         let peek = reader
@@ -309,15 +343,16 @@ impl FormatDetector {
             tracing::warn!("{}", warning);
         }
 
+        // Cap every downstream read at the file-size limit (+1 to detect
+        // overrun). fill_buf only peeked, so the buffered bytes are preserved.
+        let mut reader = reader.take(super::MAX_SBOM_FILE_SIZE + 1);
+
         match detection.parser {
             Some(ParserKind::CycloneDx) if detection.can_parse() => {
                 // Check if it's XML (needs string-based parsing)
                 let is_xml = detection.variant.as_deref() == Some("XML");
                 if is_xml {
-                    let mut content = String::new();
-                    reader
-                        .read_to_string(&mut content)
-                        .map_err(|e| ParseError::IoError(e.to_string()))?;
+                    let content = read_to_string_capped(&mut reader)?;
                     self.cyclonedx.parse_str(&content)
                 } else {
                     self.cyclonedx.parse_json_reader(reader)
@@ -328,10 +363,7 @@ impl FormatDetector {
                 let needs_string =
                     matches!(detection.variant.as_deref(), Some("tag-value" | "RDF"));
                 if needs_string {
-                    let mut content = String::new();
-                    reader
-                        .read_to_string(&mut content)
-                        .map_err(|e| ParseError::IoError(e.to_string()))?;
+                    let content = read_to_string_capped(&mut reader)?;
                     self.spdx.parse_str(&content)
                 } else {
                     self.spdx.parse_json_reader(reader)
@@ -339,10 +371,7 @@ impl FormatDetector {
             }
             Some(ParserKind::Spdx3) if detection.can_parse() => {
                 // SPDX 3.0 is JSON-LD only - read full content and parse
-                let mut content = String::new();
-                reader
-                    .read_to_string(&mut content)
-                    .map_err(|e| ParseError::IoError(e.to_string()))?;
+                let content = read_to_string_capped(&mut reader)?;
                 self.spdx3.parse_str(&content)
             }
             _ => Err(ParseError::UnknownFormat(

--- a/src/parsers/detection.rs
+++ b/src/parsers/detection.rs
@@ -382,9 +382,14 @@ impl FormatDetector {
                 }
             }
             Some(ParserKind::Spdx) if detection.can_parse() => {
-                // Check variant - tag-value and RDF need string-based parsing
-                let needs_string =
-                    matches!(detection.variant.as_deref(), Some("tag-value" | "RDF"));
+                // Check variant - tag-value and RDF need string-based parsing.
+                // detect() reports the RDF variant as "RDF/XML"; the old
+                // bare-"RDF" match never fired, so RDF/XML streams were
+                // misrouted to the JSON reader and always failed.
+                let needs_string = matches!(
+                    detection.variant.as_deref(),
+                    Some("tag-value" | "RDF" | "RDF/XML")
+                );
                 if needs_string {
                     let content = read_to_string_capped(&mut reader)?;
                     self.spdx.parse_str(&content)

--- a/src/parsers/detection.rs
+++ b/src/parsers/detection.rs
@@ -5,7 +5,7 @@
 //! thresholds and detection behavior.
 
 use super::traits::{FormatConfidence, FormatDetection, ParseError, SbomParser};
-use super::{CycloneDxParser, Spdx3Parser, SpdxParser};
+use super::{CycloneDxParser, Spdx3Parser, SpdxParser, strip_bom};
 use crate::model::NormalizedSbom;
 use std::io::{BufRead, Read};
 
@@ -174,28 +174,16 @@ impl FormatDetector {
 
     /// Detect format from full content string.
     ///
-    /// This performs full detection using each parser's `detect()` method.
-    /// SPDX 3.0 is checked first since its JSON-LD markers are more distinctive.
+    /// This performs full detection using each parser's `detect()` method
+    /// and picks the single strict winner (see [`Self::select_best_of_three`]).
     #[must_use]
     pub fn detect_from_content(&self, content: &str) -> DetectionResult {
-        // Check SPDX 3.0 first - its markers (@context, type: SpdxDocument) are distinctive
-        let spdx3_detection = self.spdx3.detect(content);
-        if spdx3_detection.confidence.value() >= FormatConfidence::HIGH.value() {
-            return DetectionResult::spdx3(spdx3_detection);
-        }
-
+        let content = strip_bom(content);
         let cdx_detection = self.cyclonedx.detect(content);
         let spdx_detection = self.spdx.detect(content);
+        let spdx3_detection = self.spdx3.detect(content);
 
-        // If SPDX 3.0 had medium confidence but beat others, use it
-        if spdx3_detection.confidence.value() >= self.min_confidence
-            && spdx3_detection.confidence.value() > cdx_detection.confidence.value()
-            && spdx3_detection.confidence.value() > spdx_detection.confidence.value()
-        {
-            return DetectionResult::spdx3(spdx3_detection);
-        }
-
-        self.select_best_parser(cdx_detection, spdx_detection)
+        self.select_best_of_three(cdx_detection, spdx_detection, spdx3_detection)
     }
 
     /// Detect format from peeked bytes (for streaming).
@@ -204,94 +192,121 @@ impl FormatDetector {
     /// streaming parsers that can only peek at the beginning of a file.
     #[must_use]
     pub fn detect_from_peek(&self, peek: &[u8]) -> DetectionResult {
-        // Find first non-whitespace byte
+        // Find first non-whitespace, non-BOM byte. A UTF-8 BOM (EF BB BF) is
+        // not ASCII whitespace, so without skipping it explicitly it would
+        // become "first_char" and fail every match arm below.
+        let peek = if peek.starts_with(&[0xEF, 0xBB, 0xBF]) {
+            &peek[3..]
+        } else {
+            peek
+        };
         let first_char = peek.iter().find(|&&b| !b.is_ascii_whitespace());
 
         match first_char {
             Some(b'{' | b'<') => {
                 // Convert peek to string for detection
                 let preview = String::from_utf8_lossy(peek);
-
-                // Check SPDX 3.0 first (distinctive JSON-LD markers)
-                let spdx3_detection = self.spdx3.detect(&preview);
-                if spdx3_detection.confidence.value() >= FormatConfidence::HIGH.value() {
-                    return DetectionResult::spdx3(spdx3_detection);
-                }
-
-                // Use actual parser detection methods for consistency
                 let cdx_detection = self.cyclonedx.detect(&preview);
                 let spdx_detection = self.spdx.detect(&preview);
+                let spdx3_detection = self.spdx3.detect(&preview);
 
-                // Check if SPDX 3.0 beat others
-                if spdx3_detection.confidence.value() >= self.min_confidence
-                    && spdx3_detection.confidence.value() > cdx_detection.confidence.value()
-                    && spdx3_detection.confidence.value() > spdx_detection.confidence.value()
-                {
-                    return DetectionResult::spdx3(spdx3_detection);
-                }
-
-                self.select_best_parser(cdx_detection, spdx_detection)
+                self.select_best_of_three(cdx_detection, spdx_detection, spdx3_detection)
             }
             Some(c) if c.is_ascii_alphabetic() => {
                 // Might be tag-value format (starts with letters like "SPDXVersion:")
                 let preview = String::from_utf8_lossy(peek);
                 let cdx_detection = self.cyclonedx.detect(&preview);
                 let spdx_detection = self.spdx.detect(&preview);
+                // SPDX 3.0 is JSON-LD only; detect() itself no-matches
+                // content that doesn't start with '{', so this is just for
+                // a single unified selection call, not a real candidate.
+                let spdx3_detection = self.spdx3.detect(&preview);
 
-                self.select_best_parser(cdx_detection, spdx_detection)
+                self.select_best_of_three(cdx_detection, spdx_detection, spdx3_detection)
             }
             Some(_) => DetectionResult::unknown("Unrecognized content format"),
             None => DetectionResult::unknown("Empty content"),
         }
     }
 
-    /// Select the best parser based on detection results.
+    /// Select the best parser among all three candidate detections.
     ///
     /// Uses consistent threshold checking and returns an error-like result
-    /// instead of defaulting to a specific parser when ambiguous.
-    fn select_best_parser(
+    /// instead of defaulting to a specific parser when ambiguous. Unlike a
+    /// short-circuit (e.g. "return SPDX 3.0 immediately if its confidence is
+    /// HIGH"), all three detections are computed and compared BEFORE any
+    /// selection, so a document that also satisfies another format's markers
+    /// as strongly cannot silently misroute or empty-parse: a genuine tie at
+    /// the top confidence is reported as ambiguous rather than resolved by
+    /// an arbitrary priority order.
+    fn select_best_of_three(
         &self,
         cdx_detection: FormatDetection,
         spdx_detection: FormatDetection,
+        spdx3_detection: FormatDetection,
     ) -> DetectionResult {
         let cdx_conf = cdx_detection.confidence.value();
         let spdx_conf = spdx_detection.confidence.value();
+        let spdx3_conf = spdx3_detection.confidence.value();
 
-        // Log detection for debugging
         tracing::debug!(
-            "Format detection: CycloneDX={:.2}, SPDX={:.2}, threshold={:.2}",
+            "Format detection: CycloneDX={:.2}, SPDX={:.2}, SPDX3={:.2}, threshold={:.2}",
             cdx_conf,
             spdx_conf,
+            spdx3_conf,
             self.min_confidence
         );
 
-        // Apply consistent threshold and select best parser
-        if cdx_conf >= self.min_confidence && cdx_conf > spdx_conf {
-            DetectionResult::cyclonedx(cdx_detection)
-        } else if spdx_conf >= self.min_confidence {
-            DetectionResult::spdx(spdx_detection)
-        } else {
-            // No default bias - return unknown if neither meets threshold
+        let max_conf = cdx_conf.max(spdx_conf).max(spdx3_conf);
+
+        if max_conf < self.min_confidence {
+            // No default bias - return unknown if nobody meets threshold
             let mut result =
                 DetectionResult::unknown("Could not detect SBOM format with sufficient confidence");
-
-            // Add helpful context about what was detected
-            if cdx_conf > 0.0 {
-                result.warnings.push(format!(
-                    "CycloneDX detection: {:.0}% confidence (threshold: {:.0}%)",
-                    cdx_conf * 100.0,
-                    self.min_confidence * 100.0
-                ));
+            for (name, conf) in [
+                ("CycloneDX", cdx_conf),
+                ("SPDX", spdx_conf),
+                ("SPDX 3.0", spdx3_conf),
+            ] {
+                if conf > 0.0 {
+                    result.warnings.push(format!(
+                        "{name} detection: {:.0}% confidence (threshold: {:.0}%)",
+                        conf * 100.0,
+                        self.min_confidence * 100.0
+                    ));
+                }
             }
-            if spdx_conf > 0.0 {
-                result.warnings.push(format!(
-                    "SPDX detection: {:.0}% confidence (threshold: {:.0}%)",
-                    spdx_conf * 100.0,
-                    self.min_confidence * 100.0
-                ));
-            }
+            return result;
+        }
 
-            result
+        // A tie at the top confidence between two or more formats is
+        // reported as ambiguous rather than resolved by priority order —
+        // this is what closes the misrouting/empty-parse class of bugs.
+        const EPSILON: f32 = 1e-6;
+        let winners: Vec<&str> = [
+            ("CycloneDX", cdx_conf),
+            ("SPDX", spdx_conf),
+            ("SPDX 3.0", spdx3_conf),
+        ]
+        .into_iter()
+        .filter(|&(_, conf)| (conf - max_conf).abs() < EPSILON)
+        .map(|(name, _)| name)
+        .collect();
+
+        if winners.len() > 1 {
+            return DetectionResult::unknown(&format!(
+                "Ambiguous format: {} are equally confident ({:.0}%) — refusing to guess",
+                winners.join(" and "),
+                max_conf * 100.0
+            ));
+        }
+
+        if (cdx_conf - max_conf).abs() < EPSILON {
+            DetectionResult::cyclonedx(cdx_detection)
+        } else if (spdx_conf - max_conf).abs() < EPSILON {
+            DetectionResult::spdx(spdx_detection)
+        } else {
+            DetectionResult::spdx3(spdx3_detection)
         }
     }
 
@@ -336,12 +351,20 @@ impl FormatDetector {
             return Err(ParseError::IoError("Empty content".to_string()));
         }
 
+        // detect_from_peek already skips a leading BOM for its own analysis;
+        // separately note its length so it can be consumed from the actual
+        // stream below — parse_json_reader reads straight from `reader` with
+        // no string-level strip_bom() pass, so the BOM must be physically
+        // skipped here or it reaches serde_json and fails to parse.
+        let bom_len = usize::from(peek.starts_with(&[0xEF, 0xBB, 0xBF])) * 3;
         let detection = self.detect_from_peek(peek);
 
         // Log any warnings
         for warning in &detection.warnings {
             tracing::warn!("{}", warning);
         }
+
+        reader.consume(bom_len);
 
         // Cap every downstream read at the file-size limit (+1 to detect
         // overrun). fill_buf only peeked, so the buffered bytes are preserved.
@@ -462,5 +485,79 @@ mod tests {
         if result.confidence.value() < 0.5 {
             assert!(!result.can_parse());
         }
+    }
+
+    /// A UTF-8 BOM must not defeat detection: str::trim() does not strip
+    /// U+FEFF, so a BOM-prefixed valid document previously failed on the
+    /// content.trim().starts_with('{') check in every parser's detect().
+    #[test]
+    fn bom_prefixed_content_still_detects() {
+        let detector = FormatDetector::new();
+        let content = "\u{FEFF}{\"bomFormat\": \"CycloneDX\", \"specVersion\": \"1.5\"}";
+        let result = detector.detect_from_content(content);
+        assert_eq!(result.parser, Some(ParserKind::CycloneDx));
+        assert!(result.can_parse());
+    }
+
+    /// Same BOM guard on the peek/streaming path.
+    #[test]
+    fn bom_prefixed_peek_still_detects() {
+        let detector = FormatDetector::new();
+        let mut peek = vec![0xEF, 0xBB, 0xBF];
+        peek.extend_from_slice(br#"{"bomFormat": "CycloneDX", "specVersion": "1.5"}"#);
+        let result = detector.detect_from_peek(&peek);
+        assert_eq!(result.parser, Some(ParserKind::CycloneDx));
+        assert!(result.can_parse());
+    }
+
+    /// A component/property VALUE that happens to equal a marker word
+    /// ("SPDXID") must not trip SPDX detection on an unrelated CycloneDX
+    /// document — the marker must appear as an actual JSON key.
+    #[test]
+    fn marker_word_as_value_does_not_misroute() {
+        let detector = FormatDetector::new();
+        let content = r#"{"bomFormat": "CycloneDX", "specVersion": "1.5",
+            "components": [{"type": "library", "name": "spdxVersion", "version": "1.0"},
+                            {"type": "library", "name": "SPDXID", "version": "1.0"}]}"#;
+        let result = detector.detect_from_content(content);
+        assert_eq!(
+            result.parser,
+            Some(ParserKind::CycloneDx),
+            "a component merely NAMED 'spdxVersion'/'SPDXID' must not misroute to SPDX"
+        );
+    }
+
+    /// A CycloneDX document that also contains "@context"/"spdx3" as plain
+    /// text (e.g. in a description) must not be misrouted to the SPDX 3.0
+    /// parser and silently produce an empty SBOM.
+    #[test]
+    fn cyclonedx_with_spdx3_looking_text_is_not_misrouted() {
+        let detector = FormatDetector::new();
+        let content = r#"{"bomFormat": "CycloneDX", "specVersion": "1.5",
+            "components": [{"type": "library", "name": "lib", "version": "1.0",
+                "description": "migrated from spdx3 format; see @context notes"}]}"#;
+        let result = detector.detect_from_content(content);
+        assert_eq!(result.parser, Some(ParserKind::CycloneDx));
+        assert!(result.can_parse());
+    }
+
+    /// A genuine tie at the top confidence between two formats must be
+    /// reported as ambiguous, not silently resolved by an arbitrary
+    /// priority order (the previous SPDX3-short-circuit / SPDX-tie-break
+    /// bias).
+    #[test]
+    fn genuine_tie_is_reported_ambiguous_not_silently_resolved() {
+        let detector = FormatDetector::new();
+        // CERTAIN CycloneDX markers (bomFormat + CycloneDX) AND CERTAIN SPDX
+        // markers (spdxVersion + SPDXID keys) in the same document.
+        let content = r#"{"bomFormat": "CycloneDX", "specVersion": "1.5",
+            "spdxVersion": "SPDX-2.3", "SPDXID": "SPDXRef-DOCUMENT"}"#;
+        let result = detector.detect_from_content(content);
+        assert!(
+            result.parser.is_none(),
+            "a genuine tie must not silently pick a parser, got {:?}",
+            result.parser
+        );
+        assert!(!result.can_parse());
     }
 }

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -90,6 +90,32 @@ pub fn detect_format(content: &str) -> Option<DetectedFormat> {
 /// whole document into a string. Inputs larger than this are rejected.
 pub(crate) const MAX_SBOM_FILE_SIZE: u64 = 512 * 1024 * 1024;
 
+/// Defensive cap on a single vulnerability description (64 KiB).
+///
+/// A vulnerability's description is attacker-controlled and attached to every
+/// component the vulnerability affects; without a cap, one huge description
+/// deep-cloned across thousands of `affects`/`to` targets is a memory-
+/// amplification DoS. Real CVE descriptions are a paragraph, so 64 KiB is
+/// ~100x headroom while bounding the per-target clone to a constant.
+pub(crate) const MAX_VULN_DESCRIPTION_BYTES: usize = 64 * 1024;
+
+/// Clone an optional description, truncated to [`MAX_VULN_DESCRIPTION_BYTES`]
+/// on a UTF-8 char boundary with a marker appended when truncated.
+pub(crate) fn capped_description(desc: &Option<String>) -> Option<String> {
+    desc.as_ref().map(|d| {
+        if d.len() <= MAX_VULN_DESCRIPTION_BYTES {
+            return d.clone();
+        }
+        let mut end = MAX_VULN_DESCRIPTION_BYTES;
+        while end > 0 && !d.is_char_boundary(end) {
+            end -= 1;
+        }
+        let mut truncated = d[..end].to_string();
+        truncated.push_str("… [truncated]");
+        truncated
+    })
+}
+
 /// Detect SBOM format from file content and parse accordingly
 ///
 /// Uses confidence-based detection to select the best parser.
@@ -140,6 +166,22 @@ pub fn is_spdx(content: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn capped_description_truncates_on_char_boundary() {
+        assert_eq!(capped_description(&None), None);
+        assert_eq!(
+            capped_description(&Some("short".to_string())).as_deref(),
+            Some("short")
+        );
+        // Multi-byte char straddling the cap must not panic and must produce
+        // valid UTF-8.
+        let big = "é".repeat(MAX_VULN_DESCRIPTION_BYTES); // 2 bytes each
+        let out = capped_description(&Some(big)).unwrap();
+        assert!(out.len() <= MAX_VULN_DESCRIPTION_BYTES + 16);
+        assert!(out.ends_with("… [truncated]"));
+        assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
 
     #[test]
     fn test_detect_cyclonedx_json() {

--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -37,7 +37,7 @@ pub use cyclonedx::CycloneDxParser;
 pub use detection::{DetectionResult, FormatDetector, MIN_CONFIDENCE_THRESHOLD, ParserKind};
 pub use spdx::SpdxParser;
 pub use spdx3::Spdx3Parser;
-pub use streaming::{ParseEvent, ParseProgress, StreamingConfig, StreamingParser};
+pub use streaming::{ParseEvent, ParseProgress, ParsedMetadata, StreamingConfig, StreamingParser};
 pub use traits::{FormatConfidence, FormatDetection, ParseError, SbomParser};
 
 use crate::model::NormalizedSbom;
@@ -89,6 +89,40 @@ pub fn detect_format(content: &str) -> Option<DetectedFormat> {
 /// Maximum SBOM file size (512 MB), enforced to bound memory use when loading a
 /// whole document into a string. Inputs larger than this are rejected.
 pub(crate) const MAX_SBOM_FILE_SIZE: u64 = 512 * 1024 * 1024;
+
+/// Strip a leading UTF-8 BOM (U+FEFF), if present.
+///
+/// `str::trim()` does not remove U+FEFF (it is not `White_Space`), so a
+/// BOM-prefixed but otherwise valid SBOM file fails every parser's
+/// `content.trim().starts_with('{'/'<')` dispatch and is rejected as
+/// unknown format. Every parser's `detect()`/`parse_str()` calls this first.
+pub(crate) fn strip_bom(content: &str) -> &str {
+    content.strip_prefix('\u{FEFF}').unwrap_or(content)
+}
+
+/// Whether `content` contains `key` used as a JSON object key — i.e. a
+/// quoted `key` immediately followed by (optional whitespace, then) `:` —
+/// rather than merely appearing as, or inside, a string *value* anywhere in
+/// the document.
+///
+/// Format detection scans raw text for markers like `"spdxVersion"` without
+/// parsing JSON, so a document whose value happens to equal a marker word
+/// (e.g. a component literally named `"spdxVersion"`, or a property value of
+/// `"SPDXID"`) previously tripped detection for an unrelated format. This
+/// keeps detection allocation-free and streaming-peek-compatible while
+/// requiring the marker to be used as a key, not a coincidental value.
+pub(crate) fn contains_json_key(content: &str, key: &str) -> bool {
+    let quoted = format!("\"{key}\"");
+    let mut search_from = 0;
+    while let Some(rel) = content[search_from..].find(quoted.as_str()) {
+        let after = search_from + rel + quoted.len();
+        if content[after..].trim_start().starts_with(':') {
+            return true;
+        }
+        search_from = after;
+    }
+    false
+}
 
 /// Defensive cap on a single vulnerability description (64 KiB).
 ///
@@ -181,6 +215,43 @@ mod tests {
         assert!(out.len() <= MAX_VULN_DESCRIPTION_BYTES + 16);
         assert!(out.ends_with("… [truncated]"));
         assert!(std::str::from_utf8(out.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn strip_bom_removes_only_a_leading_marker() {
+        assert_eq!(strip_bom("\u{FEFF}{\"a\":1}"), "{\"a\":1}");
+        assert_eq!(strip_bom("{\"a\":1}"), "{\"a\":1}");
+        // A BOM elsewhere in the content (not at the start) is untouched.
+        assert_eq!(strip_bom("{\"a\":\"\u{FEFF}\"}"), "{\"a\":\"\u{FEFF}\"}");
+    }
+
+    #[test]
+    fn contains_json_key_requires_key_position() {
+        assert!(contains_json_key(
+            r#"{"spdxVersion":"SPDX-2.3"}"#,
+            "spdxVersion"
+        ));
+        assert!(contains_json_key(
+            r#"{"spdxVersion"   :   "SPDX-2.3"}"#,
+            "spdxVersion"
+        ));
+        // A value equal to the marker word must NOT count as a key.
+        assert!(!contains_json_key(
+            r#"{"name":"spdxVersion","other":1}"#,
+            "spdxVersion"
+        ));
+        assert!(!contains_json_key("no markers here", "spdxVersion"));
+    }
+
+    /// A BOM-prefixed CycloneDX document must parse successfully end to end,
+    /// not just detect correctly — the dispatch check and the actual
+    /// serde_json::from_str/quick_xml call must both see BOM-free content.
+    #[test]
+    fn bom_prefixed_document_parses_end_to_end() {
+        let content = "\u{FEFF}{\"bomFormat\": \"CycloneDX\", \"specVersion\": \"1.5\", \
+            \"components\": [{\"type\": \"library\", \"name\": \"lib\", \"version\": \"1.0\"}]}";
+        let sbom = parse_sbom_str(content).expect("BOM-prefixed document must parse");
+        assert_eq!(sbom.component_count(), 1);
     }
 
     #[test]

--- a/src/parsers/spdx.rs
+++ b/src/parsers/spdx.rs
@@ -15,6 +15,38 @@ use quick_xml::events::Event;
 use serde::Deserialize;
 use std::collections::HashMap;
 
+/// Accumulate a possibly-multi-line SPDX `<text>…</text>` value.
+///
+/// If `first` opens a `<text>` block that doesn't close on the same line,
+/// consume subsequent lines from `rest` (joined with newlines) until the
+/// closing `</text>`, then strip both markers. A single-line value (or one
+/// with a matched `<text>…</text>`) is returned with markers stripped. This
+/// stops inner lines of a free-form field from being reparsed as tags.
+fn accumulate_text_block<'a, I: Iterator<Item = &'a str>>(first: &str, rest: &mut I) -> String {
+    let Some(after_open) = first.strip_prefix("<text>") else {
+        return first.to_string();
+    };
+    // Closes on the same line: strip both markers.
+    if let Some(inner) = after_open.strip_suffix("</text>") {
+        return inner.to_string();
+    }
+    if let Some(idx) = after_open.find("</text>") {
+        return after_open[..idx].to_string();
+    }
+    // Multi-line: keep raw lines until the closing tag.
+    let mut acc = String::from(after_open);
+    for line in rest.by_ref() {
+        if let Some(idx) = line.find("</text>") {
+            acc.push('\n');
+            acc.push_str(&line[..idx]);
+            break;
+        }
+        acc.push('\n');
+        acc.push_str(line);
+    }
+    acc
+}
+
 /// Parser for SPDX SBOM format
 #[allow(dead_code)]
 pub struct SpdxParser {
@@ -75,6 +107,11 @@ impl SpdxParser {
         };
 
         let mut current_package: Option<SpdxPackage> = None;
+        // Once a File section starts, its tags (including SPDXID) must not be
+        // attributed to the enclosing package — SPDX tag-value packages have
+        // no explicit terminator, so a File's SPDXID used to clobber the
+        // package's.
+        let mut in_file_section = false;
         let mut packages = Vec::new();
         let mut relationships = Vec::new();
         let mut creation_info = SpdxCreationInfo {
@@ -84,23 +121,40 @@ impl SpdxParser {
             comment: None,
         };
 
-        for line in content.lines() {
-            let line = line.trim();
+        let mut lines = content.lines();
+        while let Some(raw) = lines.next() {
+            let line = raw.trim();
             if line.is_empty() || line.starts_with('#') {
                 continue;
             }
 
             if let Some((key, value)) = line.split_once(':') {
                 let key = key.trim();
-                let value = value.trim();
+                // Free-form fields may be wrapped in a multi-line
+                // <text>…</text> block. Accumulate until the closing tag so
+                // inner lines are NOT reparsed as top-level tags (which let a
+                // crafted description inject SPDXID/Created/etc.).
+                let value = accumulate_text_block(value.trim(), &mut lines);
+                let value = value.as_str();
 
                 match key {
                     "SPDXVersion" => doc.spdx_version = value.to_string(),
+                    "FileName" => {
+                        // A File section begins: close the current package so
+                        // subsequent File tags can't overwrite it.
+                        if let Some(pkg) = current_package.take() {
+                            packages.push(pkg);
+                        }
+                        in_file_section = true;
+                    }
                     "SPDXID" if current_package.is_some() => {
                         if let Some(ref mut pkg) = current_package {
                             pkg.spdx_id = value.to_string();
                         }
                     }
+                    // A File's SPDXID (or any SPDXID once we're past the header)
+                    // must not overwrite the document SPDXID.
+                    "SPDXID" if in_file_section => {}
                     "SPDXID" => doc.spdx_id = value.to_string(),
                     "DocumentName" => doc.name = value.to_string(),
                     "DataLicense" => doc.data_license = value.to_string(),
@@ -115,6 +169,7 @@ impl SpdxParser {
                         if let Some(pkg) = current_package.take() {
                             packages.push(pkg);
                         }
+                        in_file_section = false;
                         current_package = Some(SpdxPackage {
                             spdx_id: String::new(),
                             name: value.to_string(),
@@ -1211,4 +1266,67 @@ struct SpdxExternalDocRef {
     external_document_id: String,
     spdx_document: String,
     checksum: SpdxChecksum,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parsers::traits::SbomParser;
+
+    fn parse_tv(content: &str) -> NormalizedSbom {
+        SpdxParser::new()
+            .parse_str(content)
+            .expect("tag-value should parse")
+    }
+
+    fn component<'a>(sbom: &'a NormalizedSbom, name: &str) -> &'a crate::model::Component {
+        sbom.components
+            .values()
+            .find(|c| c.name == name)
+            .unwrap_or_else(|| panic!("component {name} not found"))
+    }
+
+    /// A File section's SPDXID must not overwrite the enclosing package's
+    /// SPDXID (packages have no explicit terminator in tag-value).
+    #[test]
+    fn tag_value_file_spdxid_does_not_clobber_package() {
+        let sbom = parse_tv(
+            "SPDXVersion: SPDX-2.3\n\
+             SPDXID: SPDXRef-DOCUMENT\n\
+             DocumentName: test\n\
+             PackageName: libfoo\n\
+             SPDXID: SPDXRef-Package-libfoo\n\
+             PackageVersion: 1.0\n\
+             FileName: ./src/main.c\n\
+             SPDXID: SPDXRef-File-main\n",
+        );
+        let comp = component(&sbom, "libfoo");
+        assert_eq!(
+            comp.identifiers.format_id, "SPDXRef-Package-libfoo",
+            "the File SPDXID must not overwrite the package SPDXID"
+        );
+    }
+
+    /// A multi-line <text> block must be captured as one value; its inner
+    /// lines must NOT be reparsed as tags (SPDXID/Created injection).
+    #[test]
+    fn tag_value_multiline_text_block_is_not_reparsed() {
+        let sbom = parse_tv(
+            "SPDXVersion: SPDX-2.3\n\
+             SPDXID: SPDXRef-DOCUMENT\n\
+             DocumentName: test\n\
+             PackageName: libfoo\n\
+             SPDXID: SPDXRef-Package-libfoo\n\
+             PackageCopyrightText: <text>Copyright ACME\n\
+             SPDXID: SPDXRef-INJECTED\n\
+             Created: 1999-01-01T00:00:00Z</text>\n\
+             PackageVersion: 2.0\n",
+        );
+        let comp = component(&sbom, "libfoo");
+        // The injected SPDXID inside the <text> block must not have taken
+        // effect; the real package id survives and the version after the
+        // block still parses.
+        assert_eq!(comp.identifiers.format_id, "SPDXRef-Package-libfoo");
+        assert_eq!(comp.version.as_deref(), Some("2.0"));
+    }
 }

--- a/src/parsers/spdx.rs
+++ b/src/parsers/spdx.rs
@@ -870,7 +870,13 @@ impl SpdxParser {
             .as_ref()
             .and_then(|ci| ci.created.as_ref())
             .and_then(|c| DateTime::parse_from_rfc3339(c).ok())
-            .map_or_else(Utc::now, |dt| dt.with_timezone(&Utc));
+            // Deterministic fallback: a document with a missing/invalid
+            // timestamp must hash identically on every parse (created is
+            // folded into the content hash; Utc::now() here made every
+            // parse of such a document content-unique, defeating diff
+            // identity and the incremental cache). Epoch is an honest
+            // "unknown" sentinel rather than a fabricated parse time.
+            .map_or(DateTime::UNIX_EPOCH, |dt| dt.with_timezone(&Utc));
 
         let mut creators = Vec::new();
         if let Some(creation_info) = &spdx.creation_info {

--- a/src/parsers/spdx.rs
+++ b/src/parsers/spdx.rs
@@ -1040,6 +1040,7 @@ impl Default for SpdxParser {
 
 impl SbomParser for SpdxParser {
     fn parse_str(&self, content: &str) -> Result<NormalizedSbom, ParseError> {
+        let content = super::strip_bom(content);
         let trimmed = content.trim();
         if trimmed.starts_with('{') {
             self.parse_json(content)
@@ -1067,16 +1068,21 @@ impl SbomParser for SpdxParser {
     }
 
     fn detect(&self, content: &str) -> crate::parsers::traits::FormatDetection {
+        use crate::parsers::contains_json_key;
         use crate::parsers::traits::{FormatConfidence, FormatDetection};
 
+        let content = super::strip_bom(content);
         let trimmed = content.trim();
 
-        // Check for JSON SPDX
+        // Check for JSON SPDX. Marker keys must appear as actual JSON keys,
+        // not a coincidental string VALUE elsewhere (e.g. a CycloneDX
+        // component or property literally named/valued "spdxVersion" or
+        // "SPDXID" previously tripped SPDX detection for an unrelated file).
         if trimmed.starts_with('{') {
-            let has_spdx_version = content.contains("\"spdxVersion\"");
-            let has_spdx_id = content.contains("\"SPDXID\"");
-            let has_data_license = content.contains("\"dataLicense\"");
-            let has_packages = content.contains("\"packages\"");
+            let has_spdx_version = contains_json_key(content, "spdxVersion");
+            let has_spdx_id = contains_json_key(content, "SPDXID");
+            let has_data_license = contains_json_key(content, "dataLicense");
+            let has_packages = contains_json_key(content, "packages");
 
             // Extract version if possible
             let version = Self::extract_spdx_version(content);

--- a/src/parsers/spdx3.rs
+++ b/src/parsers/spdx3.rs
@@ -66,8 +66,16 @@ impl Spdx3Parser {
         let mut seen_ids: HashSet<String> = HashSet::new();
         let mut duplicate_count: usize = 0;
 
-        // First pass: categorize elements by type (move, not clone)
-        if let Some(elements) = doc.element.take() {
+        // First pass: categorize elements by type (move, not clone).
+        // Elements may be provided inline (`element`) or as a JSON-LD flat
+        // graph (`@graph`); handle both, chained.
+        let elements = doc
+            .element
+            .take()
+            .into_iter()
+            .flatten()
+            .chain(doc.graph.take().into_iter().flatten());
+        {
             for element in elements {
                 // Track duplicate element IDs
                 let element_id = match &element {
@@ -167,6 +175,28 @@ impl Spdx3Parser {
                         if let Some(id) = lic.spdx_id {
                             let text = lic.license_text.unwrap_or_default();
                             license_elements.insert(id, text);
+                        }
+                    }
+                    Spdx3Element::SpdxDocument(inner) => {
+                        // In @graph serialization the document metadata lives
+                        // on a node inside the graph, not the top level.
+                        // Lift it (without clobbering an already-populated
+                        // top-level document, e.g. a mixed serialization).
+                        let inner = *inner;
+                        if doc.name.is_none() {
+                            doc.name = inner.name;
+                        }
+                        if doc.creation_info.is_none() {
+                            doc.creation_info = inner.creation_info;
+                        }
+                        if doc.root_element.is_none() {
+                            doc.root_element = inner.root_element;
+                        }
+                        if doc.spdx_id.is_none() {
+                            doc.spdx_id = inner.spdx_id;
+                        }
+                        if doc.description.is_none() {
+                            doc.description = inner.description;
                         }
                     }
                     _ => {} // Skip unknown element types
@@ -909,59 +939,91 @@ impl Spdx3Parser {
         license_elements: &HashMap<String, String>,
     ) {
         let rel_type = rel.relationship_type.as_deref().unwrap_or("");
+        // SPDX 3.0 JSON-LD serializes relationship types in camelCase
+        // ("dependsOn", "hasDeclaredLicense", "fixedIn"); older/underscore
+        // forms ("DEPENDS_ON") also occur. Normalize BOTH to UPPER_SNAKE so
+        // spec-compliant camelCase documents don't parse to zero edges (a
+        // bare to_uppercase() turned "dependsOn" into "DEPENDSON", matching
+        // no arm).
+        let normalized = normalize_relationship_type(rel_type);
+        // Inverse (`*_OF` / `GENERATED_FROM` / `*_TOOL_OF`) relationships
+        // read "A is a dependency of B" = B depends on A, so their edge is
+        // swapped relative to the forward form. Types with a dedicated
+        // DependencyType (ContainedBy/AncestorOf/VariantOf/Patch/Copy/…)
+        // keep from→to, since the type itself encodes the direction.
+        let swap = is_inverse_dependency(&normalized);
 
-        match rel_type.to_uppercase().as_str() {
+        match normalized.as_str() {
             // Dependency relationships -> DependencyEdge
             "DEPENDS_ON" | "DEPENDENCY_OF" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::DependsOn);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::DependsOn, swap);
             }
             "DEV_DEPENDENCY_OF" | "DEV_DEPENDS_ON" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::DevDependsOn);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::DevDependsOn, swap);
             }
             "BUILD_DEPENDENCY_OF" | "BUILD_DEPENDS_ON" | "BUILD_TOOL_OF" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::BuildDependsOn);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::BuildDependsOn, swap);
             }
             "TEST_DEPENDENCY_OF" | "TEST_DEPENDS_ON" | "TEST_TOOL_OF" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::TestDependsOn);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::TestDependsOn, swap);
             }
             "RUNTIME_DEPENDENCY_OF" | "RUNTIME_DEPENDS_ON" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::RuntimeDependsOn);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::RuntimeDependsOn, swap);
             }
             "OPTIONAL_DEPENDENCY_OF" | "OPTIONAL_DEPENDS_ON" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::OptionalDependsOn);
+                self.add_dependency_edge(
+                    rel,
+                    id_map,
+                    sbom,
+                    DependencyType::OptionalDependsOn,
+                    swap,
+                );
             }
             "PROVIDED_DEPENDENCY_OF" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::ProvidedDependsOn);
+                self.add_dependency_edge(
+                    rel,
+                    id_map,
+                    sbom,
+                    DependencyType::ProvidedDependsOn,
+                    swap,
+                );
             }
             "CONTAINS" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::Contains);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::Contains, false);
             }
             "DESCRIBES" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::Describes);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::Describes, false);
             }
             "GENERATES" | "GENERATED_FROM" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::Generates);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::Generates, swap);
             }
             "ANCESTOR_OF" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::AncestorOf);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::AncestorOf, false);
             }
             "VARIANT_OF" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::VariantOf);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::VariantOf, false);
             }
             "DISTRIBUTION_ARTIFACT" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::DistributionArtifact);
+                self.add_dependency_edge(
+                    rel,
+                    id_map,
+                    sbom,
+                    DependencyType::DistributionArtifact,
+                    false,
+                );
             }
             "PATCH_FOR" | "PATCH_APPLIED" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::PatchFor);
+                // Both have from=patch, to=target (same direction per spec).
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::PatchFor, false);
             }
             "COPY_OF" | "EXPANDED_FROM_ARCHIVE" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::CopyOf);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::CopyOf, false);
             }
             "DYNAMIC_LINK" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::DynamicLink);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::DynamicLink, false);
             }
             "STATIC_LINK" => {
-                self.add_dependency_edge(rel, id_map, sbom, DependencyType::StaticLink);
+                self.add_dependency_edge(rel, id_map, sbom, DependencyType::StaticLink, false);
             }
 
             // License relationships -> populate Component.licenses
@@ -975,7 +1037,7 @@ impl Spdx3Parser {
                             && let Some(comp) = sbom.components.get_mut(canonical_id)
                         {
                             let lic = LicenseExpression::new(expr.clone());
-                            if rel_type.to_uppercase().contains("CONCLUDED") {
+                            if normalized.contains("CONCLUDED") {
                                 comp.licenses.concluded = Some(lic);
                             } else {
                                 comp.licenses.add_declared(lic);
@@ -1049,13 +1111,12 @@ impl Spdx3Parser {
                 // These are processed in process_vuln_assessment()
             }
 
-            // AI profile: an ai_AIPackage TRAINED_ON a dataset. SPDX 3.0 JSON-LD
-            // uppercases the relationship type WITHOUT an underscore ("trainedOn"
-            // → "TRAINEDON"), so the canonical key has no separator. This is the
-            // SPDX equivalent of CycloneDX `modelParameters.datasets`; populate the
-            // model's typed `training_datasets` so AI-003 passes for SPDX too.
-            // `testedOn` is intentionally not treated as a training dataset.
-            "TRAINEDON" | "TRAINED_ON" => {
+            // AI profile: an ai_AIPackage TRAINED_ON a dataset (SPDX 3.0
+            // JSON-LD "trainedOn"). The SPDX equivalent of CycloneDX
+            // `modelParameters.datasets`; populate the model's typed
+            // `training_datasets` so AI-003 passes for SPDX too. `testedOn`
+            // is intentionally not treated as a training dataset.
+            "TRAINED_ON" => {
                 if let Some(from_ref) = &rel.from
                     && let Some(from_id) = id_map.get(from_ref)
                     && let Some(to_refs) = &rel.to
@@ -1087,19 +1148,25 @@ impl Spdx3Parser {
                         id_map,
                         sbom,
                         DependencyType::Other(rel_type.to_string()),
+                        false,
                     );
                 }
             }
         }
     }
 
-    /// Add a dependency edge from a relationship
+    /// Add a dependency edge from a relationship.
+    ///
+    /// `swap` reverses the edge direction for inverse relationship types
+    /// (`*_OF`): SPDX "A DEPENDENCY_OF B" means B depends on A, so the edge
+    /// runs to→from rather than from→to.
     fn add_dependency_edge(
         &self,
         rel: &Spdx3Relationship,
         id_map: &HashMap<String, CanonicalId>,
         sbom: &mut NormalizedSbom,
         dep_type: DependencyType,
+        swap: bool,
     ) {
         if let Some(from_ref) = &rel.from
             && let Some(from_id) = id_map.get(from_ref)
@@ -1107,11 +1174,12 @@ impl Spdx3Parser {
         {
             for to_ref in to_refs {
                 if let Some(to_id) = id_map.get(to_ref) {
-                    sbom.add_edge(DependencyEdge::new(
-                        from_id.clone(),
-                        to_id.clone(),
-                        dep_type.clone(),
-                    ));
+                    let (src, dst) = if swap {
+                        (to_id.clone(), from_id.clone())
+                    } else {
+                        (from_id.clone(), to_id.clone())
+                    };
+                    sbom.add_edge(DependencyEdge::new(src, dst, dep_type.clone()));
                 }
             }
         }
@@ -1263,6 +1331,46 @@ impl Spdx3Parser {
     }
 }
 
+/// Normalize a relationship type to UPPER_SNAKE_CASE.
+///
+/// Accepts both the SPDX 3.0 JSON-LD camelCase form ("dependsOn") and the
+/// underscore form ("DEPENDS_ON"): a `_` is inserted at each lower→upper
+/// camelCase boundary and the whole string uppercased, so both map to the
+/// same key. Without this, camelCase types uppercased to "DEPENDSON" and
+/// matched no arm, so spec-compliant documents parsed with zero edges.
+fn normalize_relationship_type(rel_type: &str) -> String {
+    let mut out = String::with_capacity(rel_type.len() + 4);
+    let mut prev_lower_or_digit = false;
+    for ch in rel_type.chars() {
+        if ch.is_ascii_uppercase() && prev_lower_or_digit {
+            out.push('_');
+        }
+        // Underscores already present pass through; runs won't double because
+        // an existing '_' resets prev_lower_or_digit to false.
+        out.push(ch.to_ascii_uppercase());
+        prev_lower_or_digit = ch.is_ascii_lowercase() || ch.is_ascii_digit();
+    }
+    out
+}
+
+/// Whether a (normalized) relationship type is the inverse of a forward
+/// dependency and therefore needs its edge direction swapped.
+fn is_inverse_dependency(normalized: &str) -> bool {
+    matches!(
+        normalized,
+        "DEPENDENCY_OF"
+            | "DEV_DEPENDENCY_OF"
+            | "BUILD_DEPENDENCY_OF"
+            | "TEST_DEPENDENCY_OF"
+            | "RUNTIME_DEPENDENCY_OF"
+            | "OPTIONAL_DEPENDENCY_OF"
+            | "PROVIDED_DEPENDENCY_OF"
+            | "BUILD_TOOL_OF"
+            | "TEST_TOOL_OF"
+            | "GENERATED_FROM"
+    )
+}
+
 /// Map SPDX 3.0 hash algorithm names to our enum
 fn map_spdx3_hash_algorithm(algo: &str) -> HashAlgorithm {
     match algo.to_uppercase().as_str() {
@@ -1314,8 +1422,16 @@ struct Spdx3Document {
     imports: Option<Vec<Spdx3ExternalMap>>,
     /// Root elements (URIs of primary elements)
     root_element: Option<Vec<String>>,
-    /// All elements in the document
+    /// All elements in the document (embedded serialization)
     element: Option<Vec<Spdx3Element>>,
+    /// JSON-LD `@graph` node set. The canonical SPDX 3.0/3.0.1 serialization
+    /// (pyspdx and the spec examples) is a flat graph — `{"@graph":[ …all
+    /// elements…, {"type":"SpdxDocument", …} ]}` — rather than an
+    /// SpdxDocument with an inline `element` array. Without this the parser
+    /// only read `element` and produced a silently empty SBOM for
+    /// spec-conformant documents.
+    #[serde(rename = "@graph")]
+    graph: Option<Vec<Spdx3Element>>,
     /// Profile conformance declarations
     profile_conformance: Option<Vec<String>>,
     /// Integrity methods (hash/signature)
@@ -1428,9 +1544,28 @@ enum Spdx3Element {
     SsvcAssessment(Spdx3VulnAssessment),
     /// Lifecycle-scoped relationship
     LifecycleScopedRelationship(Spdx3Relationship),
+    /// An SpdxDocument node appearing INSIDE a JSON-LD `@graph` (its
+    /// metadata is lifted into the top-level document, which is empty in
+    /// that serialization). Its `element`/`rootElement` are ID-reference
+    /// strings, so it uses a metadata-only struct rather than the full
+    /// `Spdx3Document` (whose `element` is objects).
+    SpdxDocument(Box<Spdx3DocumentMeta>),
     /// Catch-all for unknown types (deserialized as raw JSON)
     #[serde(other)]
     Unknown,
+}
+
+/// Metadata-only view of an SpdxDocument node inside a JSON-LD `@graph`.
+/// Deliberately omits `element` (string ID refs there, not objects), which
+/// serde then ignores.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct Spdx3DocumentMeta {
+    spdx_id: Option<String>,
+    name: Option<String>,
+    creation_info: Option<Spdx3CreationInfo>,
+    root_element: Option<Vec<String>>,
+    description: Option<String>,
 }
 
 /// SPDX 3.0 Package (Software profile)
@@ -1980,6 +2115,119 @@ mod tests {
             .values()
             .find(|c| c.name == name)
             .expect("component present")
+    }
+
+    #[test]
+    fn normalize_relationship_type_handles_camel_and_snake() {
+        assert_eq!(normalize_relationship_type("dependsOn"), "DEPENDS_ON");
+        assert_eq!(normalize_relationship_type("DEPENDS_ON"), "DEPENDS_ON");
+        assert_eq!(normalize_relationship_type("dependencyOf"), "DEPENDENCY_OF");
+        assert_eq!(
+            normalize_relationship_type("hasDeclaredLicense"),
+            "HAS_DECLARED_LICENSE"
+        );
+        assert_eq!(normalize_relationship_type("fixedIn"), "FIXED_IN");
+        assert_eq!(normalize_relationship_type("buildToolOf"), "BUILD_TOOL_OF");
+        assert!(is_inverse_dependency("DEPENDENCY_OF"));
+        assert!(is_inverse_dependency("GENERATED_FROM"));
+        assert!(!is_inverse_dependency("DEPENDS_ON"));
+        assert!(!is_inverse_dependency("CONTAINS"));
+    }
+
+    fn edge_between<'a>(sbom: &'a NormalizedSbom, from_name: &str, to_name: &str) -> bool {
+        let id = |name: &str| {
+            sbom.components
+                .iter()
+                .find(|(_, c)| c.name == name)
+                .map(|(id, _)| id.clone())
+        };
+        let (Some(f), Some(t)) = (id(from_name), id(to_name)) else {
+            return false;
+        };
+        sbom.edges.iter().any(|e| e.from == f && e.to == t)
+    }
+
+    /// SPDX 3.0 JSON-LD camelCase `dependsOn` must produce a dependency edge
+    /// (a bare to_uppercase turned it into "DEPENDSON", matching no arm →
+    /// zero edges for spec-compliant documents).
+    #[test]
+    fn spdx3_camelcase_relationship_produces_edge() {
+        let doc = r#"{
+          "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+          "type": "SpdxDocument", "spdxId": "urn:doc",
+          "element": [
+            {"type": "software_Package", "spdxId": "urn:app", "name": "app",
+             "software_packageUrl": "pkg:npm/app@1.0"},
+            {"type": "software_Package", "spdxId": "urn:lib", "name": "lib",
+             "software_packageUrl": "pkg:npm/lib@1.0"},
+            {"type": "Relationship", "spdxId": "urn:rel",
+             "relationshipType": "dependsOn", "from": "urn:app", "to": ["urn:lib"]}
+          ]
+        }"#;
+        let sbom = Spdx3Parser::new().parse_str(doc).expect("parse");
+        assert!(
+            edge_between(&sbom, "app", "lib"),
+            "camelCase dependsOn must yield app→lib, edges={:?}",
+            sbom.edges
+        );
+    }
+
+    /// An inverse `dependencyOf` relationship must be direction-swapped:
+    /// "lib dependencyOf app" means app depends on lib → edge app→lib.
+    #[test]
+    fn spdx3_inverse_dependency_swaps_direction() {
+        let doc = r#"{
+          "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+          "type": "SpdxDocument", "spdxId": "urn:doc",
+          "element": [
+            {"type": "software_Package", "spdxId": "urn:app", "name": "app",
+             "software_packageUrl": "pkg:npm/app@1.0"},
+            {"type": "software_Package", "spdxId": "urn:lib", "name": "lib",
+             "software_packageUrl": "pkg:npm/lib@1.0"},
+            {"type": "Relationship", "spdxId": "urn:rel",
+             "relationshipType": "dependencyOf", "from": "urn:lib", "to": ["urn:app"]}
+          ]
+        }"#;
+        let sbom = Spdx3Parser::new().parse_str(doc).expect("parse");
+        assert!(
+            edge_between(&sbom, "app", "lib"),
+            "dependencyOf must swap to app→lib, edges={:?}",
+            sbom.edges
+        );
+        assert!(
+            !edge_between(&sbom, "lib", "app"),
+            "the un-swapped lib→app edge must not exist"
+        );
+    }
+
+    /// The canonical @graph JSON-LD serialization must parse to a populated
+    /// SBOM (was silently empty — only the inline `element` array was read).
+    #[test]
+    fn spdx3_graph_envelope_is_not_empty() {
+        let doc = r#"{
+          "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+          "@graph": [
+            {"type": "SpdxDocument", "spdxId": "urn:doc", "name": "d",
+             "rootElement": ["urn:app"], "element": ["urn:app", "urn:lib", "urn:rel"]},
+            {"type": "software_Package", "spdxId": "urn:app", "name": "app",
+             "software_packageUrl": "pkg:npm/app@1.0"},
+            {"type": "software_Package", "spdxId": "urn:lib", "name": "lib",
+             "software_packageUrl": "pkg:npm/lib@1.0"},
+            {"type": "Relationship", "spdxId": "urn:rel",
+             "relationshipType": "dependsOn", "from": "urn:app", "to": ["urn:lib"]}
+          ]
+        }"#;
+        let sbom = Spdx3Parser::new().parse_str(doc).expect("parse");
+        assert_eq!(sbom.component_count(), 2, "@graph elements must be parsed");
+        assert!(edge_between(&sbom, "app", "lib"));
+        // Document metadata and the primary component are lifted from the
+        // in-@graph SpdxDocument node (CRA compliance keys on the primary).
+        assert_eq!(sbom.document.name.as_deref(), Some("d"));
+        assert_eq!(
+            sbom.primary_component().map(|c| c.name.as_str()),
+            Some("app"),
+            "rootElement must designate the primary component in @graph mode"
+        );
     }
 
     /// An AFFECTS relationship with a duplicated `to` target must attach the

--- a/src/parsers/spdx3.rs
+++ b/src/parsers/spdx3.rs
@@ -750,8 +750,9 @@ impl Spdx3Parser {
         // Use resolved VEX state from enum variant discrimination
         let vex_state = assessment.resolved_vex_state.clone();
 
-        // Extract CVSS score if present
-        let cvss_score = assessment.score.map(|score| {
+        // Extract CVSS score if present. Reject non-finite (NaN/inf) scores
+        // so a hostile value can't reach severity derivation.
+        let cvss_score = assessment.score.filter(|s| s.is_finite()).map(|score| {
             // Infer version from vector string (more precise), fallback to variant type
             let version = assessment.vector.as_deref().map_or_else(
                 || {
@@ -782,19 +783,23 @@ impl Spdx3Parser {
             cs
         });
 
-        // Map justification string to enum
-        let justification = assessment.justification.as_deref().map(|j| {
+        // Map justification string to enum. Unknown/unrecognized yields None,
+        // never fabricating a strong not-affected justification from hostile
+        // or malformed input.
+        let justification = assessment.justification.as_deref().and_then(|j| {
             match j.to_lowercase().replace(['-', '_'], "").as_str() {
-                "componentnotpresent" => VexJustification::ComponentNotPresent,
-                "vulnerablecodenotpresent" => VexJustification::VulnerableCodeNotPresent,
+                "componentnotpresent" => Some(VexJustification::ComponentNotPresent),
+                "vulnerablecodenotpresent" => Some(VexJustification::VulnerableCodeNotPresent),
                 "vulnerablecodenotinexecutepath" => {
-                    VexJustification::VulnerableCodeNotInExecutePath
+                    Some(VexJustification::VulnerableCodeNotInExecutePath)
                 }
                 "vulnerablecodecannotbecontrolledbyadversary" => {
-                    VexJustification::VulnerableCodeCannotBeControlledByAdversary
+                    Some(VexJustification::VulnerableCodeCannotBeControlledByAdversary)
                 }
-                "inlinemitigationsalreadyexist" => VexJustification::InlineMitigationsAlreadyExist,
-                _ => VexJustification::VulnerableCodeNotPresent, // fallback
+                "inlinemitigationsalreadyexist" => {
+                    Some(VexJustification::InlineMitigationsAlreadyExist)
+                }
+                _ => None,
             }
         });
 
@@ -987,12 +992,18 @@ impl Spdx3Parser {
                     && let Some(vuln) = vuln_map.get(from_ref)
                     && let Some(to_refs) = &rel.to
                 {
+                    // Convert ONCE (capped description) and clone per target,
+                    // deduped: rebuilding per `to` entry re-clones the
+                    // attacker-controlled description — a memory-amplification
+                    // DoS from one relationship with a huge `to` array.
+                    let vuln_ref = self.convert_vulnerability(vuln);
+                    let mut seen: HashSet<&CanonicalId> = HashSet::new();
                     for to_ref in to_refs {
-                        if let Some(canonical_id) = id_map.get(to_ref) {
-                            let vuln_ref = self.convert_vulnerability(vuln);
-                            if let Some(comp) = sbom.components.get_mut(canonical_id) {
-                                comp.vulnerabilities.push(vuln_ref);
-                            }
+                        if let Some(canonical_id) = id_map.get(to_ref)
+                            && seen.insert(canonical_id)
+                            && let Some(comp) = sbom.components.get_mut(canonical_id)
+                        {
+                            comp.vulnerabilities.push(vuln_ref.clone());
                         }
                     }
                 }
@@ -1004,10 +1015,23 @@ impl Spdx3Parser {
                     && let Some(vuln) = vuln_map.get(from_ref)
                     && let Some(to_refs) = &rel.to
                 {
+                    let mut base = self.convert_vulnerability(vuln);
+                    base.vex_status = Some(VexStatus {
+                        status: VexState::Fixed,
+                        justification: None,
+                        action_statement: None,
+                        impact_statement: None,
+                        responses: Vec::new(),
+                        detail: None,
+                    });
+                    let mut seen: HashSet<&CanonicalId> = HashSet::new();
                     for to_ref in to_refs {
-                        if let Some(canonical_id) = id_map.get(to_ref) {
-                            let mut vuln_ref = self.convert_vulnerability(vuln);
-                            vuln_ref.vex_status = Some(VexStatus {
+                        if let Some(canonical_id) = id_map.get(to_ref)
+                            && seen.insert(canonical_id)
+                            && let Some(comp) = sbom.components.get_mut(canonical_id)
+                        {
+                            comp.vulnerabilities.push(base.clone());
+                            comp.vex_status = Some(VexStatus {
                                 status: VexState::Fixed,
                                 justification: None,
                                 action_statement: None,
@@ -1015,17 +1039,6 @@ impl Spdx3Parser {
                                 responses: Vec::new(),
                                 detail: None,
                             });
-                            if let Some(comp) = sbom.components.get_mut(canonical_id) {
-                                comp.vulnerabilities.push(vuln_ref);
-                                comp.vex_status = Some(VexStatus {
-                                    status: VexState::Fixed,
-                                    justification: None,
-                                    action_statement: None,
-                                    impact_statement: None,
-                                    responses: Vec::new(),
-                                    detail: None,
-                                });
-                            }
                         }
                     }
                 }
@@ -1133,7 +1146,7 @@ impl Spdx3Parser {
         };
 
         let mut vuln_ref = VulnerabilityRef::new(id, source);
-        vuln_ref.description.clone_from(&vuln.description);
+        vuln_ref.description = super::capped_description(&vuln.description);
 
         // Parse published/modified times
         if let Some(t) = &vuln.published_time {
@@ -1942,6 +1955,65 @@ mod tests {
             ds.sensitivity_classifications
                 .contains(&"amber".to_string())
         );
+    }
+
+    fn spdx3_lib(elements: &str) -> NormalizedSbom {
+        let doc = format!(
+            r#"{{
+              "@context": "https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+              "type": "SpdxDocument", "spdxId": "urn:doc",
+              "element": [
+                {{"type": "software_Package", "spdxId": "urn:pkg:lib", "name": "lib",
+                 "software_packageVersion": "1.0",
+                 "software_packageUrl": "pkg:npm/lib@1.0"}},
+                {{"type": "security_Vulnerability", "spdxId": "urn:vuln:cve",
+                 "name": "CVE-2025-9999", "description": "boom"}},
+                {elements}
+              ]
+            }}"#
+        );
+        Spdx3Parser::new().parse_str(&doc).expect("parse")
+    }
+
+    fn spdx3_component<'a>(sbom: &'a NormalizedSbom, name: &str) -> &'a Component {
+        sbom.components
+            .values()
+            .find(|c| c.name == name)
+            .expect("component present")
+    }
+
+    /// An AFFECTS relationship with a duplicated `to` target must attach the
+    /// vuln once (dedup, bounding the memory-amplification fan-out).
+    #[test]
+    fn spdx3_affects_dedups_duplicate_targets() {
+        let sbom = spdx3_lib(
+            r#"{"type": "Relationship", "spdxId": "urn:rel:affects",
+                "relationshipType": "AFFECTS", "from": "urn:vuln:cve",
+                "to": ["urn:pkg:lib", "urn:pkg:lib", "urn:pkg:lib"]}"#,
+        );
+        assert_eq!(
+            spdx3_component(&sbom, "lib").vulnerabilities.len(),
+            1,
+            "duplicated AFFECTS targets must dedup, not attach N times"
+        );
+    }
+
+    /// An unknown VEX justification must yield None, never fabricate the
+    /// strong VulnerableCodeNotPresent not-affected claim.
+    #[test]
+    fn spdx3_unknown_vex_justification_is_none() {
+        let sbom = spdx3_lib(
+            r#"{"type": "security_VexNotAffectedVulnAssessmentRelationship",
+                "spdxId": "urn:assess:vex", "from": "urn:vuln:cve",
+                "assessedElement": "urn:pkg:lib",
+                "security_justificationType": "totally_made_up"}"#,
+        );
+        if let Some(vex) = &spdx3_component(&sbom, "lib").vex_status {
+            assert_eq!(
+                vex.justification, None,
+                "unknown justification must not fabricate a strong claim"
+            );
+        }
     }
 
     #[test]

--- a/src/parsers/spdx3.rs
+++ b/src/parsers/spdx3.rs
@@ -342,7 +342,13 @@ impl Spdx3Parser {
             .as_ref()
             .and_then(|ci| ci.created.as_ref())
             .and_then(|t| DateTime::parse_from_rfc3339(t).ok())
-            .map_or_else(Utc::now, |dt| dt.with_timezone(&Utc));
+            // Deterministic fallback: a document with a missing/invalid
+            // timestamp must hash identically on every parse (created is
+            // folded into the content hash; Utc::now() here made every
+            // parse of such a document content-unique, defeating diff
+            // identity and the incremental cache). Epoch is an honest
+            // "unknown" sentinel rather than a fabricated parse time.
+            .map_or(DateTime::UNIX_EPOCH, |dt| dt.with_timezone(&Utc));
 
         let mut creators = Vec::new();
         if let Some(ci) = &doc.creation_info {
@@ -924,7 +930,9 @@ impl Spdx3Parser {
                 .spdx_id
                 .clone()
                 .unwrap_or_else(|| "unknown".to_string()),
-            annotation_date: Utc::now(), // SPDX 3.0 annotations don't always have timestamps
+            // Deterministic: annotations without timestamps must not make
+            // serialized output differ run-to-run.
+            annotation_date: DateTime::UNIX_EPOCH,
             annotation_type: ann_type,
             comment: statement,
         });

--- a/src/parsers/spdx3.rs
+++ b/src/parsers/spdx3.rs
@@ -35,6 +35,7 @@ impl Spdx3Parser {
 
     /// Parse SPDX 3.0 JSON-LD content
     fn parse_json_ld(&self, content: &str) -> Result<NormalizedSbom, ParseError> {
+        let content = super::strip_bom(content);
         let doc: Spdx3Document =
             serde_json::from_str(content).map_err(|e| ParseError::JsonError(e.to_string()))?;
 
@@ -1252,23 +1253,31 @@ impl SbomParser for Spdx3Parser {
     }
 
     fn detect(&self, content: &str) -> FormatDetection {
+        use crate::parsers::contains_json_key;
+
+        let content = super::strip_bom(content);
         let trimmed = content.trim();
 
         if !trimmed.starts_with('{') {
             return FormatDetection::no_match();
         }
 
-        // SPDX 3.0 indicators
-        let has_context = content.contains("\"@context\"");
-        let has_spdx3_context = content.contains("spdx.org/rdf/3")
-            || content.contains("spdx.org/rdf/v3")
-            || content.contains("spdx3");
+        // SPDX 3.0 indicators. Marker keys must appear as actual JSON keys
+        // (see contains_json_key), not a coincidental string value elsewhere.
+        // The bare "spdx3" substring (no namespace URL, no quoting) was
+        // dropped: real SPDX 3.0 JSON-LD documents always carry one of the
+        // two spdx.org/rdf/{3,v3} context URLs below, and the bare word was
+        // the exact vector for an unrelated document (e.g. one that mentions
+        // "spdx3" in a description or property) to be misrouted here.
+        let has_context = contains_json_key(content, "@context");
+        let has_spdx3_context =
+            content.contains("spdx.org/rdf/3") || content.contains("spdx.org/rdf/v3");
         let has_type_spdx_document =
-            content.contains("\"type\"") && content.contains("\"SpdxDocument\"");
-        let has_spdx_id = content.contains("\"spdxId\"");
-        let has_creation_info = content.contains("\"creationInfo\"");
-        let has_element = content.contains("\"element\"");
-        let has_root_element = content.contains("\"rootElement\"");
+            contains_json_key(content, "type") && content.contains("\"SpdxDocument\"");
+        let has_spdx_id = contains_json_key(content, "spdxId");
+        let has_creation_info = contains_json_key(content, "creationInfo");
+        let has_element = contains_json_key(content, "element");
+        let has_root_element = contains_json_key(content, "rootElement");
 
         // Extract version
         let version = Self::extract_spec_version(content);

--- a/src/parsers/streaming.rs
+++ b/src/parsers/streaming.rs
@@ -25,7 +25,7 @@
 //!
 //! for event in stream {
 //!     match event {
-//!         Ok(ParseEvent::Metadata(doc)) => println!("Document: {:?}", doc.format),
+//!         Ok(ParseEvent::Metadata(meta)) => println!("Document: {:?}", meta.document.format),
 //!         Ok(ParseEvent::Component(comp)) => println!("Component: {}", comp.name),
 //!         Ok(ParseEvent::Dependency(edge)) => println!("Dependency: {} -> {}", edge.from, edge.to),
 //!         Ok(ParseEvent::Complete) => println!("Done!"),
@@ -36,7 +36,9 @@
 
 use super::detection::FormatDetector;
 use super::traits::ParseError;
-use crate::model::{Component, DependencyEdge, DocumentMetadata, NormalizedSbom};
+use crate::model::{
+    CanonicalId, Component, DependencyEdge, DocumentMetadata, FormatExtensions, NormalizedSbom,
+};
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
@@ -158,14 +160,29 @@ impl std::fmt::Debug for StreamingConfig {
 /// Events emitted during streaming parsing
 #[derive(Debug, Clone)]
 pub enum ParseEvent {
-    /// Document metadata has been parsed
-    Metadata(DocumentMetadata),
+    /// Document metadata has been parsed.
+    ///
+    /// Carries `primary_component_id`/`extensions` alongside the document so
+    /// a consumer reconstructing a full `NormalizedSbom` from the event
+    /// stream (see [`StreamingIterator::collect_sbom`]) does not silently
+    /// lose them — both live on `NormalizedSbom` itself, not on
+    /// `DocumentMetadata`, and previously had no event to travel in at all.
+    /// Boxed to keep this variant from dominating `ParseEvent`'s size.
+    Metadata(Box<ParsedMetadata>),
     /// A component has been parsed
     Component(Box<Component>),
     /// A dependency relationship has been parsed
     Dependency(DependencyEdge),
     /// Parsing is complete
     Complete,
+}
+
+/// Payload for [`ParseEvent::Metadata`].
+#[derive(Debug, Clone)]
+pub struct ParsedMetadata {
+    pub document: DocumentMetadata,
+    pub primary_component_id: Option<CanonicalId>,
+    pub extensions: FormatExtensions,
 }
 
 /// Streaming parser for large SBOMs
@@ -287,12 +304,18 @@ impl StreamingIterator {
     /// Collect all events into a `NormalizedSbom`
     pub fn collect_sbom(&mut self) -> Result<NormalizedSbom, ParseError> {
         let mut metadata: Option<DocumentMetadata> = None;
+        let mut primary_component_id: Option<CanonicalId> = None;
+        let mut extensions: Option<FormatExtensions> = None;
         let mut components = Vec::new();
         let mut edges = Vec::new();
 
         for event in self.by_ref() {
             match event {
-                Ok(ParseEvent::Metadata(doc)) => metadata = Some(doc),
+                Ok(ParseEvent::Metadata(meta)) => {
+                    metadata = Some(meta.document);
+                    primary_component_id = meta.primary_component_id;
+                    extensions = Some(meta.extensions);
+                }
                 Ok(ParseEvent::Component(comp)) => components.push(*comp),
                 Ok(ParseEvent::Dependency(edge)) => edges.push(edge),
                 Ok(ParseEvent::Complete) => break,
@@ -302,6 +325,8 @@ impl StreamingIterator {
 
         let document = metadata.unwrap_or_default();
         let mut sbom = NormalizedSbom::new(document);
+        sbom.primary_component_id = primary_component_id;
+        sbom.extensions = extensions.unwrap_or_default();
 
         for comp in components {
             sbom.add_component(comp);
@@ -360,14 +385,20 @@ impl StreamingIterator {
             } => {
                 // Emit metadata first
                 if !metadata_emitted {
-                    let doc = sbom.document.clone();
+                    let document = sbom.document.clone();
+                    let primary_component_id = sbom.primary_component_id.clone();
+                    let extensions = sbom.extensions.clone();
                     self.state = StreamingState::Emitting {
                         sbom,
                         component_index,
                         dependency_index,
                         metadata_emitted: true,
                     };
-                    return Some(Ok(ParseEvent::Metadata(doc)));
+                    return Some(Ok(ParseEvent::Metadata(Box::new(ParsedMetadata {
+                        document,
+                        primary_component_id,
+                        extensions,
+                    }))));
                 }
 
                 // IndexMap allows O(1) positional access; cloning the whole
@@ -537,5 +568,69 @@ mod tests {
     fn test_streaming_parser_creation() {
         let parser = StreamingParser::default_config();
         assert_eq!(parser.config.chunk_size, 64 * 1024);
+    }
+
+    /// The streaming path must not lose `primary_component_id`/`extensions`
+    /// relative to the non-streaming parse of the same input — both live on
+    /// `NormalizedSbom`, not `DocumentMetadata`, and previously had no event
+    /// to travel through at all, so `collect_sbom()` always produced `None`/
+    /// default regardless of what the source document actually declared.
+    #[test]
+    fn collect_sbom_preserves_primary_component_and_extensions() {
+        let cdx = r#"{
+            "bomFormat": "CycloneDX", "specVersion": "1.5",
+            "metadata": {
+                "component": {
+                    "type": "application", "bom-ref": "pkg:npm/app@1.0",
+                    "name": "app", "version": "1.0"
+                }
+            },
+            "components": [
+                {"type": "library", "bom-ref": "pkg:npm/lib@1.0", "name": "lib", "version": "1.0"}
+            ]
+        }"#;
+
+        let non_streaming = crate::parsers::parse_sbom_str(cdx).expect("non-streaming parse");
+        let mut stream = StreamingParser::default_config()
+            .parse_str(cdx)
+            .expect("stream start");
+        let streamed = stream.collect_sbom().expect("collect_sbom");
+
+        assert!(
+            non_streaming.primary_component_id.is_some(),
+            "fixture must actually exercise a primary component"
+        );
+        assert_eq!(
+            streamed.primary_component_id, non_streaming.primary_component_id,
+            "streaming must preserve primary_component_id"
+        );
+        assert_eq!(streamed.component_count(), non_streaming.component_count());
+    }
+
+    /// The no-primary-component case must round-trip as `None`, not panic
+    /// or silently become `Some(default)`.
+    #[test]
+    fn collect_sbom_preserves_absent_primary_component_as_none() {
+        let cdx = r#"{
+            "bomFormat": "CycloneDX", "specVersion": "1.5",
+            "components": [
+                {"type": "library", "bom-ref": "pkg:npm/lib@1.0", "name": "lib", "version": "1.0"}
+            ]
+        }"#;
+
+        let non_streaming = crate::parsers::parse_sbom_str(cdx).expect("non-streaming parse");
+        assert!(
+            non_streaming.primary_component_id.is_none(),
+            "fixture must have no metadata.component"
+        );
+
+        let mut stream = StreamingParser::default_config()
+            .parse_str(cdx)
+            .expect("stream start");
+        let streamed = stream.collect_sbom().expect("collect_sbom");
+        assert!(
+            streamed.primary_component_id.is_none(),
+            "absent primary component must round-trip as None, not Some(default)"
+        );
     }
 }

--- a/src/parsers/streaming.rs
+++ b/src/parsers/streaming.rs
@@ -370,13 +370,17 @@ impl StreamingIterator {
                     return Some(Ok(ParseEvent::Metadata(doc)));
                 }
 
-                // Collect components into a vec for indexed access
-                let components: Vec<_> = sbom.components.values().cloned().collect();
+                // IndexMap allows O(1) positional access; cloning the whole
+                // component map on every advance() (once per emitted event)
+                // was O(n²) time and allocation churn for a streaming parser.
                 let edges_len = sbom.edges.len();
 
                 // Emit components
-                if component_index < components.len() {
-                    let comp = components[component_index].clone();
+                if let Some(comp) = sbom
+                    .components
+                    .get_index(component_index)
+                    .map(|(_, c)| c.clone())
+                {
                     self.progress.components_parsed += 1;
                     if self.progress.components_parsed.is_multiple_of(100) {
                         self.report_progress();
@@ -435,10 +439,15 @@ pub fn estimate_component_count(path: &Path) -> Result<ComponentEstimate, ParseE
 
     let file_size = file.metadata().map(|m| m.len()).unwrap_or(0);
 
-    let reader = BufReader::new(file);
     let mut count = 0;
-    let mut bytes_sampled = 0;
+    let mut bytes_sampled = 0usize;
     let sample_limit = 1024 * 1024; // Sample first 1MB
+
+    // Cap the whole read at the sample limit (+1 to see we hit it) BEFORE
+    // splitting into lines. Minified SBOMs are single-line JSON, so
+    // `reader.lines()` on the raw file would allocate the ENTIRE file (e.g.
+    // 10 GB) into one String before the sample check could fire.
+    let reader = BufReader::new(file.take(sample_limit as u64 + 1));
 
     for line in reader.lines() {
         let line = line.map_err(|e| ParseError::IoError(e.to_string()))?;

--- a/src/quality/compliance/bsi.rs
+++ b/src/quality/compliance/bsi.rs
@@ -56,10 +56,11 @@ impl ComplianceChecker {
         // §5.2 — ISO-8601 timestamp (mandatory).
         // Our `DocumentMetadata::created` is `DateTime<Utc>`, always ISO-8601
         // when serialised; the practical risk is the `created` field being
-        // unset in the source SBOM. NormalizedSbom default is Utc::now(), so
-        // we look for tell-tale unix-epoch / very-old fallback values.
-        let created = sbom.document.created;
-        if created.timestamp() <= 0 {
+        // unset in the source SBOM. Parsers substitute the UNIX_EPOCH sentinel
+        // for a missing/invalid timestamp (see
+        // `DocumentMetadata::has_known_timestamp`), so a non-positive
+        // timestamp means "missing".
+        if !sbom.document.has_known_timestamp() {
             violations.push(Violation {
                 severity: ViolationSeverity::Error,
                 category: ViolationCategory::DocumentMetadata,

--- a/src/quality/compliance/bsi_sbom_for_ai.rs
+++ b/src/quality/compliance/bsi_sbom_for_ai.rs
@@ -115,9 +115,10 @@ impl ComplianceChecker {
         }
 
         // Timestamp present (MUST). DocumentMetadata::created is DateTime<Utc>,
-        // always ISO-8601; the risk is the source SBOM not carrying one (which
-        // surfaces as a unix-epoch / pre-epoch fallback).
-        if doc.created.timestamp() <= 0 {
+        // always ISO-8601; the risk is the source SBOM not carrying one, which
+        // parsers surface as the UNIX_EPOCH sentinel (see
+        // DocumentMetadata::has_known_timestamp).
+        if !doc.has_known_timestamp() {
             violations.push(Violation {
                 severity: ViolationSeverity::Error,
                 category: ViolationCategory::DocumentMetadata,

--- a/src/quality/compliance/cra.rs
+++ b/src/quality/compliance/cra.rs
@@ -128,32 +128,48 @@ impl ComplianceChecker {
 
     /// CRA gap checks: Art. 13(3), 13(5), 13(9), Annex I Part III, Annex III
     pub(crate) fn check_cra_gaps(&self, sbom: &NormalizedSbom, violations: &mut Vec<Violation>) {
-        // B1: Art. 13(3) — Update frequency / SBOM freshness
-        let age_days = (chrono::Utc::now() - sbom.document.created).num_days();
-        if age_days > 90 {
+        // B1: Art. 13(3) — Update frequency / SBOM freshness. A missing
+        // timestamp (epoch sentinel) is a freshness gap in its own right, but
+        // must be reported as "missing", not as a bogus ~20000-day age.
+        if !sbom.document.has_known_timestamp() {
             violations.push(Violation {
                 severity: ViolationSeverity::Warning,
                 category: ViolationCategory::DocumentMetadata,
-                message: format!(
-                    "[CRA Art. 13(3)] SBOM is {age_days} days old; CRA requires timely updates when components change"
-                ),
+                message: "[CRA Art. 13(3)] SBOM has no creation timestamp; \
+                          CRA requires timely updates when components change"
+                    .to_string(),
                 element: None,
                 requirement: "CRA Art. 13(3): SBOM update frequency".to_string(),
                 rule_id: "SBOM-CRA-ART-13-3",
                 standard_refs: Vec::new(),
             });
-        } else if age_days > 30 {
-            violations.push(Violation {
-                severity: ViolationSeverity::Info,
-                category: ViolationCategory::DocumentMetadata,
-                message: format!(
-                    "[CRA Art. 13(3)] SBOM is {age_days} days old; consider regenerating after component changes"
-                ),
-                element: None,
-                requirement: "CRA Art. 13(3): SBOM update frequency".to_string(),
-                rule_id: "SBOM-CRA-ART-13-3",
-                standard_refs: Vec::new(),
-            });
+        } else {
+            let age_days = (chrono::Utc::now() - sbom.document.created).num_days();
+            if age_days > 90 {
+                violations.push(Violation {
+                    severity: ViolationSeverity::Warning,
+                    category: ViolationCategory::DocumentMetadata,
+                    message: format!(
+                        "[CRA Art. 13(3)] SBOM is {age_days} days old; CRA requires timely updates when components change"
+                    ),
+                    element: None,
+                    requirement: "CRA Art. 13(3): SBOM update frequency".to_string(),
+                    rule_id: "SBOM-CRA-ART-13-3",
+                    standard_refs: Vec::new(),
+                });
+            } else if age_days > 30 {
+                violations.push(Violation {
+                    severity: ViolationSeverity::Info,
+                    category: ViolationCategory::DocumentMetadata,
+                    message: format!(
+                        "[CRA Art. 13(3)] SBOM is {age_days} days old; consider regenerating after component changes"
+                    ),
+                    element: None,
+                    requirement: "CRA Art. 13(3): SBOM update frequency".to_string(),
+                    rule_id: "SBOM-CRA-ART-13-3",
+                    standard_refs: Vec::new(),
+                });
+            }
         }
 
         // B2: Art. 13(5) — Licensed component tracking (all components should have license info)

--- a/src/quality/metrics.rs
+++ b/src/quality/metrics.rs
@@ -1185,9 +1185,15 @@ pub struct ProvenanceMetrics {
     pub has_serial_number: bool,
     /// Whether the document has a name
     pub has_document_name: bool,
-    /// Age of the SBOM in days (since creation timestamp)
+    /// Age of the SBOM in days (since creation timestamp). Meaningful only
+    /// when `timestamp_known` is true; a missing timestamp is not "very old".
     pub timestamp_age_days: u32,
-    /// Whether the SBOM is considered fresh (< 90 days old)
+    /// Whether the document carries a real creation timestamp (vs. the epoch
+    /// sentinel parsers substitute for a missing/invalid one).
+    #[serde(default = "default_timestamp_known")]
+    pub timestamp_known: bool,
+    /// Whether the SBOM is considered fresh (< 90 days old). False when the
+    /// timestamp is unknown — a missing timestamp is not fresh.
     pub is_fresh: bool,
     /// Whether a primary/described component is identified
     pub has_primary_component: bool,
@@ -1205,6 +1211,13 @@ pub struct ProvenanceMetrics {
 
 /// Freshness threshold in days
 const FRESHNESS_THRESHOLD_DAYS: u32 = 90;
+
+/// serde default for `ProvenanceMetrics::timestamp_known` when deserializing
+/// older records that predate the field: assume the timestamp was known
+/// (the field only distinguishes the epoch-sentinel case introduced later).
+const fn default_timestamp_known() -> bool {
+    true
+}
 
 impl ProvenanceMetrics {
     /// Calculate provenance metrics from an SBOM
@@ -1226,6 +1239,7 @@ impl ProvenanceMetrics {
             .any(|c| c.creator_type == CreatorType::Organization);
         let has_contact_email = doc.creators.iter().any(|c| c.email.is_some());
 
+        let timestamp_known = doc.has_known_timestamp();
         let age_days = (chrono::Utc::now() - doc.created).num_days().max(0) as u32;
 
         Self {
@@ -1235,8 +1249,14 @@ impl ProvenanceMetrics {
             has_contact_email,
             has_serial_number: doc.serial_number.is_some(),
             has_document_name: doc.name.is_some(),
-            timestamp_age_days: age_days,
-            is_fresh: age_days < FRESHNESS_THRESHOLD_DAYS,
+            // Report 0 for an unknown timestamp rather than ~20000 days;
+            // consumers gate the display on timestamp_known.
+            timestamp_age_days: if timestamp_known { age_days } else { 0 },
+            timestamp_known,
+            // A missing timestamp is not fresh — this is the correctness fix:
+            // the old Utc::now() fallback silently granted freshness credit to
+            // every timestamp-less document.
+            is_fresh: timestamp_known && age_days < FRESHNESS_THRESHOLD_DAYS,
             has_primary_component: sbom.primary_component_id.is_some(),
             lifecycle_phase: doc.lifecycle_phase.clone(),
             completeness_declaration: doc.completeness_declaration.clone(),
@@ -2219,6 +2239,7 @@ mod tests {
             has_serial_number: true,
             has_document_name: true,
             timestamp_age_days: 10,
+            timestamp_known: true,
             is_fresh: true,
             has_primary_component: true,
             lifecycle_phase: Some("build".to_string()),
@@ -2241,6 +2262,7 @@ mod tests {
             has_serial_number: true,
             has_document_name: true,
             timestamp_age_days: 10,
+            timestamp_known: true,
             is_fresh: true,
             has_primary_component: true,
             lifecycle_phase: None,
@@ -2511,5 +2533,34 @@ mod tests {
     fn quantum_readiness_pct_zero_algorithms() {
         let m = CryptographyMetrics::default();
         assert!((m.quantum_readiness_pct() - 0.0).abs() < 0.01);
+    }
+
+    /// A document with no timestamp (epoch sentinel) must NOT be counted as
+    /// fresh, and its age must report as unknown (0), not ~20000 days — the
+    /// old Utc::now() fallback silently granted freshness credit.
+    #[test]
+    fn provenance_missing_timestamp_is_not_fresh() {
+        let cdx = r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+            "components":[{"type":"library","name":"a","version":"1.0"}]}"#;
+        let sbom = crate::parsers::parse_sbom_str(cdx).expect("parse");
+        assert!(
+            !sbom.document.has_known_timestamp(),
+            "fixture must have no timestamp"
+        );
+        let prov = ProvenanceMetrics::from_sbom(&sbom);
+        assert!(!prov.timestamp_known);
+        assert!(!prov.is_fresh, "a timestamp-less SBOM must not be fresh");
+        assert_eq!(
+            prov.timestamp_age_days, 0,
+            "unknown age must not leak a huge number"
+        );
+
+        // A timestamped document stays fresh.
+        let cdx_ts = r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+            "metadata":{"timestamp":"3999-01-01T00:00:00Z"},
+            "components":[{"type":"library","name":"a","version":"1.0"}]}"#;
+        let sbom_ts = crate::parsers::parse_sbom_str(cdx_ts).expect("parse");
+        let prov_ts = ProvenanceMetrics::from_sbom(&sbom_ts);
+        assert!(prov_ts.timestamp_known && prov_ts.is_fresh);
     }
 }

--- a/src/tui/shared/quality.rs
+++ b/src/tui/shared/quality.rs
@@ -931,17 +931,18 @@ fn render_insights_panel(frame: &mut Frame, area: Rect, report: &QualityReport) 
     ));
 
     // SBOM age
-    let age = prov.timestamp_age_days;
     let age_color = if prov.is_fresh {
         scheme.success
     } else {
         scheme.warning
     };
     line1.push(Span::styled("Age: ", Style::default().fg(scheme.muted)));
-    line1.push(Span::styled(
-        format!("{age}d"),
-        Style::default().fg(age_color),
-    ));
+    let age_text = if prov.timestamp_known {
+        format!("{}d", prov.timestamp_age_days)
+    } else {
+        "unknown".to_string()
+    };
+    line1.push(Span::styled(age_text, Style::default().fg(age_color)));
 
     // Complexity level
     if let Some(ref level) = dep.complexity_level {
@@ -1879,7 +1880,11 @@ fn render_integrity_provenance_details(frame: &mut Frame, area: Rect, report: &Q
         Line::from(vec![
             check(p.is_fresh),
             Span::styled(
-                format!("Fresh ({} days old)", p.timestamp_age_days),
+                if p.timestamp_known {
+                    format!("Fresh ({} days old)", p.timestamp_age_days)
+                } else {
+                    "Fresh (no timestamp)".to_string()
+                },
                 Style::default().fg(scheme.text_muted),
             ),
         ]),

--- a/src/tui/view/views/overview.rs
+++ b/src/tui/view/views/overview.rs
@@ -770,12 +770,21 @@ fn render_document_info(frame: &mut Frame, area: Rect, app: &ViewApp) {
         ),
     ]));
 
-    let (age_str, age_color) = format_age(doc.created);
-    lines.push(Line::from(vec![
-        Span::styled("Created: ", label_style),
-        Span::raw(doc.created.format("%Y-%m-%d %H:%M:%S").to_string()),
-        Span::styled(format!("  ({age_str})"), Style::default().fg(age_color)),
-    ]));
+    // A missing timestamp is the epoch sentinel, not a genuine 1970 date —
+    // don't render a fabricated "~56 years ago" for it.
+    if doc.has_known_timestamp() {
+        let (age_str, age_color) = format_age(doc.created);
+        lines.push(Line::from(vec![
+            Span::styled("Created: ", label_style),
+            Span::raw(doc.created.format("%Y-%m-%d %H:%M:%S").to_string()),
+            Span::styled(format!("  ({age_str})"), Style::default().fg(age_color)),
+        ]));
+    } else {
+        lines.push(Line::from(vec![
+            Span::styled("Created: ", label_style),
+            Span::styled("unknown", Style::default().fg(scheme.warning)),
+        ]));
+    }
 
     // Creators (people and orgs)
     let authors: Vec<_> = doc

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1945,12 +1945,48 @@ mod model_tests {
 
         assert_ne!(sbom.content_hash, 0, "Content hash should be calculated");
 
-        // Same content should produce same hash
+        // Same bytes MUST produce the same hash — this is the diff
+        // engine's identity check and the incremental cache key. This doc
+        // deliberately has NO timestamp: parsers previously substituted
+        // Utc::now(), making every parse of a timestamp-less document
+        // content-unique.
         let mut sbom2 = parse_sbom_str(content).unwrap();
         sbom2.calculate_content_hash();
+        assert_eq!(
+            sbom.content_hash, sbom2.content_hash,
+            "identical input bytes must produce identical content hashes"
+        );
+    }
 
-        // Note: Hash might differ due to parsing order, but should be consistent
-        // for the same input
+    /// Parse determinism across all three formats: identical bytes yield
+    /// identical content hashes, timestamp or not.
+    #[test]
+    fn test_content_hash_deterministic_across_formats() {
+        let cases: &[&str] = &[
+            // CycloneDX without timestamp
+            r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+                "components":[{"type":"library","name":"a","version":"1.0"}]}"#,
+            // CycloneDX with timestamp
+            r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+                "metadata":{"timestamp":"2024-01-01T00:00:00Z"},
+                "components":[{"type":"library","name":"a","version":"1.0"}]}"#,
+            // SPDX 2.x JSON without created
+            r#"{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","name":"d",
+                "dataLicense":"CC0-1.0",
+                "packages":[{"SPDXID":"SPDXRef-a","name":"a","versionInfo":"1.0"}]}"#,
+            // SPDX 3.0 without creationInfo.created
+            r#"{"@context":"https://spdx.org/rdf/3.0.1/spdx-context.jsonld",
+                "type":"SpdxDocument","spdxId":"urn:doc",
+                "element":[{"type":"software_Package","spdxId":"urn:a","name":"a"}]}"#,
+        ];
+        for (i, content) in cases.iter().enumerate() {
+            let a = parse_sbom_str(content).unwrap_or_else(|e| panic!("case {i}: {e}"));
+            let b = parse_sbom_str(content).unwrap();
+            assert_eq!(
+                a.content_hash, b.content_hash,
+                "case {i}: identical bytes must hash identically"
+            );
+        }
     }
 
     #[test]
@@ -3044,6 +3080,103 @@ mod streaming_tests {
 
         assert_eq!(sbom.document.spec_version, "3.0.1");
         assert_eq!(sbom.component_count(), 4);
+    }
+
+    /// The reader path (FormatDetector::parse_reader, serde_json::from_reader
+    /// for the JSON variants) is a genuinely different code path than
+    /// parse_str/from_str; the two must produce IDENTICAL NormalizedSbom
+    /// output for the same bytes, across every format variant. Compared via
+    /// serialized JSON so any field-level divergence fails loudly.
+    #[test]
+    fn test_reader_path_equivalent_to_string_path_across_formats() {
+        use std::path::Path;
+
+        let fixtures = [
+            "tests/fixtures/cyclonedx/minimal.cdx.json",
+            "tests/fixtures/cyclonedx/minimal-1.5.cdx.xml",
+            "tests/fixtures/cyclonedx/with-vulnerabilities.cdx.json",
+            "tests/fixtures/spdx/minimal.spdx.json",
+            "tests/fixtures/spdx/minimal.spdx.rdf.xml",
+            "tests/fixtures/spdx3/minimal.spdx3.json",
+            "tests/fixtures/spdx3/security-profile.spdx3.json",
+        ];
+
+        let detector = sbom_tools::parsers::FormatDetector::new();
+        for rel in fixtures {
+            let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+            let content = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("{rel}: read failed: {e}"));
+
+            let via_str = detector
+                .parse_str(&content)
+                .unwrap_or_else(|e| panic!("{rel}: parse_str failed: {e}"));
+            let via_reader = detector
+                .parse_reader(std::io::BufReader::new(content.as_bytes()))
+                .unwrap_or_else(|e| panic!("{rel}: parse_reader failed: {e}"));
+
+            assert_sboms_equivalent(&via_str, &via_reader, rel);
+        }
+    }
+
+    /// Field-level equivalence check for two parses of the same bytes.
+    /// (NormalizedSbom's IndexMap<CanonicalId, _> keys aren't JSON map keys,
+    /// so a whole-struct serde compare isn't possible.)
+    fn assert_sboms_equivalent(
+        a: &sbom_tools::model::NormalizedSbom,
+        b: &sbom_tools::model::NormalizedSbom,
+        label: &str,
+    ) {
+        let mut a = a.clone();
+        let mut b = b.clone();
+        a.calculate_content_hash();
+        b.calculate_content_hash();
+        assert_eq!(
+            a.content_hash, b.content_hash,
+            "{label}: content hashes must match (doc metadata + components + edges)"
+        );
+        assert_eq!(
+            a.component_count(),
+            b.component_count(),
+            "{label}: component count"
+        );
+        assert_eq!(a.edges.len(), b.edges.len(), "{label}: edge count");
+        assert_eq!(
+            a.primary_component_id, b.primary_component_id,
+            "{label}: primary component"
+        );
+        assert_eq!(
+            serde_json::to_value(&a.extensions).expect("ext"),
+            serde_json::to_value(&b.extensions).expect("ext"),
+            "{label}: extensions"
+        );
+        let ids = |s: &sbom_tools::model::NormalizedSbom| {
+            let mut v: Vec<String> = s.components.keys().map(|k| k.value().to_string()).collect();
+            v.sort();
+            v
+        };
+        assert_eq!(ids(&a), ids(&b), "{label}: component id sets");
+    }
+
+    /// SPDX tag-value through the reader path (not covered by the JSON
+    /// fixtures above — tag-value takes the read_to_string_capped branch).
+    #[test]
+    fn test_reader_path_equivalent_for_tag_value() {
+        let content = "SPDXVersion: SPDX-2.3\n\
+             SPDXID: SPDXRef-DOCUMENT\n\
+             DocumentName: eq-test\n\
+             DataLicense: CC0-1.0\n\
+             Created: 2024-01-01T00:00:00Z\n\
+             PackageName: libfoo\n\
+             SPDXID: SPDXRef-Package-libfoo\n\
+             PackageVersion: 1.0\n";
+
+        let detector = sbom_tools::parsers::FormatDetector::new();
+        let via_str = detector.parse_str(content).expect("parse_str");
+        let via_reader = detector
+            .parse_reader(std::io::BufReader::new(content.as_bytes()))
+            .expect("parse_reader");
+
+        assert_sboms_equivalent(&via_str, &via_reader, "tag-value");
     }
 }
 


### PR DESCRIPTION
Systematic hardening of `src/parsers` — the layer that ingests untrusted third-party SBOM files across CycloneDX (JSON/XML), SPDX 2.x (JSON/tag-value/RDF), SPDX 3.0 (JSON-LD), plus format detection and streaming. Addresses all **29 confirmed findings** from a map→analyze→adversarially-verify analysis of the subsystem. Every cluster was A/B'd against its predecessor commit, adversarially audited (each audit found real issues, fixed before landing), and the DoS/determinism claims were reproduced with measurements.

## Cluster A — DoS / robustness + VEX security-inversion (`179887c`)
- **Memory-amplification DoS**: a single hostile vulnerability (5 MB description × 50k `affects`/`to` targets) drove a linear ~250 GB blowup; measured OLD SIGABRT at a 2 GB probe cap vs **NEW 23 MB** (description capped, targets deduped, O(D+N)).
- 512 MB reader cap on the streaming entry point (was an unbounded `read_to_string` OOM vector); streaming iterator O(n²)→O(1) (**~440× faster** on 5k components); `estimate_component_count` read cap.
- **VEX/severity can no longer be downgraded by hostile input**: unknown justification → `None` (not the strongest not-affected claim); severity is max-across-ratings (a leading `severity:"none"` can't suppress a CVSS-10); component VEX keeps the highest-risk status; `exploitable`→Affected; non-CVSS methods don't fabricate a CVSS score; NaN/inf rejected.

## Cluster C — SPDX correctness (`0bb3971`)
- **SPDX 3.0 camelCase relationships**: `dependsOn` uppercased to `DEPENDSON`, matching no arm → every spec-compliant SPDX 3.0 doc parsed with mis-typed `Other` edges (silent graph corruption). Normalized to `UPPER_SNAKE`.
- **Inverse `*_OF` direction**: emitted the same direction as forward → backwards dependency graph (SPDX 2 already swapped these). Now direction-swapped.
- **Canonical `@graph` serialization** parsed to a silently empty SBOM (only inline `element` was read); now recovers components, edges, and the primary component.
- **Tag-value**: multi-line `<text>` blocks were reparsed as tags (SPDXID/Created injection); a `FileName` section clobbered the package's SPDXID. Both fixed; first inline tests for the SPDX 2 parser.

## Cluster D — detection / streaming (`2b7faf6`)
- **UTF-8 BOM** rejected valid files on every path (`str::trim()` doesn't strip U+FEFF). Stripped at every entry point incl. the reader path.
- **Streaming lost `primary_component_id`/`extensions`** on every input (no event carried them); restored.
- **Detection misrouting fixed at the root**: marker words must be JSON *keys*, not coincidental values; the SPDX 3.0 short-circuit is gone — all three detectors are computed and a genuine tie is reported *ambiguous* rather than silently picking one. This closes both "valid CycloneDX rejected" and "valid CycloneDX silently parsed as an empty SPDX3 SBOM".

## Cluster F — content-hash determinism + coverage (`e53c874`)
- **Content-hash nondeterminism** (a real defect, not a test gap): parsers substituted `Utc::now()` for a missing timestamp, folded into the content hash → a timestamp-less SBOM hashed differently every parse, defeating diff identity and the incremental cache. Now `UNIX_EPOCH`; `has_known_timestamp()` threads through every age/freshness consumer so a missing timestamp reads "unknown", not a fabricated ~55-year-old SBOM.
- **RDF/XML streaming was entirely broken** (found by a new reader-equivalence test): `parse_reader` matched `"RDF"` but detection emits `"RDF/XML"`.
- SPDX3 fuzz target (the loosest parser had none); CycloneDX `apply_vulnerability` made fuzz-reachable; seed corpus; reader-vs-string equivalence tests.

## Verification
Full suite green (1644 tests), `clippy -D warnings` and `fmt` clean, no snapshot churn. Deferred pre-existing items (outside the 29 findings) are logged for a follow-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)