### PR TITLE
fix: close the four bugs found by post-merge end-to-end testing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -329,7 +329,8 @@ struct DiffArgs {
     #[arg(long)]
     fail_on_kev: bool,
 
-    /// Exit with code 1 if any changes detected (default for non-zero changes)
+    /// Exit with code 1 if any changes detected (without this flag, changes
+    /// still exit 0)
     #[arg(long)]
     fail_on_change: bool,
 

--- a/src/model/license.rs
+++ b/src/model/license.rs
@@ -50,6 +50,15 @@ impl LicenseExpression {
         }
     }
 
+    /// Human-readable display form: the name resolved from the document's
+    /// license definitions (e.g. SPDX `hasExtractedLicensingInfos` for a bare
+    /// `LicenseRef-*`) when present, otherwise the raw expression. For
+    /// rendering/emit only — equality and identity stay on `expression`.
+    #[must_use]
+    pub fn display_name(&self) -> &str {
+        self.resolved_name.as_deref().unwrap_or(&self.expression)
+    }
+
     /// Create from an SPDX license ID
     #[must_use]
     pub fn from_spdx_id(id: &str) -> Self {
@@ -424,6 +433,17 @@ mod tests {
             info(&["MIT"], Some("GPL-3.0-only")).effective_family(),
             LicenseFamily::Copyleft
         );
+    }
+
+    #[test]
+    fn display_name_prefers_resolved_name() {
+        let mut lic = LicenseExpression::new("LicenseRef-foo".to_string());
+        assert_eq!(lic.display_name(), "LicenseRef-foo");
+
+        lic.resolved_name = Some("Foo Proprietary License".to_string());
+        assert_eq!(lic.display_name(), "Foo Proprietary License");
+        // Identity (equality) still ignores the resolved display name.
+        assert_eq!(lic, LicenseExpression::new("LicenseRef-foo".to_string()));
     }
 
     #[test]

--- a/src/parsers/cyclonedx.rs
+++ b/src/parsers/cyclonedx.rs
@@ -1334,6 +1334,22 @@ impl CycloneDxParser {
                     && seen.insert(canonical_id)
                     && let Some(comp) = sbom.components.get_mut(canonical_id)
                 {
+                    // Per-entry version status also gates the attachment
+                    // itself: a component whose concrete version is
+                    // explicitly declared "unaffected" must not receive the
+                    // vulnerability. Only exact `version` matches skip —
+                    // `range` entries are not evaluated (no vers-range
+                    // parsing), and a component without a version always
+                    // attaches: false positives are safer here.
+                    if let (Some(versions), Some(comp_version)) =
+                        (&affect.versions, comp.version.as_deref())
+                        && versions.iter().any(|ver| {
+                            ver.status.as_deref() == Some("unaffected")
+                                && ver.version.as_deref() == Some(comp_version)
+                        })
+                    {
+                        continue;
+                    }
                     let mut v = vuln_ref.clone();
                     if let Some(versions) = &affect.versions {
                         // Respect per-entry status: only "affected" (or
@@ -3203,6 +3219,70 @@ mod tests {
             desc.len() <= super::super::MAX_VULN_DESCRIPTION_BYTES + 32,
             "description must be capped, got {} bytes",
             desc.len()
+        );
+    }
+
+    /// affects[].versions per-entry status must gate the attachment itself:
+    /// a component whose exact version is listed "unaffected" gets no vuln,
+    /// while one whose version is listed "affected" still does.
+    #[test]
+    fn unaffected_version_status_skips_vuln_attachment() {
+        let vulns = r#""vulnerabilities":[{"id":"CVE-1","affects":[{"ref":"c","versions":[
+            {"version":"1.2.3","status":"affected"},
+            {"version":"2.0.0","status":"unaffected"}]}]}]"#;
+        let json = |version: &str| {
+            format!(
+                r#"{{"bomFormat":"CycloneDX","specVersion":"1.5",
+                    "components":[{{"type":"library","bom-ref":"c","name":"libc","version":"{version}","purl":"pkg:npm/libc@{version}"}}],
+                    {vulns}}}"#
+            )
+        };
+
+        let affected = parse_json(&json("1.2.3"));
+        assert_eq!(
+            component(&affected, "libc").vulnerabilities.len(),
+            1,
+            "version listed as affected must receive the vuln"
+        );
+
+        let unaffected = parse_json(&json("2.0.0"));
+        assert_eq!(
+            component(&unaffected, "libc").vulnerabilities.len(),
+            0,
+            "version explicitly listed as unaffected must not receive the vuln"
+        );
+
+        // Unlisted version: conservative — attach.
+        let unlisted = parse_json(&json("3.0.0"));
+        assert_eq!(component(&unlisted, "libc").vulnerabilities.len(), 1);
+    }
+
+    /// Range entries and versionless components never trigger the
+    /// "unaffected" skip — no vers-range parsing, false positives are safer.
+    #[test]
+    fn unaffected_skip_ignores_ranges_and_versionless_components() {
+        let ranged = parse_json(
+            r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+                "components":[{"type":"library","bom-ref":"c","name":"libc","version":"2.0.0","purl":"pkg:npm/libc@2.0.0"}],
+                "vulnerabilities":[{"id":"CVE-1","affects":[{"ref":"c","versions":[
+                    {"range":"vers:npm/>=2.0.0","status":"unaffected"}]}]}]}"#,
+        );
+        assert_eq!(
+            component(&ranged, "libc").vulnerabilities.len(),
+            1,
+            "unaffected range entries must not skip (no range parsing)"
+        );
+
+        let versionless = parse_json(
+            r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+                "components":[{"type":"library","bom-ref":"c","name":"libc"}],
+                "vulnerabilities":[{"id":"CVE-1","affects":[{"ref":"c","versions":[
+                    {"version":"2.0.0","status":"unaffected"}]}]}]}"#,
+        );
+        assert_eq!(
+            component(&versionless, "libc").vulnerabilities.len(),
+            1,
+            "a component without a concrete version always attaches"
         );
     }
 

--- a/src/quality/compliance/generic.rs
+++ b/src/quality/compliance/generic.rs
@@ -26,7 +26,7 @@ impl ComplianceChecker {
                 ),
                 _ => (
                     "Document creator identification".to_string(),
-                    "SBOM-CRA-GENERAL",
+                    generic_rule_id_for_level(self.level),
                 ),
             };
             violations.push(Violation {
@@ -515,7 +515,7 @@ impl ComplianceChecker {
             let rule_id = if self.level == ComplianceLevel::FdaMedicalDevice {
                 "SBOM-FDA-NAMESPACE"
             } else {
-                "SBOM-CRA-GENERAL"
+                generic_rule_id_for_level(self.level)
             };
             violations.push(Violation {
                 severity: ViolationSeverity::Warning,
@@ -578,7 +578,10 @@ impl ComplianceChecker {
                         "FDA: Component name (required)".to_string(),
                         "SBOM-FDA-GENERAL",
                     ),
-                    _ => ("Component name (required)".to_string(), "SBOM-CRA-GENERAL"),
+                    _ => (
+                        "Component name (required)".to_string(),
+                        generic_rule_id_for_level(self.level),
+                    ),
                 };
                 violations.push(Violation {
                     severity: ViolationSeverity::Error,
@@ -711,7 +714,7 @@ impl ComplianceChecker {
                             comp.name
                         ),
                         "Standard identifier (PURL/CPE/SWHID)".to_string(),
-                        "SBOM-CRA-GENERAL",
+                        generic_rule_id_for_level(self.level),
                     ),
                 };
                 violations.push(Violation {
@@ -805,7 +808,7 @@ impl ComplianceChecker {
                     message: format!("Component '{}' should have license information", comp.name),
                     element: Some(comp.name.clone()),
                     requirement: "License declaration".to_string(),
-                    rule_id: "SBOM-CRA-GENERAL",
+                    rule_id: generic_rule_id_for_level(self.level),
                     component_id: Some(comp.canonical_id.value().to_string()),
                     counts: None,
                     standard_refs: Vec::new(),
@@ -835,7 +838,7 @@ impl ComplianceChecker {
                         rule_id: if self.level == ComplianceLevel::FdaMedicalDevice {
                             "SBOM-FDA-HASH"
                         } else {
-                            "SBOM-CRA-GENERAL"
+                            generic_rule_id_for_level(self.level)
                         },
                         component_id: Some(comp.canonical_id.value().to_string()),
                         counts: None,
@@ -1218,7 +1221,7 @@ impl ComplianceChecker {
                 message: format!("CycloneDX {version} is outdated, consider upgrading to 1.7+"),
                 element: None,
                 requirement: "Current CycloneDX version".to_string(),
-                rule_id: "SBOM-CRA-GENERAL",
+                rule_id: generic_rule_id_for_level(self.level),
                 component_id: None,
                 counts: None,
                 standard_refs: Vec::new(),
@@ -1235,7 +1238,7 @@ impl ComplianceChecker {
                     message: format!("Component '{}' may be missing bom-ref", comp.name),
                     element: Some(comp.name.clone()),
                     requirement: "CycloneDX: bom-ref for dependency tracking".to_string(),
-                    rule_id: "SBOM-CRA-GENERAL",
+                    rule_id: generic_rule_id_for_level(self.level),
                     component_id: Some(comp.canonical_id.value().to_string()),
                     counts: None,
                     standard_refs: Vec::new(),
@@ -1260,7 +1263,7 @@ impl ComplianceChecker {
                 message: format!("Unknown SPDX version: {version}"),
                 element: None,
                 requirement: "Valid SPDX version".to_string(),
-                rule_id: "SBOM-CRA-GENERAL",
+                rule_id: generic_rule_id_for_level(self.level),
                 component_id: None,
                 counts: None,
                 standard_refs: Vec::new(),
@@ -1292,7 +1295,7 @@ impl ComplianceChecker {
                     ),
                     element: Some(comp.name.clone()),
                     requirement: expected.to_string(),
-                    rule_id: "SBOM-CRA-GENERAL",
+                    rule_id: generic_rule_id_for_level(self.level),
                     component_id: Some(comp.canonical_id.value().to_string()),
                     counts: None,
                     standard_refs: Vec::new(),

--- a/src/quality/compliance/mod.rs
+++ b/src/quality/compliance/mod.rs
@@ -641,12 +641,44 @@ impl Violation {
     }
 
     /// Externally-visible SARIF rule id for this violation, looked up from
-    /// the rule registry by [`Violation::rule_id`]. Unregistered keys fall
-    /// back to the generic CRA rule — the exact fallback the SARIF renderer
-    /// uses, so JSON and SARIF always agree.
+    /// the rule registry by [`Violation::rule_id`]. Check sites stamp a
+    /// family-correct generic id (via [`generic_rule_id_for_level`]) when no
+    /// specific rule applies, so registered keys — i.e. every violation the
+    /// checkers produce — serialize identically in JSON and SARIF. Truly
+    /// unregistered keys (violations built outside the checkers, e.g. from
+    /// external config) fall back to the generic CRA rule here; the SARIF
+    /// renderer additionally re-buckets those by standard family, which is
+    /// the one residual place the two outputs can differ.
     #[must_use]
     pub fn sarif_rule_id(&self) -> &'static str {
         rule_meta(self.rule_id).map_or("SBOM-CRA-GENERAL", |m| m.sarif_id)
+    }
+}
+
+/// Family-generic rule for a compliance standard: the id a check site (or
+/// the SARIF renderer) falls back to when a finding has no specific registry
+/// mapping. Every returned id is a registered self-descriptor
+/// (`rule_meta(id).sarif_id == id`), so rule catalogues always declare it
+/// with registry metadata.
+#[must_use]
+pub const fn generic_rule_id_for_level(level: ComplianceLevel) -> &'static str {
+    match level {
+        ComplianceLevel::Minimum | ComplianceLevel::Standard | ComplianceLevel::Comprehensive => {
+            "SBOM-QUALITY-GENERAL"
+        }
+        ComplianceLevel::NtiaMinimum => "SBOM-NTIA-GENERAL",
+        ComplianceLevel::CraPhase1
+        | ComplianceLevel::CraPhase2
+        | ComplianceLevel::CraOssSteward => "SBOM-CRA-GENERAL",
+        ComplianceLevel::FdaMedicalDevice => "SBOM-FDA-GENERAL",
+        ComplianceLevel::NistSsdf => "SBOM-SSDF-GENERAL",
+        ComplianceLevel::Eo14028 => "SBOM-EO14028-GENERAL",
+        ComplianceLevel::Cnsa2 => "SBOM-CNSA2-GENERAL",
+        ComplianceLevel::NistPqc => "SBOM-PQC-GENERAL",
+        ComplianceLevel::BsiTr03183_2 => "SBOM-BSI-TR-03183-2-GENERAL",
+        ComplianceLevel::EuccSubstantial => "SBOM-EUCC-GENERAL",
+        ComplianceLevel::EuAiAct => "SBOM-AIACT-GENERAL",
+        ComplianceLevel::BsiSbomForAi => "SBOM-BSIAI-GENERAL",
     }
 }
 

--- a/src/quality/compliance/registry.rs
+++ b/src/quality/compliance/registry.rs
@@ -442,6 +442,18 @@ pub fn rule_meta(rule_id: &str) -> Option<RuleMeta> {
             refs: &[],
             remediation: REMEDIATION_GENERIC,
         },
+        // Generic bucket for quality-profile (Minimum/Standard/Comprehensive)
+        // findings whose check site has no specific registry mapping. The
+        // SARIF renderer re-buckets the `SBOM-CRA-GENERAL` fallback onto this
+        // rule for quality runs so they never surface under a CRA identity.
+        "SBOM-QUALITY-GENERAL" => RuleMeta {
+            sarif_id: "SBOM-QUALITY-GENERAL",
+            name: "QualityGeneralRequirement",
+            short_description: "SBOM quality: general quality-profile requirement",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[],
+            remediation: "Review the requirement and update the SBOM accordingly.",
+        },
         // ---- EUCC Substantial (reference-only profile) -------------------
         "SBOM-EUCC-PP" => RuleMeta {
             sarif_id: "SBOM-EUCC-PP",
@@ -481,6 +493,16 @@ pub fn rule_meta(rule_id: &str) -> Option<RuleMeta> {
             short_description: "EUCC (Reg. (EU) 2024/482): Certification/Attestation external reference to an EUCC certificate (recommended)",
             default_severity: ViolationSeverity::Warning,
             refs: &[(K::Eucc, "Certification reference")],
+            remediation: REMEDIATION_EUCC,
+        },
+        // Generic bucket for EUCC-run findings whose check site has no
+        // specific registry mapping (SARIF fallback re-bucketing).
+        "SBOM-EUCC-GENERAL" => RuleMeta {
+            sarif_id: "SBOM-EUCC-GENERAL",
+            name: "EuccGeneralRequirement",
+            short_description: "EUCC (Reg. (EU) 2024/482): general SBOM evidence requirement",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::Eucc, "Reg. (EU) 2024/482")],
             remediation: REMEDIATION_EUCC,
         },
         // ---- EU AI Act Annex IV technical-documentation readiness --------
@@ -611,6 +633,16 @@ pub fn rule_meta(rule_id: &str) -> Option<RuleMeta> {
             default_severity: ViolationSeverity::Warning,
             refs: &[(K::EuAiAct, "Annex IV: applicability")],
             remediation: REMEDIATION_UNTYPED_ML,
+        },
+        // Generic bucket for EU-AI-Act-run findings whose check site has no
+        // specific registry mapping (SARIF fallback re-bucketing).
+        "SBOM-AIACT-GENERAL" => RuleMeta {
+            sarif_id: "SBOM-AIACT-GENERAL",
+            name: "AiActGeneralRequirement",
+            short_description: "EU AI Act Annex IV: general documentation-readiness requirement",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::EuAiAct, "Annex IV")],
+            remediation: "Review the EU AI Act Annex IV documentation requirement and update the AI-BOM metadata accordingly.",
         },
         // ---- BSI/G7 SBOM-for-AI Minimum Elements readiness ---------------
         // Self-descriptors for the shared per-cluster SARIF rules the
@@ -900,6 +932,16 @@ pub fn rule_meta(rule_id: &str) -> Option<RuleMeta> {
             short_description: "BSI/G7 SBOM-for-AI Security cluster: AI-specific security controls, exploitability references",
             default_severity: ViolationSeverity::Info,
             refs: &[(K::BsiSbomForAi, "Security / Exploitability reference")],
+            remediation: REMEDIATION_BSIAI_GENERAL,
+        },
+        // Generic bucket for BSI/G7-SBOM-for-AI-run findings whose check site
+        // has no specific registry mapping (SARIF fallback re-bucketing).
+        "SBOM-BSIAI-GENERAL" => RuleMeta {
+            sarif_id: "SBOM-BSIAI-GENERAL",
+            name: "BsiSbomForAiGeneralRequirement",
+            short_description: "BSI/G7 SBOM-for-AI: general minimum-elements requirement",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::BsiSbomForAi, "Minimum Elements")],
             remediation: REMEDIATION_BSIAI_GENERAL,
         },
         // ---- NTIA --------------------------------------------------------
@@ -1504,6 +1546,16 @@ pub fn rule_meta(rule_id: &str) -> Option<RuleMeta> {
             refs: &[(K::Cnsa2, "CNSA 2.0")],
             remediation: REMEDIATION_CNSA2,
         },
+        // Generic bucket for CNSA-2.0-run findings whose check site has no
+        // specific registry mapping (SARIF fallback re-bucketing).
+        "SBOM-CNSA2-GENERAL" => RuleMeta {
+            sarif_id: "SBOM-CNSA2-GENERAL",
+            name: "Cnsa2GeneralRequirement",
+            short_description: "CNSA 2.0: general algorithm-suite requirement",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::Cnsa2, "CNSA 2.0")],
+            remediation: REMEDIATION_CNSA2,
+        },
         // ---- NIST PQC ----------------------------------------------------
         "SBOM-PQC-000" => RuleMeta {
             sarif_id: "SBOM-PQC-000",
@@ -1621,6 +1673,16 @@ pub fn rule_meta(rule_id: &str) -> Option<RuleMeta> {
             refs: &[(K::NistPqc, "IR 8547 ipd")],
             remediation: REMEDIATION_PQC_UNKNOWN,
         },
+        // Generic bucket for NIST-PQC-run findings whose check site has no
+        // specific registry mapping (SARIF fallback re-bucketing).
+        "SBOM-PQC-GENERAL" => RuleMeta {
+            sarif_id: "SBOM-PQC-GENERAL",
+            name: "PqcGeneralRequirement",
+            short_description: "NIST PQC: general post-quantum readiness requirement",
+            default_severity: ViolationSeverity::Warning,
+            refs: &[(K::NistPqc, "IR 8547 ipd")],
+            remediation: REMEDIATION_PQC,
+        },
         _ => return None,
     };
     Some(meta)
@@ -1664,11 +1726,13 @@ const ALL_RULE_IDS: &[&str] = &[
     "SBOM-CRA-PRE-8-RQ-02",
     "SBOM-CRA-PRE-7-RQ-07-RE",
     "SBOM-CRA-GENERAL",
+    "SBOM-QUALITY-GENERAL",
     "SBOM-EUCC-PP",
     "SBOM-EUCC-TOE",
     "SBOM-EUCC-ITSEF",
     "SBOM-EUCC-VALIDITY",
     "SBOM-EUCC-CERTREF",
+    "SBOM-EUCC-GENERAL",
     "SBOM-AIACT-ANNEX-IV-1",
     "SBOM-AIACT-ANNEX-IV-2D",
     "SBOM-AIACT-ANNEX-IV-2G",
@@ -1684,6 +1748,7 @@ const ALL_RULE_IDS: &[&str] = &[
     "SBOM-AIACT-ANNEX-IV-2C-ENERGY",
     "SBOM-AIACT-ANNEX-IV-3-LIMITATIONS",
     "SBOM-AIACT-UNTYPED-ML",
+    "SBOM-AIACT-GENERAL",
     "SBOM-BSIAI-META",
     "SBOM-BSIAI-SYS",
     "SBOM-BSIAI-MODEL",
@@ -1719,6 +1784,7 @@ const ALL_RULE_IDS: &[&str] = &[
     "SBOM-BSIAI-INFRA-RUNTIME",
     "SBOM-BSIAI-SEC-CONTROLS",
     "SBOM-BSIAI-SEC-EXPLOITABILITY",
+    "SBOM-BSIAI-GENERAL",
     "SBOM-NTIA-VERSION",
     "SBOM-NTIA-TIMESTAMP",
     "SBOM-NTIA-SUPPLIER",
@@ -1790,6 +1856,7 @@ const ALL_RULE_IDS: &[&str] = &[
     "SBOM-CNSA2-PROTO-001",
     "SBOM-CNSA2-PROTO-002",
     "SBOM-CNSA2-PROTO-UNKNOWN",
+    "SBOM-CNSA2-GENERAL",
     "SBOM-PQC-000",
     "SBOM-PQC-001",
     "SBOM-PQC-012",
@@ -1803,6 +1870,7 @@ const ALL_RULE_IDS: &[&str] = &[
     "SBOM-PQC-PROTO-001",
     "SBOM-PQC-PROTO-002",
     "SBOM-PQC-PROTO-UNKNOWN",
+    "SBOM-PQC-GENERAL",
 ];
 
 /// Enumerate every registered internal rule key, in registry order.
@@ -1971,6 +2039,7 @@ pub const CNSA2_SARIF_RULE_IDS: &[&str] = &[
     "SBOM-CNSA2-PROTO-001",
     "SBOM-CNSA2-PROTO-002",
     "SBOM-CNSA2-PROTO-UNKNOWN",
+    "SBOM-CNSA2-GENERAL",
 ];
 
 /// NIST PQC readiness SARIF rule catalogue: every `SBOM-PQC-*`
@@ -1990,6 +2059,7 @@ pub const PQC_SARIF_RULE_IDS: &[&str] = &[
     "SBOM-PQC-PROTO-001",
     "SBOM-PQC-PROTO-002",
     "SBOM-PQC-PROTO-UNKNOWN",
+    "SBOM-PQC-GENERAL",
 ];
 
 #[cfg(test)]

--- a/src/quality/metrics.rs
+++ b/src/quality/metrics.rs
@@ -434,6 +434,10 @@ pub struct IdentifierMetrics {
     pub ecosystems: Vec<String>,
     /// Components missing all identifiers (only name)
     pub missing_all_identifiers: usize,
+    /// File-typed inventory entries excluded from per-component counting
+    /// (denominator plumbing for `quality_score`; not part of the report).
+    #[serde(skip)]
+    pub file_components: usize,
 }
 
 impl IdentifierMetrics {
@@ -447,9 +451,19 @@ impl IdentifierMetrics {
         let mut with_swid = 0;
         let mut with_valid_id = 0;
         let mut missing_all = 0;
+        let mut file_components = 0;
         let mut ecosystems = std::collections::HashSet::new();
 
         for comp in sbom.components.values() {
+            // File/snippet inventory entries are not packages: they
+            // structurally lack purl/cpe/swid, and counting them cratered
+            // identifier coverage for file-cataloguing SBOMs (same exemption
+            // as CompletenessMetrics).
+            if matches!(comp.component_type, ComponentType::File) {
+                file_components += 1;
+                continue;
+            }
+
             let has_purl = comp.identifiers.purl.is_some();
             let has_cpe = !comp.identifiers.cpe.is_empty();
             let has_swid = comp.identifiers.swid.is_some();
@@ -504,26 +518,30 @@ impl IdentifierMetrics {
             components_with_valid_id: with_valid_id,
             ecosystems: ecosystem_list,
             missing_all_identifiers: missing_all,
+            file_components,
         }
     }
 
     /// Calculate identifier quality score (0-100)
     #[must_use]
     pub fn quality_score(&self, total_components: usize) -> f32 {
-        if total_components == 0 {
+        // File entries are exempt from identifier counting (see from_sbom),
+        // so remove them from the denominator too — otherwise a file
+        // catalogue dilutes package identifier coverage.
+        let countable = total_components.saturating_sub(self.file_components);
+        if countable == 0 {
             return 0.0;
         }
 
         // Coverage over components with at least one valid identifier — NOT
         // the sum of per-type counts, which a single PURL+CPE+SWID component
         // would inflate 3x (masking identifier-less components).
-        let coverage = (self.components_with_valid_id.min(total_components) as f32
-            / total_components as f32)
-            * 100.0;
+        let coverage =
+            (self.components_with_valid_id.min(countable) as f32 / countable as f32) * 100.0;
 
         // Penalize invalid identifiers
         let invalid_count = self.invalid_purls + self.invalid_cpes;
-        let penalty = (invalid_count as f32 / total_components as f32) * 20.0;
+        let penalty = (invalid_count as f32 / countable as f32) * 20.0;
 
         (coverage - penalty).clamp(0.0, 100.0)
     }
@@ -552,6 +570,10 @@ pub struct LicenseMetrics {
     pub copyleft_license_ids: Vec<String>,
     /// Unique licenses found
     pub unique_licenses: Vec<String>,
+    /// File-typed inventory entries excluded from per-component counting
+    /// (denominator plumbing for `quality_score`; not part of the report).
+    #[serde(skip)]
+    pub file_components: usize,
 }
 
 impl LicenseMetrics {
@@ -565,6 +587,7 @@ impl LicenseMetrics {
         let mut noassertion = 0;
         let mut deprecated = 0;
         let mut restrictive = 0;
+        let mut file_components = 0;
         let mut licenses = HashSet::new();
         let mut copyleft_ids = HashSet::new();
 
@@ -574,6 +597,16 @@ impl LicenseMetrics {
         // ratio past 1.0 — and a NOASSERTION-only component counted as
         // license-documented.
         for comp in sbom.components.values() {
+            // File/snippet inventory entries are not packages: per-file
+            // license facts (e.g. SPDX LicenseInfoInFile) must not dilute
+            // per-component license counting (same exemption as
+            // CompletenessMetrics). Their license strings still feed the
+            // informational unique/copyleft lists below.
+            let is_file = matches!(comp.component_type, ComponentType::File);
+            if is_file {
+                file_components += 1;
+            }
+
             let mut has_real_entry = false;
             let mut has_noassertion = false;
             let mut all_valid = true;
@@ -603,6 +636,12 @@ impl LicenseMetrics {
                     any_restrictive = true;
                     copyleft_ids.insert(expr.clone());
                 }
+            }
+
+            if is_file {
+                // Exempt from all per-component counters (license strings
+                // were still collected above).
+                continue;
             }
 
             if has_noassertion {
@@ -644,17 +683,22 @@ impl LicenseMetrics {
             restrictive_licenses: restrictive,
             copyleft_license_ids: copyleft_list,
             unique_licenses: license_list,
+            file_components,
         }
     }
 
     /// Calculate license quality score (0-100)
     #[must_use]
     pub fn quality_score(&self, total_components: usize) -> f32 {
-        if total_components == 0 {
+        // File entries are exempt from per-component license counting (see
+        // from_sbom), so remove them from the denominator too — otherwise a
+        // file catalogue dilutes package license coverage.
+        let countable = total_components.saturating_sub(self.file_components);
+        if countable == 0 {
             return 0.0;
         }
 
-        let coverage = (self.with_declared as f32 / total_components as f32) * 60.0;
+        let coverage = (self.with_declared as f32 / countable as f32) * 60.0;
 
         // Bonus for SPDX compliance
         let spdx_ratio = if self.with_declared > 0 {
@@ -665,8 +709,7 @@ impl LicenseMetrics {
         let spdx_bonus = spdx_ratio * 30.0;
 
         // Penalty for NOASSERTION
-        let noassertion_penalty =
-            (self.noassertion_count as f32 / total_components.max(1) as f32) * 10.0;
+        let noassertion_penalty = (self.noassertion_count as f32 / countable as f32) * 10.0;
 
         // Penalty for deprecated licenses (2 points each, capped)
         let deprecated_penalty = (self.deprecated_licenses as f32 * 2.0).min(10.0);
@@ -867,6 +910,10 @@ pub struct DependencyMetrics {
     pub complexity_level: Option<ComplexityLevel>,
     /// Factor breakdown. `None` when graph analysis skipped.
     pub complexity_factors: Option<ComplexityFactors>,
+    /// File-typed inventory entries excluded from the coverage denominator in
+    /// `quality_score` (denominator plumbing; not part of the report).
+    #[serde(skip)]
+    pub file_components: usize,
 }
 
 impl DependencyMetrics {
@@ -876,6 +923,17 @@ impl DependencyMetrics {
         use crate::model::CanonicalId;
 
         let total_deps = sbom.edges.len();
+
+        // File/snippet inventory entries are not dependency-graph members:
+        // nobody "depends on" a file, so they are excluded from the coverage
+        // denominator in quality_score (same exemption as
+        // CompletenessMetrics). Cycle/orphan penalties for real packages are
+        // unchanged.
+        let file_components = sbom
+            .components
+            .values()
+            .filter(|c| matches!(c.component_type, ComponentType::File))
+            .count();
 
         // Build adjacency lists using CanonicalId.value() for string keys
         let mut children: HashMap<&str, Vec<&str>> = HashMap::new();
@@ -924,6 +982,7 @@ impl DependencyMetrics {
                 software_complexity_index: None,
                 complexity_level: None,
                 complexity_factors: None,
+                file_components,
             };
         }
 
@@ -962,6 +1021,7 @@ impl DependencyMetrics {
             software_complexity_index: Some(complexity_index),
             complexity_level: Some(complexity_lvl),
             complexity_factors: Some(factors),
+            file_components,
         }
     }
 
@@ -972,14 +1032,19 @@ impl DependencyMetrics {
             return 0.0;
         }
 
+        // File entries are not dependency-graph members (see from_sbom), so
+        // they are excluded from the coverage denominator — otherwise a file
+        // catalogue dilutes package dependency coverage.
+        let countable = total_components.saturating_sub(self.file_components);
+
         // Score based on how many components have dependency info. Clamp to
         // 100 BEFORE subtracting penalties: with an N/(N-1) denominator a
         // fully-cyclic graph reaches ~125% coverage, which silently absorbed
         // the cycle/orphan penalties below.
-        let coverage = if total_components > 1 {
-            ((self.components_with_deps as f32 / (total_components - 1) as f32) * 100.0).min(100.0)
+        let coverage = if countable > 1 {
+            ((self.components_with_deps as f32 / (countable - 1) as f32) * 100.0).min(100.0)
         } else {
-            100.0 // Single component SBOM
+            100.0 // Single package (or pure file inventory)
         };
 
         // Slight penalty for orphan components
@@ -1890,6 +1955,20 @@ impl CryptographyMetrics {
             return None;
         }
 
+        // Documented crypto assets exist but NONE are classifiable as an
+        // algorithm/certificate/key/protocol, so no penalty below can ever
+        // trigger and the 100 baseline would be vacuous. The compliance
+        // checkers treat such an inventory as unverifiable (the CNSA2/PQC
+        // "evaluable assets" gates fail it), so the score reads fully
+        // degraded instead of perfect.
+        let classified = self.algorithms_count
+            + self.certificates_count
+            + self.keys_count
+            + self.protocols_count;
+        if classified == 0 {
+            return Some(0.0);
+        }
+
         let mut score = 100.0_f32;
 
         // Weak algorithms: severe penalty (15 each, capped at 50)
@@ -1904,6 +1983,20 @@ impl CryptographyMetrics {
         score -= (self.inadequate_key_sizes as f32 * 5.0).min(20.0);
         // Expiring-soon certs: mild penalty (3 each, capped at 15)
         score -= (self.expiring_soon_certificates as f32 * 3.0).min(15.0);
+        // Unresolved crypto references: cert/key/protocol assets whose
+        // algorithm linkage can't be resolved are documented-but-unverifiable
+        // (the compliance checkers warn on them, and none of the penalties
+        // above can ever fire for them), so an inventory of opaque refs must
+        // not read as perfect hygiene. Proportional, mirroring
+        // `crypto_dependency_score`.
+        let linkable = self.certificates_count + self.keys_count + self.protocols_count;
+        if linkable > 0 {
+            let resolved = self.certs_with_signature_algo_ref
+                + self.keys_with_algorithm_ref
+                + self.protocols_with_cipher_suites;
+            let unresolved_pct = 1.0 - (resolved as f32 / linkable as f32);
+            score -= unresolved_pct * 30.0;
+        }
         // Hybrid PQC bonus: +2 each (capped at +10)
         score += (self.hybrid_pqc_count as f32 * 2.0).min(10.0);
 
@@ -2130,6 +2223,110 @@ mod tests {
         );
     }
 
+    /// Same File exemption for identifier scoring: files structurally lack
+    /// purl/cpe/swid, so a file catalogue must not dilute package identifier
+    /// coverage.
+    #[test]
+    fn file_components_do_not_dilute_identifier_score() {
+        use crate::model::{Component, ComponentType, NormalizedSbom};
+        let mut sbom = NormalizedSbom::default();
+        let mut pkg = Component::new("app".to_string(), "app@1".to_string());
+        pkg.identifiers.purl = Some("pkg:cargo/app@1.0.0".to_string());
+        sbom.add_component(pkg);
+        for i in 0..30 {
+            let mut f = Component::new(format!("file-{i}"), format!("file-{i}@x"));
+            f.component_type = ComponentType::File;
+            sbom.add_component(f);
+        }
+
+        let im = IdentifierMetrics::from_sbom(&sbom);
+        assert_eq!(im.file_components, 30);
+        assert_eq!(
+            im.missing_all_identifiers, 0,
+            "exempt files must not count as identifier-less"
+        );
+        let score = im.quality_score(sbom.components.len());
+        assert!(
+            (score - 100.0).abs() < 0.01,
+            "30 files must not dilute the package's identifier coverage, got {score}"
+        );
+    }
+
+    /// Same File exemption for license scoring: per-file license facts are
+    /// not package license documentation, so a file catalogue must not dilute
+    /// package license coverage (license strings still reach the lists).
+    #[test]
+    fn file_components_do_not_dilute_license_score() {
+        use crate::model::{Component, ComponentType, LicenseExpression, NormalizedSbom};
+        let mut sbom = NormalizedSbom::default();
+        let mut pkg = Component::new("app".to_string(), "app@1".to_string());
+        pkg.licenses
+            .add_declared(LicenseExpression::new("MIT".to_string()));
+        sbom.add_component(pkg);
+        for i in 0..30 {
+            let mut f = Component::new(format!("file-{i}"), format!("file-{i}@x"));
+            f.component_type = ComponentType::File;
+            f.licenses
+                .add_declared(LicenseExpression::new("GPL-2.0-only".to_string()));
+            sbom.add_component(f);
+        }
+
+        let lm = LicenseMetrics::from_sbom(&sbom);
+        assert_eq!(lm.file_components, 30);
+        assert_eq!(lm.with_declared, 1, "files are exempt from counters");
+        assert!(
+            lm.unique_licenses.contains(&"GPL-2.0-only".to_string()),
+            "file license strings still feed the informational lists"
+        );
+        // Coverage 1/1 * 60 + full SPDX bonus 30 = 90 for the one package.
+        let score = lm.quality_score(sbom.components.len());
+        assert!(
+            (score - 90.0).abs() < 0.01,
+            "30 files must not dilute the package's license coverage, got {score}"
+        );
+    }
+
+    /// Same File exemption for the dependency-coverage denominator: files
+    /// (typically attached via CONTAINS) are not dependency-graph members.
+    #[test]
+    fn file_components_do_not_dilute_dependency_coverage() {
+        use crate::model::{
+            Component, ComponentType, DependencyEdge, DependencyType, NormalizedSbom,
+        };
+        let mut sbom = NormalizedSbom::default();
+        let app = Component::new("app".to_string(), "app@1".to_string());
+        let lib = Component::new("lib".to_string(), "lib@1".to_string());
+        let app_id = app.canonical_id.clone();
+        let lib_id = lib.canonical_id.clone();
+        sbom.add_component(app);
+        sbom.add_component(lib);
+        sbom.add_edge(DependencyEdge::new(
+            app_id.clone(),
+            lib_id,
+            DependencyType::DependsOn,
+        ));
+        for i in 0..30 {
+            let mut f = Component::new(format!("file-{i}"), format!("file-{i}@x"));
+            f.component_type = ComponentType::File;
+            let file_id = f.canonical_id.clone();
+            sbom.add_component(f);
+            // SPDX-style package CONTAINS file relationship.
+            sbom.add_edge(DependencyEdge::new(
+                app_id.clone(),
+                file_id,
+                DependencyType::Contains,
+            ));
+        }
+
+        let dm = DependencyMetrics::from_sbom(&sbom);
+        assert_eq!(dm.file_components, 30);
+        let score = dm.quality_score(sbom.components.len());
+        assert!(
+            (score - 100.0).abs() < 0.01,
+            "30 contained files must not dilute dependency coverage, got {score}"
+        );
+    }
+
     /// A Cryptographic component with NO cryptoProperties must not count as
     /// crypto inventory — otherwise has_data() is true and the CBOM sub-scores
     /// return 100 (grade A) for undocumented crypto.
@@ -2150,6 +2347,65 @@ mod tests {
         assert!(
             !m.has_data(),
             "has_data must be false → CBOM scores are N/A, not 100"
+        );
+    }
+
+    /// A CBOM whose documented crypto assets are ALL unclassifiable (asset
+    /// types outside algorithm/certificate/key/protocol) has nothing
+    /// evaluable, so no hygiene penalty can ever trigger — the score must
+    /// read fully degraded, not a vacuous 100 (matching the CNSA2/PQC
+    /// "evaluable assets" compliance gates, which fail such inventories).
+    #[test]
+    fn unclassifiable_crypto_inventory_scores_degraded_not_perfect() {
+        use crate::model::{
+            Component, ComponentType, CryptoAssetType, CryptoProperties, NormalizedSbom,
+        };
+        let mut sbom = NormalizedSbom::default();
+        let mut c = Component::new("mystery-asset".to_string(), "ma@1".to_string());
+        c.component_type = ComponentType::Cryptographic;
+        c.crypto_properties = Some(CryptoProperties::new(CryptoAssetType::Other(
+            "unknown".to_string(),
+        )));
+        sbom.add_component(c);
+
+        let m = CryptographyMetrics::from_sbom(&sbom);
+        assert!(m.has_data(), "documented crypto assets are inventory");
+        assert_eq!(m.algorithms_count, 0);
+        assert_eq!(
+            m.quality_score(),
+            Some(0.0),
+            "all-unclassifiable inventory must read degraded, not 100"
+        );
+    }
+
+    /// Certificates/protocols whose algorithm references cannot be resolved
+    /// are documented-but-unverifiable: none of the hygiene penalties can
+    /// fire for them, so without the unresolved-reference penalty an
+    /// inventory of opaque refs would read a perfect 100 while the
+    /// compliance checkers warn on every asset.
+    #[test]
+    fn unresolved_crypto_references_degrade_the_quality_score() {
+        use crate::model::{
+            CertificateProperties, Component, ComponentType, CryptoAssetType, CryptoProperties,
+            NormalizedSbom,
+        };
+        let mut sbom = NormalizedSbom::default();
+        let mut c = Component::new("opaque-cert".to_string(), "oc@1".to_string());
+        c.component_type = ComponentType::Cryptographic;
+        // Certificate with no signatureAlgorithmRef: classified, unlinked.
+        c.crypto_properties = Some(
+            CryptoProperties::new(CryptoAssetType::Certificate)
+                .with_certificate_properties(CertificateProperties::new()),
+        );
+        sbom.add_component(c);
+
+        let m = CryptographyMetrics::from_sbom(&sbom);
+        assert_eq!(m.certificates_count, 1);
+        assert_eq!(m.certs_with_signature_algo_ref, 0);
+        let score = m.quality_score().expect("has data");
+        assert!(
+            score <= 70.0,
+            "fully-unresolved references must degrade the score, got {score}"
         );
     }
 

--- a/src/quality/mod.rs
+++ b/src/quality/mod.rs
@@ -37,7 +37,7 @@ pub use compliance::{
     ComplianceLevel, ComplianceResult, ConformityAssessmentSummary, ConformityEvidence, CraPhase,
     EO14028_SARIF_RULE_IDS, FDA_SARIF_RULE_IDS, NTIA_SARIF_RULE_IDS, PQC_SARIF_RULE_IDS, RuleMeta,
     SSDF_SARIF_RULE_IDS, StandardKind, StandardRef, StandardSelector, Violation, ViolationCategory,
-    ViolationCounts, ViolationSeverity, all_rule_ids, rule_meta,
+    ViolationCounts, ViolationSeverity, all_rule_ids, generic_rule_id_for_level, rule_meta,
 };
 pub use metrics::{
     AuditabilityMetrics, CompletenessMetrics, ComplexityFactors, ComplexityLevel,

--- a/src/reports/csv.rs
+++ b/src/reports/csv.rs
@@ -97,7 +97,7 @@ impl ReportGenerator for CsvReporter {
                 .licenses
                 .declared
                 .iter()
-                .map(|l| l.expression.as_str())
+                .map(|l| l.display_name())
                 .collect::<Vec<_>>()
                 .join("; ");
             let vuln_count = comp.vulnerabilities.len();

--- a/src/reports/html.rs
+++ b/src/reports/html.rs
@@ -407,7 +407,7 @@ fn write_view_component_table(html: &mut String, sbom: &NormalizedSbom) -> std::
             .licenses
             .declared
             .first()
-            .map_or("-", |l| l.expression.as_str());
+            .map_or("-", |l| l.display_name());
         let vuln_count = comp.vulnerabilities.len();
         let vuln_badge = if vuln_count > 0 {
             format!("<span class=\"badge badge-critical\">{vuln_count}</span>")
@@ -1199,7 +1199,12 @@ impl ReportGenerator for HtmlReporter {
         let licenses: HashSet<String> = sbom
             .components
             .values()
-            .flat_map(|c| c.licenses.declared.iter().map(|l| l.expression.clone()))
+            .flat_map(|c| {
+                c.licenses
+                    .declared
+                    .iter()
+                    .map(|l| l.display_name().to_string())
+            })
             .collect();
 
         let subtitle = sbom

--- a/src/reports/json.rs
+++ b/src/reports/json.rs
@@ -190,7 +190,7 @@ impl ReportGenerator for JsonReporter {
                         .licenses
                         .declared
                         .iter()
-                        .map(|l| l.expression.clone())
+                        .map(|l| l.display_name().to_string())
                         .collect(),
                     supplier: c.supplier.as_ref().map(|s| s.name.clone()),
                     dependency_kind: kind,

--- a/src/reports/markdown.rs
+++ b/src/reports/markdown.rs
@@ -643,7 +643,7 @@ impl ReportGenerator for MarkdownReporter {
                 .licenses
                 .declared
                 .first()
-                .map(|l| escape_markdown_table(&l.expression));
+                .map(|l| escape_markdown_table(l.display_name()));
             let license = license.as_deref().unwrap_or("-");
             writeln!(
                 md,

--- a/src/reports/sarif.rs
+++ b/src/reports/sarif.rs
@@ -3,7 +3,10 @@
 use super::{ReportConfig, ReportError, ReportFormat, ReportGenerator, ReportType};
 use crate::diff::{DiffResult, SlaStatus, VulnerabilityDetail};
 use crate::model::NormalizedSbom;
-use crate::quality::{ComplianceLevel, ComplianceResult, ViolationSeverity, rule_meta};
+use crate::quality::{
+    ComplianceLevel, ComplianceResult, StandardRef, ViolationSeverity, generic_rule_id_for_level,
+    rule_meta,
+};
 use serde::Serialize;
 
 /// SARIF report generator
@@ -853,16 +856,44 @@ fn compliance_results_to_sarif(result: &ComplianceResult, label: Option<&str>) -
         .iter()
         .map(|v| {
             let element = v.element.as_deref().unwrap_or("unknown");
-            let standard_ids: Vec<String> = v
-                .standard_refs
+            // The externally-visible SARIF rule ID comes from the rule
+            // registry keyed by the violation's stable `rule_id` — never from
+            // re-parsing the human-readable requirement string. Check sites
+            // with no specific mapping stamp the generic `SBOM-CRA-GENERAL`
+            // key regardless of which checker ran; re-bucket that fallback
+            // (and any unregistered key) onto the running standard's own
+            // generic rule so NTIA/quality/... findings never surface under
+            // a CRA identity. Specifically-mapped rules keep their identity.
+            let is_unmapped = v.rule_id == "SBOM-CRA-GENERAL" || rule_meta(v.rule_id).is_none();
+            let sarif_rule_id = if is_unmapped {
+                generic_rule_id_for_level(result.level)
+            } else {
+                v.sarif_rule_id()
+            };
+            // Fallback violations carry no standard_refs (the generic CRA
+            // bucket has none); resolve them from the family-generic rule so
+            // fallback results still carry `properties.standardIds` when the
+            // running standard is known.
+            let fallback_refs: Vec<StandardRef>;
+            let refs: &[StandardRef] = if is_unmapped && v.standard_refs.is_empty() {
+                fallback_refs = rule_meta(sarif_rule_id)
+                    .map(|m| {
+                        m.refs
+                            .iter()
+                            .map(|(kind, id)| StandardRef::new(*kind, *id))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                &fallback_refs
+            } else {
+                &v.standard_refs
+            };
+            let standard_ids: Vec<String> = refs
                 .iter()
                 .map(|sr| format!("{}:{}", sarif_standard_label(sr.standard), sr.id))
                 .collect();
-            let standard_help_uris: Vec<String> = v
-                .standard_refs
-                .iter()
-                .filter_map(|sr| sr.help_uri.clone())
-                .collect();
+            let standard_help_uris: Vec<String> =
+                refs.iter().filter_map(|sr| sr.help_uri.clone()).collect();
             let properties = if standard_ids.is_empty()
                 && standard_help_uris.is_empty()
                 && v.component_id.is_none()
@@ -879,14 +910,8 @@ fn compliance_results_to_sarif(result: &ComplianceResult, label: Option<&str>) -
                     ..SarifResultProperties::default()
                 })
             };
-            // The externally-visible SARIF rule ID comes from the rule
-            // registry keyed by the violation's stable `rule_id` — never from
-            // re-parsing the human-readable requirement string. Unregistered
-            // keys fall back to the generic CRA rule (the same lookup the
-            // serde `sarif_rule_id` field uses, so JSON and SARIF agree).
-            let sarif_rule_id = v.sarif_rule_id().to_string();
             SarifResult {
-                rule_id: sarif_rule_id,
+                rule_id: sarif_rule_id.to_string(),
                 level: violation_severity_to_level(v.severity),
                 message: SarifMessage {
                     text: format!(

--- a/src/reports/summary.rs
+++ b/src/reports/summary.rs
@@ -601,7 +601,7 @@ impl ReportGenerator for TableReporter {
                 .licenses
                 .declared
                 .first()
-                .map_or("-", |l| l.expression.as_str());
+                .map_or("-", |l| l.display_name());
             let vulns = comp.vulnerabilities.len();
             let vuln_display = if vulns > 0 {
                 self.color(&vulns.to_string(), "red")

--- a/src/serialization/emit/cyclonedx.rs
+++ b/src/serialization/emit/cyclonedx.rs
@@ -14,7 +14,10 @@
 
 use serde_json::{Map, Value, json};
 
-use crate::model::{Component, ComponentType, DependencyType, Hash, NormalizedSbom};
+use crate::model::{
+    Component, ComponentType, Creator, CreatorType, DependencyType, Hash, LicenseExpression,
+    NormalizedSbom,
+};
 
 use super::EmitError;
 use super::fidelity::FidelityReport;
@@ -55,6 +58,14 @@ pub fn emit_cyclonedx(sbom: &NormalizedSbom) -> Result<(String, FidelityReport),
     );
     if let Some(tools) = emit_tools(sbom) {
         metadata.insert("tools".to_string(), tools);
+    }
+    if let Some(authors) = emit_authors(sbom) {
+        metadata.insert("authors".to_string(), authors);
+        report.synthesized("metadata.authors from person creators");
+    }
+    if let Some(manufacturer) = emit_manufacturer(sbom) {
+        metadata.insert("manufacturer".to_string(), manufacturer);
+        report.synthesized("metadata.manufacturer from organization creator");
     }
     if let Some(primary) = primary_component_json {
         metadata.insert("component".to_string(), primary);
@@ -223,16 +234,13 @@ fn emit_licenses(component: &Component) -> Option<Value> {
     for expr in &component.licenses.declared {
         if !seen.contains(&expr.expression.as_str()) {
             seen.push(&expr.expression);
-            items.push(license_choice(&expr.expression, expr.is_valid_spdx));
+            items.push(license_choice(expr));
         }
     }
     if let Some(concluded) = &component.licenses.concluded
         && !seen.contains(&concluded.expression.as_str())
     {
-        items.push(license_choice(
-            &concluded.expression,
-            concluded.is_valid_spdx,
-        ));
+        items.push(license_choice(concluded));
     }
     if items.is_empty() {
         None
@@ -243,16 +251,24 @@ fn emit_licenses(component: &Component) -> Option<Value> {
 
 /// Build one CycloneDX license-choice object.
 ///
-/// Valid single SPDX ids use `{license:{id}}`; compound/invalid expressions use
-/// the `{expression}` form, matching CycloneDX semantics.
-fn license_choice(expr: &str, is_valid_spdx: bool) -> Value {
-    let is_compound = expr.contains(" OR ") || expr.contains(" AND ") || expr.contains(" WITH ");
-    if is_valid_spdx && !is_compound {
-        json!({ "license": { "id": expr } })
-    } else if is_valid_spdx {
-        json!({ "expression": expr })
+/// Valid single SPDX ids use `{license:{id}}`; compound valid expressions use
+/// the `{expression}` form, matching CycloneDX semantics. A bare
+/// `LicenseRef-*`/`DocumentRef-*` token parses as a valid SPDX *expression* but
+/// is not a valid SPDX *identifier*, so it must not go in `license.id`: it is
+/// emitted as `{license:{name}}`, preferring the human-readable name resolved
+/// from the source document (SPDX `hasExtractedLicensingInfos`) over the raw
+/// ref string.
+fn license_choice(expr: &LicenseExpression) -> Value {
+    let raw = expr.expression.as_str();
+    let is_compound = raw.contains(" OR ") || raw.contains(" AND ") || raw.contains(" WITH ");
+    let is_local_ref =
+        !is_compound && (raw.starts_with("LicenseRef-") || raw.starts_with("DocumentRef-"));
+    if expr.is_valid_spdx && !is_compound && !is_local_ref {
+        json!({ "license": { "id": raw } })
+    } else if expr.is_valid_spdx && is_compound {
+        json!({ "expression": raw })
     } else {
-        json!({ "license": { "name": expr } })
+        json!({ "license": { "name": expr.display_name() } })
     }
 }
 
@@ -498,7 +514,7 @@ fn emit_tools(sbom: &NormalizedSbom) -> Option<Value> {
         .document
         .creators
         .iter()
-        .filter(|c| matches!(c.creator_type, crate::model::CreatorType::Tool))
+        .filter(|c| matches!(c.creator_type, CreatorType::Tool))
         .map(|c| json!({ "name": c.name }))
         .collect();
     if tools.is_empty() {
@@ -506,6 +522,60 @@ fn emit_tools(sbom: &NormalizedSbom) -> Option<Value> {
     } else {
         Some(Value::Array(tools))
     }
+}
+
+/// Render a creator as a CycloneDX `organizationalContact` object.
+fn contact_json(creator: &Creator) -> Value {
+    let mut o = Map::new();
+    o.insert("name".to_string(), json!(creator.name));
+    if let Some(email) = &creator.email {
+        o.insert("email".to_string(), json!(email));
+    }
+    Value::Object(o)
+}
+
+/// Emit `metadata.authors` (CycloneDX 1.5+) from Person creators — the inverse
+/// of the parser's `metadata.authors` → Person mapping. Organization creators
+/// beyond the one emitted as `metadata.manufacturer` are folded in as well so
+/// no document creator is silently dropped (manufacturer is single-valued).
+fn emit_authors(sbom: &NormalizedSbom) -> Option<Value> {
+    let mut authors: Vec<Value> = sbom
+        .document
+        .creators
+        .iter()
+        .filter(|c| matches!(c.creator_type, CreatorType::Person))
+        .map(contact_json)
+        .collect();
+    authors.extend(
+        sbom.document
+            .creators
+            .iter()
+            .filter(|c| matches!(c.creator_type, CreatorType::Organization))
+            .skip(1)
+            .map(contact_json),
+    );
+    if authors.is_empty() {
+        None
+    } else {
+        Some(Value::Array(authors))
+    }
+}
+
+/// Emit `metadata.manufacturer` (CycloneDX 1.5+) from the first Organization
+/// creator — the inverse of the parser's manufacturer → Organization mapping
+/// (BSI TR-03183-2 Table 8's "Creator of the SBOM").
+fn emit_manufacturer(sbom: &NormalizedSbom) -> Option<Value> {
+    let org = sbom
+        .document
+        .creators
+        .iter()
+        .find(|c| matches!(c.creator_type, CreatorType::Organization))?;
+    let mut o = Map::new();
+    o.insert("name".to_string(), json!(org.name));
+    if let Some(email) = &org.email {
+        o.insert("contact".to_string(), json!([{ "email": email }]));
+    }
+    Some(Value::Object(o))
 }
 
 /// Emit the `dependencies` array from the edge list.
@@ -615,6 +685,109 @@ mod tests {
         // root (primary) + lodash
         assert_eq!(reparsed.components.len(), 2);
         assert_eq!(reparsed.document.format_version, "1.7");
+    }
+
+    /// SPDX input with a resolved LicenseRef (hasExtractedLicensingInfos), an
+    /// unresolved LicenseRef, and a plain SPDX id.
+    const SPDX_LICENSE_REFS: &str = r#"{
+        "spdxVersion": "SPDX-2.3", "dataLicense": "CC0-1.0",
+        "SPDXID": "SPDXRef-DOCUMENT", "name": "license-ref-doc",
+        "documentNamespace": "https://example.com/license-ref-doc",
+        "creationInfo": {"created": "2024-01-01T00:00:00Z",
+                         "creators": ["Tool: sbom-gen-1.0"]},
+        "packages": [
+            {"SPDXID": "SPDXRef-Package-a", "name": "pkg-a", "versionInfo": "1.0",
+             "downloadLocation": "NOASSERTION",
+             "licenseDeclared": "LicenseRef-foo", "licenseConcluded": "LicenseRef-foo"},
+            {"SPDXID": "SPDXRef-Package-b", "name": "pkg-b", "versionInfo": "1.0",
+             "downloadLocation": "NOASSERTION", "licenseDeclared": "LicenseRef-bar"},
+            {"SPDXID": "SPDXRef-Package-c", "name": "pkg-c", "versionInfo": "1.0",
+             "downloadLocation": "NOASSERTION", "licenseDeclared": "MIT"}
+        ],
+        "hasExtractedLicensingInfos": [
+            {"licenseId": "LicenseRef-foo", "name": "Foo Proprietary License",
+             "extractedText": "Proprietary terms."}
+        ]
+    }"#;
+
+    /// Find the single license-choice object of the named emitted component.
+    fn license_of<'a>(doc: &'a Value, name: &str) -> &'a Value {
+        let comp = doc["components"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["name"] == name)
+            .unwrap_or_else(|| panic!("component {name} not emitted"));
+        &comp["licenses"][0]
+    }
+
+    #[test]
+    fn license_ref_emits_resolved_name_never_id() {
+        let sbom = parse_sbom_str(SPDX_LICENSE_REFS).unwrap();
+        let (json, _report) = emit_cyclonedx(&sbom).unwrap();
+        let doc: Value = serde_json::from_str(&json).unwrap();
+
+        // (a) resolved LicenseRef -> name form with the resolved human name.
+        assert_eq!(
+            license_of(&doc, "pkg-a")["license"]["name"],
+            json!("Foo Proprietary License")
+        );
+        // (b) unresolved LicenseRef -> name form keeping the raw ref string.
+        assert_eq!(
+            license_of(&doc, "pkg-b")["license"]["name"],
+            json!("LicenseRef-bar")
+        );
+        // (c) valid SPDX id keeps the id form.
+        assert_eq!(license_of(&doc, "pkg-c")["license"]["id"], json!("MIT"));
+
+        // LicenseRef-* must never appear as a license `id` anywhere.
+        fn assert_no_license_ref_id(v: &Value) {
+            match v {
+                Value::Object(o) => {
+                    if let Some(Value::String(id)) = o.get("id") {
+                        assert!(
+                            !id.starts_with("LicenseRef-"),
+                            "LicenseRef emitted as license id: {id}"
+                        );
+                    }
+                    o.values().for_each(assert_no_license_ref_id);
+                }
+                Value::Array(a) => a.iter().for_each(assert_no_license_ref_id),
+                _ => {}
+            }
+        }
+        assert_no_license_ref_id(&doc);
+    }
+
+    #[test]
+    fn person_creators_emit_metadata_authors() {
+        let cdx_with_authors: &str = r#"{
+            "bomFormat": "CycloneDX", "specVersion": "1.6", "version": 1,
+            "metadata": {
+                "authors": [{"name": "Jane Doe", "email": "jane@example.com"}],
+                "manufacturer": {"name": "Acme Corp",
+                                 "contact": [{"email": "sbom@acme.example"}]},
+                "tools": [{"name": "gen", "version": "1.0"}]
+            },
+            "components": [{"type": "library", "bom-ref": "x", "name": "x",
+                            "version": "1.0"}]
+        }"#;
+        let sbom = parse_sbom_str(cdx_with_authors).unwrap();
+        let (json, _report) = emit_cyclonedx(&sbom).unwrap();
+        let doc: Value = serde_json::from_str(&json).unwrap();
+
+        // (d) Person creator with email round-trips into metadata.authors.
+        assert_eq!(
+            doc["metadata"]["authors"],
+            json!([{ "name": "Jane Doe", "email": "jane@example.com" }])
+        );
+        // Organization creator round-trips into metadata.manufacturer.
+        assert_eq!(
+            doc["metadata"]["manufacturer"],
+            json!({ "name": "Acme Corp", "contact": [{ "email": "sbom@acme.example" }] })
+        );
+        // Tool creators stay in metadata.tools, not authors.
+        assert_eq!(doc["metadata"]["tools"], json!([{ "name": "gen 1.0" }]));
     }
 
     #[test]

--- a/src/serialization/emit/spdx.rs
+++ b/src/serialization/emit/spdx.rs
@@ -16,7 +16,8 @@ use std::collections::HashSet;
 use serde_json::{Map, Value, json};
 
 use crate::model::{
-    CanonicalId, Component, DependencyType, Hash, HashAlgorithm, LicenseExpression, NormalizedSbom,
+    CanonicalId, Component, ComponentType, DependencyType, Hash, HashAlgorithm, LicenseExpression,
+    NormalizedSbom,
 };
 
 use super::EmitError;
@@ -41,9 +42,16 @@ pub fn emit_spdx(sbom: &NormalizedSbom) -> Result<(String, FidelityReport), Emit
     let id_assigner = SpdxIdAssigner::build(sbom);
 
     let mut packages = Vec::with_capacity(sbom.components.len());
+    let mut files = Vec::new();
     for (id, component) in &sbom.components {
         let spdx_id = id_assigner.id_for(id);
-        packages.push(emit_package(component, spdx_id, &mut report));
+        // File-typed components belong in the top-level `files` array so they
+        // re-parse as files rather than being promoted to packages.
+        if component.component_type == ComponentType::File {
+            files.push(emit_file(component, spdx_id));
+        } else {
+            packages.push(emit_package(component, spdx_id, &mut report));
+        }
     }
 
     let mut doc = Map::new();
@@ -68,6 +76,30 @@ pub fn emit_spdx(sbom: &NormalizedSbom) -> Result<(String, FidelityReport), Emit
         emit_creation_info(sbom, &mut report),
     );
     doc.insert("packages".to_string(), Value::Array(packages));
+    if !files.is_empty() {
+        doc.insert("files".to_string(), Value::Array(files));
+    }
+
+    // documentDescribes is the 2.2-era primary-component idiom; emit it
+    // alongside the DESCRIBES relationship so both mechanisms round-trip.
+    if let Some(primary) = &sbom.primary_component_id
+        && id_assigner.contains(primary)
+    {
+        doc.insert(
+            "documentDescribes".to_string(),
+            json!([id_assigner.id_for(primary)]),
+        );
+        report.synthesized("documentDescribes from primary component");
+    }
+
+    let extracted = emit_extracted_licenses(sbom);
+    if !extracted.is_empty() {
+        doc.insert(
+            "hasExtractedLicensingInfos".to_string(),
+            Value::Array(extracted),
+        );
+        report.synthesized("hasExtractedLicensingInfos from resolved LicenseRef names");
+    }
 
     let relationships = emit_relationships(sbom, &id_assigner, &mut report);
     doc.insert("relationships".to_string(), Value::Array(relationships));
@@ -213,6 +245,65 @@ fn emit_package(component: &Component, spdx_id: &str, report: &mut FidelityRepor
     splice_preserved_fields(component, &mut obj, report);
 
     Value::Object(obj)
+}
+
+/// Synthesize one SPDX file object from a `ComponentType::File` component.
+///
+/// Mirrors the fields the SPDX parser reads back (`fileName`, `checksums`,
+/// `licenseConcluded`, `copyrightText`) so file components round-trip.
+fn emit_file(component: &Component, spdx_id: &str) -> Value {
+    let mut obj = Map::new();
+    obj.insert("SPDXID".to_string(), json!(spdx_id));
+    obj.insert("fileName".to_string(), json!(component.name));
+
+    if let Some(checksums) = emit_checksums(&component.hashes) {
+        obj.insert("checksums".to_string(), checksums);
+    }
+
+    let concluded = component.licenses.concluded.as_ref().map_or_else(
+        || license_field(&component.licenses.declared),
+        |c| c.expression.clone(),
+    );
+    obj.insert("licenseConcluded".to_string(), json!(concluded));
+
+    if let Some(copyright) = &component.copyright {
+        obj.insert("copyrightText".to_string(), json!(copyright));
+    }
+
+    Value::Object(obj)
+}
+
+/// Re-emit `LicenseRef-*` definitions resolved at parse time as
+/// `hasExtractedLicensingInfos` entries so the id → name mapping survives a
+/// round-trip. The model keeps only the resolved display name, so the
+/// schema-required `extractedText` falls back to that same name.
+fn emit_extracted_licenses(sbom: &NormalizedSbom) -> Vec<Value> {
+    // BTreeMap for deterministic output order.
+    let mut by_id: std::collections::BTreeMap<&str, &str> = std::collections::BTreeMap::new();
+    for component in sbom.components.values() {
+        let licenses = component
+            .licenses
+            .declared
+            .iter()
+            .chain(component.licenses.concluded.as_ref());
+        for lic in licenses {
+            if let Some(name) = &lic.resolved_name
+                && lic.expression.starts_with("LicenseRef-")
+            {
+                by_id.entry(lic.expression.as_str()).or_insert(name);
+            }
+        }
+    }
+    by_id
+        .into_iter()
+        .map(|(id, name)| {
+            json!({
+                "licenseId": id,
+                "name": name,
+                "extractedText": name,
+            })
+        })
+        .collect()
 }
 
 /// Best-effort download location: a VCS/distribution external ref URL if present,
@@ -433,7 +524,14 @@ fn emit_creation_info(sbom: &NormalizedSbom, report: &mut FidelityReport) -> Val
                 CreatorType::Organization => "Organization",
                 CreatorType::Person => "Person",
             };
-            format!("{prefix}: {}", c.name)
+            // SPDX 2.3 §6.8: Person/Organization creators carry an optional
+            // "(email)" suffix; Tool creators are name-only.
+            match &c.email {
+                Some(email) if c.creator_type != CreatorType::Tool => {
+                    format!("{prefix}: {} ({email})", c.name)
+                }
+                _ => format!("{prefix}: {}", c.name),
+            }
         })
         .collect();
     if creators.is_empty() {
@@ -647,6 +745,136 @@ mod tests {
         assert!(names.contains(&"lodash"), "lodash mapped: {names:?}");
         // app depends-on lodash survives as a relationship.
         assert!(!reparsed.edges.is_empty(), "dependency edges mapped");
+    }
+
+    /// Document exercising creators with emails, a file entry owned by the
+    /// package, documentDescribes, and a resolved LicenseRef definition.
+    const SPDX_FULL: &str = r#"{
+        "spdxVersion": "SPDX-2.3", "SPDXID": "SPDXRef-DOCUMENT", "name": "app",
+        "dataLicense": "CC0-1.0",
+        "documentNamespace": "https://example.com/app",
+        "creationInfo": {"created": "2026-01-04T12:00:00Z",
+                         "creators": ["Person: Jane Doe (jane@example.com)",
+                                      "Organization: Acme (contact@acme.com)",
+                                      "Tool: t-1.0"]},
+        "packages": [
+            {"SPDXID": "SPDXRef-Package-app", "name": "app",
+             "versionInfo": "1.0.0", "downloadLocation": "NOASSERTION",
+             "licenseDeclared": "LicenseRef-Proprietary",
+             "licenseConcluded": "LicenseRef-Proprietary",
+             "hasFiles": ["SPDXRef-File-main"]}
+        ],
+        "files": [
+            {"SPDXID": "SPDXRef-File-main", "fileName": "src/main.rs",
+             "checksums": [{"algorithm": "SHA1", "checksumValue": "deadbeef"}],
+             "licenseConcluded": "MIT",
+             "copyrightText": "Copyright Acme"}
+        ],
+        "hasExtractedLicensingInfos": [
+            {"licenseId": "LicenseRef-Proprietary", "name": "Acme Proprietary",
+             "extractedText": "All rights reserved."}
+        ],
+        "documentDescribes": ["SPDXRef-Package-app"]
+    }"#;
+
+    #[test]
+    fn creator_email_round_trips() {
+        let sbom = parse_sbom_str(SPDX_FULL).unwrap();
+        let (json, _report) = emit_spdx(&sbom).unwrap();
+        let doc: Value = serde_json::from_str(&json).unwrap();
+        let creators: Vec<&str> = doc["creationInfo"]["creators"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|c| c.as_str().unwrap())
+            .collect();
+        assert!(
+            creators.contains(&"Person: Jane Doe (jane@example.com)"),
+            "person email kept: {creators:?}"
+        );
+        assert!(
+            creators.contains(&"Organization: Acme (contact@acme.com)"),
+            "org email kept: {creators:?}"
+        );
+        assert!(creators.contains(&"Tool: t-1.0"), "tool name-only kept");
+    }
+
+    #[test]
+    fn file_components_emit_as_files_not_packages() {
+        let sbom = parse_sbom_str(SPDX_FULL).unwrap();
+        let (json, _report) = emit_spdx(&sbom).unwrap();
+        let doc: Value = serde_json::from_str(&json).unwrap();
+
+        let files = doc["files"].as_array().expect("files array emitted");
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0]["fileName"], "src/main.rs");
+        assert_eq!(files[0]["checksums"][0]["checksumValue"], "deadbeef");
+        assert_eq!(files[0]["licenseConcluded"], "MIT");
+
+        let packages = doc["packages"].as_array().unwrap();
+        assert_eq!(packages.len(), 1, "file must not appear as a package");
+        assert_eq!(packages[0]["name"], "app");
+
+        // The package→file CONTAINS edge (from hasFiles) survives.
+        let file_id = files[0]["SPDXID"].as_str().unwrap();
+        let pkg_id = packages[0]["SPDXID"].as_str().unwrap();
+        assert!(
+            doc["relationships"].as_array().unwrap().iter().any(|r| {
+                r["relationshipType"] == "CONTAINS"
+                    && r["spdxElementId"] == pkg_id
+                    && r["relatedSpdxElement"] == file_id
+            }),
+            "CONTAINS relationship preserved"
+        );
+
+        // And the whole thing re-parses with the file still typed File.
+        let reparsed = parse_sbom_str(&json).unwrap();
+        let file = reparsed
+            .components
+            .values()
+            .find(|c| c.name == "src/main.rs")
+            .expect("file component survives round-trip");
+        assert_eq!(file.component_type, crate::model::ComponentType::File);
+    }
+
+    #[test]
+    fn document_describes_emitted_for_primary() {
+        let sbom = parse_sbom_str(SPDX_FULL).unwrap();
+        assert!(sbom.primary_component_id.is_some(), "fixture has a primary");
+        let (json, _report) = emit_spdx(&sbom).unwrap();
+        let doc: Value = serde_json::from_str(&json).unwrap();
+
+        let pkg_id = doc["packages"][0]["SPDXID"].as_str().unwrap();
+        let describes = doc["documentDescribes"]
+            .as_array()
+            .expect("documentDescribes emitted");
+        assert_eq!(describes, &[json!(pkg_id)]);
+    }
+
+    #[test]
+    fn resolved_license_refs_emit_extracted_infos() {
+        let sbom = parse_sbom_str(SPDX_FULL).unwrap();
+        let (json, _report) = emit_spdx(&sbom).unwrap();
+        let doc: Value = serde_json::from_str(&json).unwrap();
+
+        let infos = doc["hasExtractedLicensingInfos"]
+            .as_array()
+            .expect("hasExtractedLicensingInfos emitted");
+        assert_eq!(infos.len(), 1);
+        assert_eq!(infos[0]["licenseId"], "LicenseRef-Proprietary");
+        assert_eq!(infos[0]["name"], "Acme Proprietary");
+
+        // The resolution survives a full round-trip.
+        let reparsed = parse_sbom_str(&json).unwrap();
+        let app = reparsed
+            .components
+            .values()
+            .find(|c| c.name == "app")
+            .unwrap();
+        assert_eq!(
+            app.licenses.declared[0].resolved_name.as_deref(),
+            Some("Acme Proprietary")
+        );
     }
 
     #[test]

--- a/tests/compliance_rule_registry_tests.rs
+++ b/tests/compliance_rule_registry_tests.rs
@@ -179,10 +179,10 @@ fn sarif_rule_ids_are_stable_for_cra_noncompliant_fixture() {
     );
 }
 
-/// The NTIA / FDA / SSDF / EO families keep their stable prefixes. The shared
-/// document-metadata checks (creator/serial-number) emit `SBOM-CRA-GENERAL`
-/// regardless of level, matching the pre-registry behaviour, so that generic
-/// fallback is permitted alongside the profile prefix.
+/// The NTIA / SSDF / EO families keep their stable prefixes — including the
+/// shared document-metadata checks (creator/serial-number), whose fallback is
+/// the family generic (`SBOM-<FAMILY>-GENERAL` via `generic_rule_id_for_level`),
+/// never another family's id.
 #[test]
 fn sarif_rule_ids_keep_profile_prefixes() {
     let fx = fixture_dir("cyclonedx").join("minimal.cdx.json");
@@ -193,9 +193,8 @@ fn sarif_rule_ids_keep_profile_prefixes() {
     ] {
         let ids = sarif_rule_ids(&fx, level);
         assert!(
-            ids.iter()
-                .all(|id| id.starts_with(prefix) || id == "SBOM-CRA-GENERAL"),
-            "{level:?} should emit only {prefix}* (or SBOM-CRA-GENERAL) rule IDs, got {ids:?}"
+            ids.iter().all(|id| id.starts_with(prefix)),
+            "{level:?} should emit only {prefix}* rule IDs, got {ids:?}"
         );
     }
 }

--- a/tests/rule_identity_tests.rs
+++ b/tests/rule_identity_tests.rs
@@ -238,6 +238,140 @@ fn quality_sarif_has_no_invented_quality_ids_and_no_error_level_recommendations(
 }
 
 // ---------------------------------------------------------------------------
+// 3b. Family-correct fallback identity for unmapped check sites
+// ---------------------------------------------------------------------------
+
+/// SBOM that also fires the level-agnostic CycloneDX bom-ref heuristic
+/// (`format_id == name`), whose check site has no specific registry mapping
+/// and therefore stamps the family-generic fallback rule for the running
+/// level (`generic_rule_id_for_level`).
+fn fallback_firing_sbom() -> NormalizedSbom {
+    let mut sbom = violating_sbom();
+    sbom.add_component(Component::new("libx".to_string(), "libx".to_string()));
+    sbom
+}
+
+fn declared_rule_ids(run: &serde_json::Value) -> BTreeSet<String> {
+    run["tool"]["driver"]["rules"]
+        .as_array()
+        .expect("rules array")
+        .iter()
+        .filter_map(|r| r["id"].as_str().map(String::from))
+        .collect()
+}
+
+/// An NTIA-only `validate -o sarif` run must never stamp a CRA-family
+/// identity on its findings: check sites without a specific registry mapping
+/// re-bucket onto SBOM-NTIA-GENERAL (declared in rules[]), and the fallback
+/// result carries `properties.standardIds` for the running standard.
+#[test]
+fn ntia_validate_sarif_emits_no_cra_rule_ids_and_family_correct_fallback() {
+    let result =
+        ComplianceChecker::new(ComplianceLevel::NtiaMinimum).check(&fallback_firing_sbom());
+    // Check sites stamp the family generic directly, so the JSON-visible
+    // rule_id agrees with SARIF — no CRA identity anywhere in the raw result.
+    assert!(
+        result
+            .violations
+            .iter()
+            .any(|v| v.rule_id == "SBOM-NTIA-GENERAL"),
+        "fixture must exercise the unmapped-fallback path"
+    );
+    assert!(
+        result
+            .violations
+            .iter()
+            .all(|v| !v.rule_id.starts_with("SBOM-CRA-")),
+        "NTIA-only violations must not carry a CRA-family rule_id"
+    );
+    let sarif = generate_compliance_sarif(&result).expect("sarif");
+    let json: serde_json::Value = serde_json::from_str(&sarif).expect("valid SARIF");
+    let run = &json["runs"][0];
+    let declared = declared_rule_ids(run);
+    let mut fallback_seen = false;
+    for r in run["results"].as_array().expect("results") {
+        let rule_id = r["ruleId"].as_str().expect("ruleId");
+        assert!(
+            !rule_id.starts_with("SBOM-CRA-"),
+            "NTIA-only run emitted CRA-family rule id {rule_id}"
+        );
+        assert!(
+            declared.contains(rule_id),
+            "result rule {rule_id} lacks a reportingDescriptor"
+        );
+        if rule_id == "SBOM-NTIA-GENERAL" {
+            fallback_seen = true;
+            let ids = r["properties"]["standardIds"]
+                .as_array()
+                .expect("fallback result carries properties.standardIds");
+            assert!(
+                ids.iter()
+                    .filter_map(|v| v.as_str())
+                    .any(|s| s.starts_with("NTIA:")),
+                "fallback standardIds must cite the running standard, got {ids:?}"
+            );
+        }
+    }
+    assert!(
+        fallback_seen,
+        "unmapped findings must re-bucket onto SBOM-NTIA-GENERAL"
+    );
+}
+
+/// A quality-report SARIF for a non-CRA profile must never stamp a
+/// CRA-family identity on its findings: unmapped check sites re-bucket onto
+/// SBOM-QUALITY-GENERAL, and every emitted ruleId is declared in rules[].
+#[test]
+fn quality_sarif_emits_no_cra_rule_ids_for_non_cra_profiles() {
+    let sbom = fallback_firing_sbom();
+    let report = QualityScorer::new(ScoringProfile::Standard).score(&sbom);
+    assert_eq!(report.compliance.level, ComplianceLevel::Standard);
+    assert!(
+        report
+            .compliance
+            .violations
+            .iter()
+            .any(|v| v.rule_id == "SBOM-QUALITY-GENERAL"),
+        "fixture must exercise the unmapped-fallback path"
+    );
+    let sarif = generate_quality_sarif(&report, "test.cdx.json", "standard").expect("sarif");
+    let json: serde_json::Value = serde_json::from_str(&sarif).expect("valid SARIF");
+    let run = &json["runs"][0];
+    let declared = declared_rule_ids(run);
+    let mut fallback_seen = false;
+    for r in run["results"].as_array().expect("results") {
+        let rule_id = r["ruleId"].as_str().expect("ruleId");
+        assert!(
+            !rule_id.starts_with("SBOM-CRA-"),
+            "quality (standard profile) SARIF emitted CRA-family rule id {rule_id}"
+        );
+        assert!(
+            declared.contains(rule_id),
+            "result rule {rule_id} lacks a reportingDescriptor"
+        );
+        fallback_seen |= rule_id == "SBOM-QUALITY-GENERAL";
+    }
+    assert!(
+        fallback_seen,
+        "unmapped findings must re-bucket onto SBOM-QUALITY-GENERAL"
+    );
+}
+
+/// CRA runs keep the historical fallback identity: the re-bucketing must not
+/// move correctly-scoped CRA findings off SBOM-CRA-GENERAL (GitHub code
+/// scanning dedups on these ids).
+#[test]
+fn cra_validate_sarif_keeps_the_cra_general_fallback() {
+    let result = ComplianceChecker::new(ComplianceLevel::CraPhase2).check(&fallback_firing_sbom());
+    let sarif = generate_compliance_sarif(&result).expect("sarif");
+    let ids = sarif_rule_ids(&sarif);
+    assert!(
+        ids.contains("SBOM-CRA-GENERAL"),
+        "CRA-run fallback findings must stay on SBOM-CRA-GENERAL, got {ids:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // 4. OSCAL per-standard identity
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Post-merge e2e testing of the recent PR wave (#311/#314/#315/#320) drove the real binary through the merged behavior and surfaced four confirmed bugs plus three smaller correctness gaps. This PR fixes all of them.

### The four confirmed bugs
1. **CDX VEX per-version status was only half-enforced** (false-positive vulns): a component whose exact version was listed `"status": "unaffected"` in `affects[].versions` still had the vulnerability attached by bom-ref. Attachment now respects exact-version unaffected entries; range entries and versionless components conservatively keep attaching.
2. **SPDX2 LicenseRef resolution was parse-only**: `resolved_name` (from `hasExtractedLicensingInfos`) was never consumed by any output. `LicenseExpression::display_name()` now feeds json/csv/summary/html/markdown rendering, the CycloneDX emitter emits resolved refs as `{"license":{"name":…}}`, and the SPDX emitter re-emits `hasExtractedLicensingInfos` so resolution round-trips.
3. **Creator email lost on emit**: SPDX target re-emits `Person: Name (email)`; CycloneDX target emits `metadata.authors` / `metadata.manufacturer`. Also fixed in the same emitter pass: File components round-tripped as packages (now `files[]`), and `documentDescribes` was dropped (now emitted for the primary).
4. **SARIF fallback minted CRA identity for non-CRA findings**: unmapped check sites stamped `SBOM-CRA-GENERAL` in NTIA-only and quality runs. The family-generic fallback (`generic_rule_id_for_level`) is now applied at the check sites, so JSON `rule_id`/`sarif_rule_id` and SARIF `ruleId` agree by construction; six missing family generics registered as self-descriptors. CRA output byte-identical.

### Smaller gaps
- `cryptography_score` read 100.0 for CBOMs with all-unclassifiable assets (now 0) or unresolvable cert/key/protocol algorithm refs (now proportionally penalized, mirroring `crypto_dependency_score`).
- File-typed components were exempt from completeness (#315) but still cratered identifier/license/dependency-coverage ratios — same exemption now applied consistently.
- `diff --fail-on-change` help text contradicted the EXIT CODES table.

### Behavior changes to note
- `view`/report license output now shows resolved license names instead of bare `LicenseRef-*` strings.
- CycloneDX emit: `LicenseRef-*` moves from the (spec-dubious) `id` field to `name`.
- SARIF/JSON rule ids change for unmapped findings in **non-CRA** runs only (e.g. `SBOM-CRA-GENERAL` → `SBOM-NTIA-GENERAL`); GitHub code-scanning dedup for CRA runs is unaffected.
- Quality scores can shift for SBOMs with File components (upward) and CBOMs with unresolvable crypto refs (downward).

### Verification
- 12 new regression tests (each verified fail-before/pass-after); full `cargo test --all-features`: 54/54 suites green; `cargo clippy --all-features -- -D warnings` clean; fmt clean.
- Every original e2e repro re-run against the rebuilt binary and confirmed fixed (unaffected-version component now 0 vulns while affected stays 1; resolved license names in all five output formats; creator email + files + documentDescribes round-trip; zero `SBOM-CRA-*` ids in NTIA/quality SARIF *and* JSON; degraded crypto scores; File-count-invariant sub-scores).

🤖 Generated with [Claude Code](https://claude.com/claude-code)