### PR TITLE
fix(cli): close the CLI audit findings — exit-code contract, fail-closed gates, data integrity

### DIFF
--- a/src/cli/cache.rs
+++ b/src/cli/cache.rs
@@ -80,36 +80,45 @@ struct SourceStatus {
 }
 
 fn source_status(name: &str, dir: &Path) -> SourceStatus {
-    let mut entries = 0usize;
-    let mut total_size = 0u64;
-    let mut oldest: Option<Duration> = None;
-    let mut newest: Option<Duration> = None;
+    let mut status = SourceStatus {
+        name: name.to_string(),
+        entries: 0,
+        total_size: 0,
+        oldest: None,
+        newest: None,
+    };
+    collect_status(dir, &mut status);
+    status
+}
 
+/// Recursively fold every `*.json` file under `dir` into `status`.
+///
+/// Export/import copy the cache as a full tree, so nested entries (e.g. a
+/// source that shards its cache into subdirectories, or an imported bundle)
+/// must be counted too — `status` and `clear` must see exactly what
+/// `export`/`import` copy.
+fn collect_status(dir: &Path, status: &mut SourceStatus) {
     if let Ok(read_dir) = fs::read_dir(dir) {
         for entry in read_dir.flatten() {
             let path = entry.path();
+            if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                collect_status(&path, status);
+                continue;
+            }
             if path.extension().is_none_or(|e| e != "json") {
                 continue;
             }
-            entries += 1;
+            status.entries += 1;
             if let Ok(meta) = entry.metadata() {
-                total_size += meta.len();
+                status.total_size += meta.len();
                 if let Ok(modified) = meta.modified()
                     && let Ok(age) = modified.elapsed()
                 {
-                    oldest = Some(oldest.map_or(age, |o| o.max(age)));
-                    newest = Some(newest.map_or(age, |n| n.min(age)));
+                    status.oldest = Some(status.oldest.map_or(age, |o| o.max(age)));
+                    status.newest = Some(status.newest.map_or(age, |n| n.min(age)));
                 }
             }
         }
-    }
-
-    SourceStatus {
-        name: name.to_string(),
-        entries,
-        total_size,
-        oldest,
-        newest,
     }
 }
 
@@ -223,15 +232,7 @@ fn cache_clear(quiet: bool) -> Result<i32> {
 
     let mut removed = 0usize;
     for ns in SOURCE_NAMESPACES {
-        let dir = root.join(ns);
-        if let Ok(read_dir) = fs::read_dir(&dir) {
-            for entry in read_dir.flatten() {
-                let path = entry.path();
-                if path.extension().is_some_and(|e| e == "json") && fs::remove_file(&path).is_ok() {
-                    removed += 1;
-                }
-            }
-        }
+        removed += remove_json_recursive(&root.join(ns));
     }
 
     if !quiet {
@@ -240,10 +241,43 @@ fn cache_clear(quiet: bool) -> Result<i32> {
     Ok(exit_codes::SUCCESS)
 }
 
+/// Recursively remove every `*.json` file under `dir`, pruning subdirectories
+/// that become empty. Returns the number of files removed. `clear` must
+/// remove exactly what `import` brought in (a full tree), not just the
+/// top-level entries.
+fn remove_json_recursive(dir: &Path) -> usize {
+    let mut removed = 0usize;
+    if let Ok(read_dir) = fs::read_dir(dir) {
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            if entry.file_type().is_ok_and(|t| t.is_dir()) {
+                removed += remove_json_recursive(&path);
+                // Prune the subdirectory if it is now empty (best-effort).
+                let _ = fs::remove_dir(&path);
+            } else if path.extension().is_some_and(|e| e == "json")
+                && fs::remove_file(&path).is_ok()
+            {
+                removed += 1;
+            }
+        }
+    }
+    removed
+}
+
 fn cache_export(dest: &Path, quiet: bool) -> Result<i32> {
     let root = root_cache_dir();
     if !root.exists() {
         anyhow::bail!("no cache to export ({} does not exist)", root.display());
+    }
+
+    // A destination inside the cache tree would be copied into while it is
+    // being read, nesting the cache into itself until the path length limit.
+    if paths_overlap(&root, dest) == Some(Containment::SecondInsideFirst) {
+        anyhow::bail!(
+            "refusing to export the cache into itself: {} is inside the cache directory {}",
+            dest.display(),
+            root.display()
+        );
     }
 
     fs::create_dir_all(dest)
@@ -265,6 +299,15 @@ fn cache_import(src: &Path, quiet: bool) -> Result<i32> {
     }
 
     let root = root_cache_dir();
+    // Importing from inside the cache (or from a directory that contains the
+    // cache) would copy the live cache into itself while reading it.
+    if paths_overlap(&root, src).is_some() {
+        anyhow::bail!(
+            "refusing to import the cache into itself: {} overlaps the cache directory {}",
+            src.display(),
+            root.display()
+        );
+    }
     fs::create_dir_all(&root)
         .with_context(|| format!("creating cache directory {}", root.display()))?;
     let copied = copy_dir_recursive(src, &root)?;
@@ -276,6 +319,58 @@ fn cache_import(src: &Path, quiet: bool) -> Result<i32> {
         );
     }
     Ok(exit_codes::SUCCESS)
+}
+
+/// How two paths overlap (see [`paths_overlap`]).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Containment {
+    /// The two paths resolve to the same directory.
+    Same,
+    /// The second path is inside the first.
+    SecondInsideFirst,
+    /// The first path is inside the second.
+    FirstInsideSecond,
+}
+
+/// Determine whether `a` and `b` overlap (same directory, or one inside the
+/// other), after resolving both to absolute, symlink-free forms. Returns
+/// `None` when the paths are disjoint.
+fn paths_overlap(a: &Path, b: &Path) -> Option<Containment> {
+    let a = resolve_for_containment(a);
+    let b = resolve_for_containment(b);
+    if a == b {
+        Some(Containment::Same)
+    } else if b.starts_with(&a) {
+        Some(Containment::SecondInsideFirst)
+    } else if a.starts_with(&b) {
+        Some(Containment::FirstInsideSecond)
+    } else {
+        None
+    }
+}
+
+/// Resolve `path` for containment checks: absolute, with symlinks in the
+/// existing portion resolved. The path itself may not exist yet — the nearest
+/// existing ancestor is canonicalized and the non-existing remainder
+/// re-appended, so `<cache>/new-subdir` still compares as inside `<cache>`.
+fn resolve_for_containment(path: &Path) -> PathBuf {
+    let abs = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+    let mut existing = abs.as_path();
+    let mut rest: Vec<std::ffi::OsString> = Vec::new();
+    while !existing.exists() {
+        match (existing.parent(), existing.file_name()) {
+            (Some(parent), Some(name)) => {
+                rest.push(name.to_os_string());
+                existing = parent;
+            }
+            _ => return abs,
+        }
+    }
+    let mut resolved = fs::canonicalize(existing).unwrap_or_else(|_| existing.to_path_buf());
+    for name in rest.iter().rev() {
+        resolved.push(name);
+    }
+    resolved
 }
 
 /// Recursively copy every file from `src` into `dest`, mirroring the directory
@@ -353,6 +448,66 @@ mod tests {
         assert_eq!(human_age(Duration::from_secs(120)), "2m");
         assert_eq!(human_age(Duration::from_secs(7200)), "2h");
         assert_eq!(human_age(Duration::from_secs(2 * 86_400)), "2d");
+    }
+
+    #[test]
+    fn paths_overlap_detects_nesting_even_for_nonexistent_dest() {
+        let root = tempfile::tempdir().unwrap();
+        let other = tempfile::tempdir().unwrap();
+
+        // dest inside root (does not exist yet) — the export runaway case.
+        let dest = root.path().join("sub").join("deeper");
+        assert_eq!(
+            paths_overlap(root.path(), &dest),
+            Some(Containment::SecondInsideFirst)
+        );
+        // Same directory.
+        assert_eq!(
+            paths_overlap(root.path(), root.path()),
+            Some(Containment::Same)
+        );
+        // root inside src — the import-from-parent runaway case.
+        let inner = other.path().join("cache");
+        fs::create_dir_all(&inner).unwrap();
+        assert_eq!(
+            paths_overlap(&inner, other.path()),
+            Some(Containment::FirstInsideSecond)
+        );
+        // Disjoint paths do not overlap.
+        assert_eq!(paths_overlap(root.path(), other.path()), None);
+    }
+
+    #[test]
+    fn source_status_counts_nested_entries() {
+        // status must see what import copied: full trees, not only the
+        // namespace directory's top level.
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("top.json"), "{}").unwrap();
+        let nested = dir.path().join("nested").join("deep");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("a.json"), "{\"k\":1}").unwrap();
+        fs::write(nested.join("ignored.txt"), "x").unwrap();
+
+        let status = source_status("osv", dir.path());
+        assert_eq!(status.entries, 2, "top-level + nested json must count");
+        assert!(status.total_size >= 2);
+    }
+
+    #[test]
+    fn remove_json_recursive_clears_nested_entries_and_prunes_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("top.json"), "{}").unwrap();
+        let nested = dir.path().join("nested").join("deep");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("a.json"), "{}").unwrap();
+        fs::write(nested.join("keep.txt"), "x").unwrap();
+
+        let removed = remove_json_recursive(dir.path());
+        assert_eq!(removed, 2);
+        assert!(!dir.path().join("top.json").exists());
+        assert!(!nested.join("a.json").exists());
+        // Non-json files survive; their directory is not pruned.
+        assert!(nested.join("keep.txt").exists());
     }
 
     #[test]

--- a/src/cli/convert.rs
+++ b/src/cli/convert.rs
@@ -4,12 +4,12 @@
 //! single target format from the canonical model. A fidelity report is written
 //! to stderr describing synthesized and dropped fields (honest about lossiness).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
-use crate::parsers::parse_sbom;
-use crate::pipeline::exit_codes;
+use crate::parsers::parse_sbom_str;
+use crate::pipeline::{exit_codes, read_input};
 use crate::serialization::emit::{self, EmitError, EmitTarget};
 
 /// Run the convert command.
@@ -19,7 +19,7 @@ use crate::serialization::emit::{self, EmitError, EmitTarget};
 /// format-specific blocks the canonical model can't fully reconstruct
 /// (`cryptoProperties`, `evidence`) are spliced back where present.
 pub fn run_convert(
-    file: &PathBuf,
+    file: &Path,
     target: &str,
     output_file: Option<&PathBuf>,
     preserve: bool,
@@ -30,8 +30,10 @@ pub fn run_convert(
         return Ok(exit_codes::ERROR);
     };
 
-    let raw_json = std::fs::read_to_string(file)?;
-    let mut sbom = parse_sbom(file)?;
+    // Shared '-'-aware input path (same as view/validate): supports piping an
+    // SBOM via stdin and gives contextful errors instead of a raw ENOENT.
+    let raw_json = read_input(file)?;
+    let mut sbom = parse_sbom_str(&raw_json)?;
 
     if preserve {
         emit::preserve_source_json(&raw_json, &mut sbom);

--- a/src/cli/cra_docs.rs
+++ b/src/cli/cra_docs.rs
@@ -18,7 +18,18 @@ use crate::quality::{ComplianceChecker, ComplianceLevel, ComplianceResult};
 use anyhow::{Context, Result};
 use std::path::PathBuf;
 
+/// The dossier files `cra-docs` writes into the output directory.
+const DOSSIER_FILES: [&str; 3] = [
+    "eu-declaration-of-conformity.md",
+    "technical-documentation.md",
+    "vulnerability-handling-policy.md",
+];
+
 /// Run the `cra-docs` command. Generates 3 Markdown files in `output_dir`.
+///
+/// Refuses to overwrite existing dossier files (they are meant to be
+/// hand-completed after generation); see [`run_cra_docs_with_force`] for the
+/// `--force` variant.
 #[allow(clippy::needless_pass_by_value)]
 pub fn run_cra_docs(
     sbom_path: PathBuf,
@@ -26,6 +37,45 @@ pub fn run_cra_docs(
     cra_sidecar_path: Option<PathBuf>,
     cra_product_class: Option<String>,
 ) -> Result<()> {
+    run_cra_docs_with_force(
+        sbom_path,
+        output_dir,
+        cra_sidecar_path,
+        cra_product_class,
+        false,
+    )
+}
+
+/// [`run_cra_docs`] with an explicit overwrite decision.
+///
+/// The generated dossier is a *starting point* the operator completes by
+/// hand (`_TBD_` placeholders), so a re-run must not silently clobber those
+/// edits: when `force` is false and any dossier file already exists, this
+/// errors listing the existing files; `--force` overwrites them.
+#[allow(clippy::needless_pass_by_value)]
+pub fn run_cra_docs_with_force(
+    sbom_path: PathBuf,
+    output_dir: PathBuf,
+    cra_sidecar_path: Option<PathBuf>,
+    cra_product_class: Option<String>,
+    force: bool,
+) -> Result<()> {
+    if !force {
+        let existing: Vec<String> = DOSSIER_FILES
+            .iter()
+            .map(|name| output_dir.join(name))
+            .filter(|p| p.exists())
+            .map(|p| format!("  {}", p.display()))
+            .collect();
+        if !existing.is_empty() {
+            anyhow::bail!(
+                "refusing to overwrite existing dossier file(s) (they may contain hand-completed \
+                 content):\n{}\nPass --force to overwrite.",
+                existing.join("\n")
+            );
+        }
+    }
+
     let parsed = parse_sbom_with_context(&sbom_path, false)?;
     let sbom = parsed.sbom();
 
@@ -63,15 +113,15 @@ pub fn run_cra_docs(
         .with_context(|| format!("creating output directory {}", output_dir.display()))?;
 
     write_doc(
-        &output_dir.join("eu-declaration-of-conformity.md"),
+        &output_dir.join(DOSSIER_FILES[0]),
         &render_doc(sbom, sidecar.as_ref(), effective_class, route),
     )?;
     write_doc(
-        &output_dir.join("technical-documentation.md"),
+        &output_dir.join(DOSSIER_FILES[1]),
         &render_tech_doc(sbom, sidecar.as_ref(), effective_class, route, &compliance),
     )?;
     write_doc(
-        &output_dir.join("vulnerability-handling-policy.md"),
+        &output_dir.join(DOSSIER_FILES[2]),
         &render_vuln_policy(sbom, sidecar.as_ref()),
     )?;
 
@@ -524,6 +574,43 @@ mod tests {
         assert!(out.join("eu-declaration-of-conformity.md").exists());
         assert!(out.join("technical-documentation.md").exists());
         assert!(out.join("vulnerability-handling-policy.md").exists());
+    }
+
+    #[test]
+    fn rerun_refuses_to_clobber_existing_dossier_unless_forced() {
+        let dir = tempdir().unwrap();
+        let sbom_path = dir.path().join("app.cdx.json");
+        std::fs::write(
+            &sbom_path,
+            r#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[]}"#,
+        )
+        .unwrap();
+        let out = dir.path().join("dossier");
+
+        run_cra_docs(sbom_path.clone(), out.clone(), None, None).expect("first run succeeds");
+
+        // Simulate the operator completing the dossier by hand.
+        let doc = out.join("eu-declaration-of-conformity.md");
+        std::fs::write(&doc, "HAND-EDITED").unwrap();
+
+        // Second run without --force must refuse, naming the existing files.
+        let err = run_cra_docs(sbom_path.clone(), out.clone(), None, None)
+            .expect_err("rerun without --force must refuse to overwrite");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("eu-declaration-of-conformity.md") && msg.contains("--force"),
+            "error must list existing files and mention --force: {msg}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&doc).unwrap(),
+            "HAND-EDITED",
+            "hand-edited dossier must be untouched"
+        );
+
+        // --force overwrites.
+        run_cra_docs_with_force(sbom_path, out.clone(), None, None, true)
+            .expect("forced rerun succeeds");
+        assert_ne!(std::fs::read_to_string(&doc).unwrap(), "HAND-EDITED");
     }
 
     #[test]

--- a/src/cli/diff.rs
+++ b/src/cli/diff.rs
@@ -38,6 +38,11 @@ pub fn run_diff(config: DiffConfig) -> Result<i32> {
         bail!("Cannot read both SBOMs from stdin ('-'); only one '-' is allowed per diff");
     }
 
+    // Reject unknown --severity / --graph-impact-threshold values before
+    // parsing or enrichment; previously they silently filtered nothing /
+    // coerced to `low`.
+    crate::pipeline::validate_post_diff_filters(&config.filtering, &config.graph_diff)?;
+
     // Parse SBOMs
     let mut old_parsed = parse_sbom_with_context(&config.paths.old, quiet)?;
     let mut new_parsed = parse_sbom_with_context(&config.paths.new, quiet)?;
@@ -99,8 +104,25 @@ pub fn run_diff(config: DiffConfig) -> Result<i32> {
         let kev_old = crate::pipeline::enrich_kev(old_parsed.sbom_mut(), &kev_config, quiet);
         let kev_new = crate::pipeline::enrich_kev(new_parsed.sbom_mut(), &kev_config, quiet);
         if kev_old.is_none() || kev_new.is_none() {
+            // The --fail-on-kev gate cannot be evaluated without KEV data:
+            // treating the load failure as a warning would silently pass the
+            // gate (fail-open). Abort as an operational error (exit 3)
+            // instead. `enrich_kev` has already printed the underlying cause
+            // ("Warning: KEV enrichment failed: ...") to stderr.
+            if config.behavior.fail_on_kev {
+                bail!(
+                    "--fail-on-kev requires KEV data: KEV catalog could not be loaded \
+                     (see warning above for the cause; if running offline, pre-populate \
+                     the KEV cache first)"
+                );
+            }
             enrichment_warnings.push("KEV enrichment failed");
         }
+    } else if config.behavior.fail_on_kev {
+        // Defensive: the CLI layer force-enables KEV enrichment whenever
+        // --fail-on-kev is set, but if a config path ever reaches here
+        // without it, the gate would be vacuously fail-open.
+        bail!("--fail-on-kev requires KEV data: KEV enrichment is not enabled");
     }
 
     // Enrich with FIRST EPSS exploit-probability scores
@@ -162,6 +184,14 @@ pub fn run_diff(config: DiffConfig) -> Result<i32> {
 
     #[cfg(not(feature = "enrichment"))]
     {
+        // Without the enrichment feature, KEV data can never be loaded, so
+        // the --fail-on-kev gate would be permanently fail-open.
+        if config.behavior.fail_on_kev {
+            bail!(
+                "--fail-on-kev requires KEV data: this binary was built without the \
+                 'enrichment' feature. Rebuild with: cargo build --features enrichment"
+            );
+        }
         if config.enrichment.enabled {
             eprintln!(
                 "Warning: enrichment requested but the 'enrichment' feature is not enabled. \
@@ -188,8 +218,8 @@ pub fn run_diff(config: DiffConfig) -> Result<i32> {
         // EU AI Act high-risk escalation, which otherwise renders COMPLIANT
         // in the TUI. Resolution is per-SBOM: each side of the diff is judged
         // against its own adjacent metadata, identically to the report stage.
-        let old_sidecar = crate::pipeline::discover_cra_sidecar(&config.paths.old);
-        let new_sidecar = crate::pipeline::discover_cra_sidecar(&config.paths.new);
+        let old_sidecar = crate::pipeline::discover_cra_sidecar(&config.paths.old)?;
+        let new_sidecar = crate::pipeline::discover_cra_sidecar(&config.paths.new)?;
 
         let (old_sbom, old_raw) = old_parsed.into_parts();
         let (new_sbom, new_raw) = new_parsed.into_parts();
@@ -231,8 +261,9 @@ pub fn run_diff(config: DiffConfig) -> Result<i32> {
 
 /// Determine the appropriate exit code based on diff results and config flags.
 ///
-/// Priority (highest exit code wins): VEX gaps (4) > vulns introduced (2) > changes (1).
-/// VEX gaps are checked first because they are more specific — a user who sets
+/// Priority (most specific gate wins): ML regression (7) > VEX gaps (4) >
+/// KEV (6) > vulns introduced (2) > changes (1). VEX gaps are checked before
+/// the generic vuln gate because they are more specific — a user who sets
 /// `--fail-on-vex-gap` wants to know about missing VEX statements, not just
 /// that vulns were introduced.
 fn determine_exit_code(config: &DiffConfig, result: &crate::diff::DiffResult) -> i32 {

--- a/src/cli/enrich.rs
+++ b/src/cli/enrich.rs
@@ -3,7 +3,7 @@
 //! Enriches an SBOM with vulnerability and EOL data, writing the result
 //! back in the original format.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
@@ -14,16 +14,19 @@ use crate::pipeline::exit_codes;
 /// Parses, enriches, and serializes the SBOM back to its original format.
 #[cfg(feature = "enrichment")]
 pub fn run_enrich(
-    file: &PathBuf,
+    file: &Path,
     output_file: Option<&PathBuf>,
     enrichment: crate::config::EnrichmentConfig,
     quiet: bool,
 ) -> Result<i32> {
-    use crate::parsers::parse_sbom;
+    use crate::parsers::parse_sbom_str;
+    use crate::pipeline::read_input;
     use crate::serialization::enrich_sbom_json;
 
-    let raw_json = std::fs::read_to_string(file)?;
-    let mut sbom = parse_sbom(file)?;
+    // Shared '-'-aware input path (same as view/validate): supports piping an
+    // SBOM via stdin and gives contextful errors instead of a raw ENOENT.
+    let raw_json = read_input(file)?;
+    let mut sbom = parse_sbom_str(&raw_json)?;
 
     // Route through the unified orchestrator so every advertised source
     // (OSV / KEV / EPSS / EOL / staleness / HuggingFace / VEX) and the config

--- a/src/cli/license_check.rs
+++ b/src/cli/license_check.rs
@@ -1,15 +1,20 @@
 //! CLI handler for the `license-check` command.
 //!
 //! Evaluates license policy compliance and dependency propagation risks.
+//!
+//! Exit codes: 0 = policy passed, 5 = policy violations (denied licenses,
+//! review-needed licenses under `--strict`, or propagation conflicts under
+//! `--check-propagation`). Operational errors (unreadable SBOM, invalid
+//! policy file, …) surface as `Err` and are routed to exit code 3 in `main`.
 
 use std::path::{Path, PathBuf};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::license::{
-    LicensePolicyConfig, PolicyDecision, check_license_propagation, evaluate_license_policy,
+    LicenseConflict, LicensePolicyConfig, LicensePolicyResult, PolicyDecision,
+    check_license_propagation, evaluate_license_policy,
 };
-use crate::parsers::parse_sbom;
 use crate::pipeline::exit_codes;
 
 /// Run the license-check command.
@@ -21,21 +26,34 @@ pub fn run_license_check(
     format: &str,
     quiet: bool,
 ) -> Result<i32> {
-    let sbom = parse_sbom(file)?;
+    // Same parse path as validate/quality: supports `-` for stdin and adds
+    // file context to parse errors.
+    let sbom = crate::pipeline::parse_sbom_with_context(file, quiet)?.into_sbom();
 
     let config = if let Some(pf) = policy_file {
-        let content = std::fs::read_to_string(pf)?;
-        serde_json::from_str(&content)?
+        let content = std::fs::read_to_string(pf)
+            .with_context(|| format!("failed to read license policy file {}", pf.display()))?;
+        serde_json::from_str(&content)
+            .with_context(|| format!("invalid license policy file {}", pf.display()))?
     } else if strict {
         LicensePolicyConfig::strict_permissive()
     } else {
         LicensePolicyConfig::permissive()
     };
 
-    let result = evaluate_license_policy(&sbom, &config);
+    let result = evaluate_license_policy(&sbom, &config, strict);
+
+    // Compute propagation conflicts up front so both output formats and the
+    // exit code see them.
+    let conflicts = if check_propagation {
+        Some(check_license_propagation(&sbom))
+    } else {
+        None
+    };
 
     if format == "json" {
-        println!("{}", serde_json::to_string_pretty(&result)?);
+        let doc = build_json_report(&result, conflicts.as_deref())?;
+        println!("{}", serde_json::to_string_pretty(&doc)?);
     } else if !quiet {
         println!("License Policy Check");
         println!("====================");
@@ -68,14 +86,12 @@ pub fn run_license_check(
                 );
             }
         }
-    }
 
-    // Check propagation risks if requested
-    if check_propagation {
-        let conflicts = check_license_propagation(&sbom);
-        if !conflicts.is_empty() && !quiet {
+        if let Some(conflicts) = conflicts.as_deref()
+            && !conflicts.is_empty()
+        {
             println!("\nLicense Propagation Risks:");
-            for c in &conflicts {
+            for c in conflicts {
                 println!("  {} → {} : {}", c.component, c.dependency, c.reason);
                 if !c.path.is_empty() {
                     println!("    path: {}", c.path.join(" → "));
@@ -84,9 +100,84 @@ pub fn run_license_check(
         }
     }
 
-    if result.denied_count > 0 {
+    let propagation_violations = conflicts.as_deref().is_some_and(|c| !c.is_empty());
+
+    if result.denied_count > 0 || propagation_violations {
         Ok(exit_codes::LICENSE_VIOLATIONS)
     } else {
         Ok(exit_codes::SUCCESS)
+    }
+}
+
+/// Build the JSON report document: the policy result, plus a
+/// `propagation_conflicts` array when `--check-propagation` was requested.
+/// Everything lives inside the single JSON document so stdout stays
+/// machine-parseable.
+fn build_json_report(
+    result: &LicensePolicyResult,
+    conflicts: Option<&[LicenseConflict]>,
+) -> Result<serde_json::Value> {
+    let mut doc = serde_json::to_value(result)?;
+    if let Some(conflicts) = conflicts {
+        doc.as_object_mut()
+            .expect("LicensePolicyResult serializes to a JSON object")
+            .insert(
+                "propagation_conflicts".to_string(),
+                serde_json::to_value(conflicts)?,
+            );
+    }
+    Ok(doc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::LicenseFamily;
+
+    fn empty_result() -> LicensePolicyResult {
+        LicensePolicyResult {
+            total_components: 0,
+            allowed_count: 0,
+            denied_count: 0,
+            review_count: 0,
+            undeclared_count: 0,
+            passed: true,
+            violations: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn json_report_without_propagation_has_no_conflicts_key() {
+        let doc = build_json_report(&empty_result(), None).unwrap();
+        assert!(doc.get("propagation_conflicts").is_none());
+        assert!(doc.get("passed").is_some());
+    }
+
+    #[test]
+    fn json_report_embeds_propagation_conflicts() {
+        let conflicts = vec![LicenseConflict {
+            component: "app".to_string(),
+            component_family: LicenseFamily::Permissive,
+            dependency: "copyleft-dep".to_string(),
+            dependency_family: LicenseFamily::Copyleft,
+            path: vec!["app".to_string(), "copyleft-dep".to_string()],
+            reason: "strong copyleft under permissive".to_string(),
+        }];
+        let doc = build_json_report(&empty_result(), Some(&conflicts)).unwrap();
+        let arr = doc
+            .get("propagation_conflicts")
+            .and_then(|v| v.as_array())
+            .expect("propagation_conflicts must be an array inside the document");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["component"], "app");
+    }
+
+    #[test]
+    fn json_report_empty_conflicts_is_empty_array() {
+        let doc = build_json_report(&empty_result(), Some(&[])).unwrap();
+        assert_eq!(
+            doc.get("propagation_conflicts"),
+            Some(&serde_json::json!([]))
+        );
     }
 }

--- a/src/cli/merge.rs
+++ b/src/cli/merge.rs
@@ -2,23 +2,25 @@
 //!
 //! Merges two SBOMs into one, deduplicating components.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
-use crate::pipeline::exit_codes;
+use crate::pipeline::{exit_codes, read_input};
 use crate::serialization::{MergeConfig, merge_sbom_json};
 
 /// Run the merge command.
 pub fn run_merge(
-    primary: &PathBuf,
-    secondary: &PathBuf,
+    primary: &Path,
+    secondary: &Path,
     output_file: Option<&PathBuf>,
     config: MergeConfig,
     quiet: bool,
 ) -> Result<i32> {
-    let primary_json = std::fs::read_to_string(primary)?;
-    let secondary_json = std::fs::read_to_string(secondary)?;
+    // Shared '-'-aware input path (same as view/validate): either input may
+    // be piped via stdin (only one of the two can actually be '-').
+    let primary_json = read_input(primary)?;
+    let secondary_json = read_input(secondary)?;
     let merged = merge_sbom_json(&primary_json, &secondary_json, &config)?;
 
     match output_file {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -26,7 +26,7 @@ mod watch;
 #[cfg(feature = "enrichment")]
 pub use cache::{CacheAction, run_cache};
 pub use convert::run_convert;
-pub use cra_docs::run_cra_docs;
+pub use cra_docs::{run_cra_docs, run_cra_docs_with_force};
 pub use cra_standards_watch::{
     OnlineProbe, TrackedStandard, WatchOutputFormat, cra_catalogue, probe_cra_standards,
     run_cra_standards_watch,
@@ -77,11 +77,12 @@ pub(crate) fn ensure_output_format_supported(
 
 /// Resolve the CRA sidecar for a command.
 ///
-/// An **explicitly** requested sidecar (CLI flag or config file) that fails
-/// to load is a hard error — the user asked for that metadata, so silently
-/// scoring without it would misreport compliance. Auto-discovery (no explicit
-/// path) stays best-effort: `find_for_sbom` logs a warning for a discovered-
-/// but-broken candidate and returns `None`.
+/// A sidecar that fails to load is a hard error whether it was **explicitly**
+/// requested (CLI flag or config file) or **auto-discovered** next to the
+/// SBOM: silently scoring without discovered-but-broken metadata shifts the
+/// verdict with only a stderr warning, and the identical file passed via
+/// `--cra-sidecar` already hard-errors — the trust decision must not depend
+/// on how the file was found.
 pub(crate) fn load_cra_sidecar(
     explicit: Option<&std::path::Path>,
     sbom_path: &std::path::Path,
@@ -90,7 +91,8 @@ pub(crate) fn load_cra_sidecar(
         Some(p) => crate::model::CraSidecarMetadata::from_file(p)
             .map(Some)
             .map_err(|e| anyhow::anyhow!("Failed to load CRA sidecar from {}: {e}", p.display())),
-        None => Ok(crate::model::CraSidecarMetadata::find_for_sbom(sbom_path)),
+        None => crate::model::CraSidecarMetadata::discover_for_sbom(sbom_path)
+            .map_err(|e| anyhow::anyhow!("Failed to load auto-discovered CRA sidecar: {e}")),
     }
 }
 

--- a/src/cli/multi.rs
+++ b/src/cli/multi.rs
@@ -12,7 +12,8 @@ use crate::matching::{FuzzyMatchConfig, MatchingRulesConfig};
 use crate::model::NormalizedSbom;
 use crate::pipeline::{
     OutputTarget, apply_post_diff_filters, auto_detect_format, enrich_sbom_full, enrich_sboms,
-    exit_codes, graph_diff_config_from, parse_sbom_with_context, write_output,
+    exit_codes, graph_diff_config_from, parse_sbom_with_context, validate_post_diff_filters,
+    write_output,
 };
 use crate::reports::ReportFormat;
 use crate::tui::{App, run_tui};
@@ -98,6 +99,12 @@ fn build_multi_engine(
 pub fn run_diff_multi(config: MultiDiffConfig) -> Result<i32> {
     let quiet = config.behavior.quiet;
 
+    // Validate output mode and filter values before doing work (parsing,
+    // enrichment) so unsupported formats and unknown filter labels fail fast,
+    // matching timeline/matrix.
+    let output_mode = resolve_multi_output(&config.output)?;
+    validate_post_diff_filters(&config.filtering, &config.graph_diff)?;
+
     // Parse baseline
     let mut baseline_parsed = parse_sbom_with_context(&config.baseline, quiet)?;
     // Parse and optionally enrich targets
@@ -112,9 +119,6 @@ pub fn run_diff_multi(config: MultiDiffConfig) -> Result<i32> {
         baseline_parsed.sbom().component_count(),
         target_sboms.len()
     );
-
-    // Validate output mode before doing work so unsupported formats fail fast.
-    let output_mode = resolve_multi_output(&config.output)?;
 
     let fuzzy_config = get_fuzzy_config(&config.matching.fuzzy_preset);
 
@@ -167,6 +171,7 @@ pub fn run_diff_multi(config: MultiDiffConfig) -> Result<i32> {
         &config.behavior,
         &config.filtering,
         result.comparisons.iter().map(|c| &c.diff),
+        PairDirection::Ordered,
     );
 
     if let MultiOutput::Json(ref output_target) = output_mode {
@@ -208,8 +213,10 @@ pub fn run_timeline(config: TimelineConfig) -> Result<i32> {
         bail!("Timeline analysis requires at least 2 SBOMs");
     }
 
-    // Validate output mode before doing work so unsupported formats fail fast.
+    // Validate output mode and filter values before doing work so unsupported
+    // formats and unknown filter labels fail fast.
     let output_mode = resolve_multi_output(&config.output)?;
+    validate_post_diff_filters(&config.filtering, &config.graph_diff)?;
 
     let (sboms, _enrich_stats) =
         parse_and_enrich_sboms(&config.sbom_paths, &config.enrichment, quiet)?;
@@ -277,6 +284,7 @@ pub fn run_timeline(config: TimelineConfig) -> Result<i32> {
         &config.behavior,
         &config.filtering,
         result.incremental_diffs.iter(),
+        PairDirection::Ordered,
     );
 
     if let MultiOutput::Json(ref output_target) = output_mode {
@@ -299,8 +307,10 @@ pub fn run_matrix(config: MatrixConfig) -> Result<i32> {
         bail!("Matrix comparison requires at least 2 SBOMs");
     }
 
-    // Validate output mode before doing work so unsupported formats fail fast.
+    // Validate output mode and filter values before doing work so unsupported
+    // formats and unknown filter labels fail fast.
     let output_mode = resolve_multi_output(&config.output)?;
+    validate_post_diff_filters(&config.filtering, &config.graph_diff)?;
 
     let (sboms, _enrich_stats) =
         parse_and_enrich_sboms(&config.sbom_paths, &config.enrichment, quiet)?;
@@ -352,6 +362,7 @@ pub fn run_matrix(config: MatrixConfig) -> Result<i32> {
         &config.behavior,
         &config.filtering,
         result.diffs.iter().flatten(),
+        PairDirection::Unordered,
     );
 
     if let MultiOutput::Json(ref output_target) = output_mode {
@@ -395,6 +406,22 @@ pub(crate) fn parse_multiple_sboms(paths: &[PathBuf]) -> Result<Vec<NormalizedSb
     Ok(sboms)
 }
 
+/// How pairwise diffs should be interpreted when aggregating gate counts.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PairDirection {
+    /// Pairs have a meaningful old→new orientation (diff-multi: baseline vs
+    /// target; timeline: chronological order). Only vulnerabilities
+    /// introduced in that direction count.
+    Ordered,
+    /// Pairs are unordered (matrix: the engine computes only the i<j upper
+    /// triangle, so which side is "old" depends on argv order). A vuln
+    /// present in exactly one side of a pair counts regardless of direction:
+    /// `resolved` in diff(a,b) is `introduced` in diff(b,a), so both are
+    /// counted to make `--fail-on-vuln` symmetric — `matrix a b` and
+    /// `matrix b a` must agree.
+    Unordered,
+}
+
 /// Determine the exit code for a multi-SBOM command from its pairwise diffs.
 ///
 /// Aggregates VEX gaps, introduced vulnerabilities, and total changes across
@@ -406,6 +433,7 @@ fn determine_multi_exit_code<'a, I>(
     behavior: &crate::config::BehaviorConfig,
     filtering: &FilterConfig,
     diffs: I,
+    direction: PairDirection,
 ) -> i32
 where
     I: IntoIterator<Item = &'a DiffResult>,
@@ -418,6 +446,11 @@ where
 
     for diff in diffs {
         total_introduced += diff.summary.vulnerabilities_introduced;
+        if direction == PairDirection::Unordered {
+            // Reverse-direction introductions surface as "resolved" in the
+            // single computed orientation of an unordered pair.
+            total_introduced += diff.summary.vulnerabilities_resolved;
+        }
         total_changes += diff.summary.total_changes;
         if filtering.fail_on_vex_gap {
             let vex = diff.vulnerabilities.vex_summary();
@@ -676,14 +709,69 @@ mod tests {
         };
         let filtering = FilterConfig::default();
         assert_eq!(
-            determine_multi_exit_code(&behavior, &filtering, std::iter::once(&diff)),
+            determine_multi_exit_code(
+                &behavior,
+                &filtering,
+                std::iter::once(&diff),
+                PairDirection::Ordered
+            ),
             exit_codes::CHANGES_DETECTED
         );
 
         // Without the gate flag, the same diff is success.
         let behavior = crate::config::BehaviorConfig::default();
         assert_eq!(
-            determine_multi_exit_code(&behavior, &filtering, std::iter::once(&diff)),
+            determine_multi_exit_code(
+                &behavior,
+                &filtering,
+                std::iter::once(&diff),
+                PairDirection::Ordered
+            ),
+            exit_codes::SUCCESS
+        );
+    }
+
+    /// Matrix pairs are unordered (the engine only computes the i<j upper
+    /// triangle), so `--fail-on-vuln` must fire when a vuln exists in either
+    /// side of a pair but not the other — otherwise `matrix a b` and
+    /// `matrix b a` disagree on the exit code.
+    #[test]
+    fn determine_multi_exit_code_vuln_gate_symmetric_for_unordered_pairs() {
+        let behavior = crate::config::BehaviorConfig {
+            fail_on_vuln: true,
+            ..Default::default()
+        };
+        let filtering = FilterConfig::default();
+
+        // `matrix a vuln.json` computes diff(a, vuln): vulns are "introduced".
+        let mut forward = DiffResult::new();
+        forward.summary.vulnerabilities_introduced = 1;
+        // `matrix vuln.json a` computes diff(vuln, a): same vulns are "resolved".
+        let mut reverse = DiffResult::new();
+        reverse.summary.vulnerabilities_resolved = 1;
+
+        for diff in [&forward, &reverse] {
+            assert_eq!(
+                determine_multi_exit_code(
+                    &behavior,
+                    &filtering,
+                    std::iter::once(diff),
+                    PairDirection::Unordered
+                ),
+                exit_codes::VULNS_INTRODUCED,
+                "matrix vuln gate must be argument-order independent"
+            );
+        }
+
+        // Ordered commands (diff-multi/timeline) keep directional semantics:
+        // a resolved vuln is progress, not a gate failure.
+        assert_eq!(
+            determine_multi_exit_code(
+                &behavior,
+                &filtering,
+                std::iter::once(&reverse),
+                PairDirection::Ordered
+            ),
             exit_codes::SUCCESS
         );
     }

--- a/src/cli/quality.rs
+++ b/src/cli/quality.rs
@@ -828,9 +828,10 @@ mod tests {
     }
 
     #[test]
-    fn auto_discovered_broken_sidecar_soft_fails() {
-        // Without an explicit path, a broken adjacent sidecar must not abort
-        // the command (best-effort discovery logs a warning instead).
+    fn auto_discovered_broken_sidecar_hard_fails() {
+        // A discovered-but-broken sidecar is a hard error, matching the
+        // explicit --cra-sidecar contract: silently scoring without it would
+        // shift the CRA verdict with only a stderr warning.
         let dir = tempfile::tempdir().unwrap();
         let sbom_path = dir.path().join("app.cdx.json");
         std::fs::write(
@@ -839,7 +840,7 @@ mod tests {
         )
         .unwrap();
         std::fs::write(dir.path().join("app.cra.json"), "{ not json").unwrap();
-        let code = run_quality(
+        let err = run_quality(
             sbom_path,
             ScoringProfile::Cra,
             ReportFormat::Json,
@@ -854,8 +855,11 @@ mod tests {
             None,
             EnrichmentConfig::default(),
         )
-        .expect("auto-discovery must soft-fail on a broken sidecar");
-        assert_eq!(code, exit_codes::SUCCESS);
+        .expect_err("a discovered-but-broken sidecar must hard-error");
+        assert!(
+            err.to_string().contains("CRA sidecar"),
+            "error must name the sidecar: {err}"
+        );
     }
 
     fn ai_config(output: ReportFormat, min_score: Option<f32>) -> QualityConfig {

--- a/src/cli/query.rs
+++ b/src/cli/query.rs
@@ -13,6 +13,20 @@ use anyhow::{Result, bail};
 use serde::Serialize;
 use std::collections::HashMap;
 
+/// Output formats `query` has a real renderer for.
+///
+/// `auto` resolves to the table renderer (there is no query TUI); JSON and
+/// CSV are dedicated emitters; `summary` renders the same compact table.
+/// Every other [`ReportFormat`] is rejected up front instead of silently
+/// falling back to the table renderer.
+pub const QUERY_OUTPUT_FORMATS: &[ReportFormat] = &[
+    ReportFormat::Auto,
+    ReportFormat::Table,
+    ReportFormat::Json,
+    ReportFormat::Csv,
+    ReportFormat::Summary,
+];
+
 // ============================================================================
 // Query Filter
 // ============================================================================
@@ -132,20 +146,23 @@ impl QueryFilter {
             None => return false,
         };
 
-        // If the filter starts with an operator, parse as semver range
+        // If the filter starts with an operator, treat it as a semver range —
+        // never fall back to comparing the component version against the range
+        // expression itself (that silently exact-matched non-semver versions).
         let trimmed = version_filter.trim();
-        let has_operator = trimmed.starts_with('<')
-            || trimmed.starts_with('>')
-            || trimmed.starts_with('=')
-            || trimmed.starts_with('~')
-            || trimmed.starts_with('^')
-            || trimmed.contains(',');
-
-        if has_operator
-            && let Ok(req) = semver::VersionReq::parse(trimmed)
-            && let Ok(ver) = semver::Version::parse(comp_version)
-        {
-            return req.matches(&ver);
+        if version_filter_is_range(trimmed) {
+            let Ok(req) = semver::VersionReq::parse(trimmed) else {
+                // Invalid range expressions are rejected up front in
+                // `run_query`; defensively exclude here.
+                return false;
+            };
+            return match semver::Version::parse(comp_version) {
+                Ok(ver) => req.matches(&ver),
+                Err(_) => {
+                    warn_non_semver_once(comp_version);
+                    false
+                }
+            };
         }
 
         // Exact string match (case-insensitive)
@@ -301,6 +318,30 @@ impl QueryFilter {
     }
 }
 
+/// Does a `--version` filter look like a semver range expression (as opposed
+/// to an exact version string)?
+fn version_filter_is_range(trimmed: &str) -> bool {
+    trimmed.starts_with('<')
+        || trimmed.starts_with('>')
+        || trimmed.starts_with('=')
+        || trimmed.starts_with('~')
+        || trimmed.starts_with('^')
+        || trimmed.contains(',')
+}
+
+/// Emit a one-time stderr warning when a component version cannot be parsed
+/// as semver during a range query (such components are excluded from the
+/// match rather than silently string-compared against the range expression).
+fn warn_non_semver_once(version: &str) {
+    static NON_SEMVER_WARNED: std::sync::Once = std::sync::Once::new();
+    NON_SEMVER_WARNED.call_once(|| {
+        eprintln!(
+            "warning: version '{version}' is not semver; excluded from range match \
+             (further non-semver versions suppressed)"
+        );
+    });
+}
+
 // ============================================================================
 // Query Results
 // ============================================================================
@@ -374,6 +415,30 @@ pub fn run_query(config: QueryConfig, filter: QueryFilter) -> Result<i32> {
         );
     }
 
+    // Reject unsupported output formats and an invalid --version range up
+    // front, before any SBOM is parsed.
+    super::ensure_output_format_supported("query", config.output.format, QUERY_OUTPUT_FORMATS)?;
+
+    let target = OutputTarget::from_option(config.output.file.clone());
+    let format = auto_detect_format(config.output.format, &target);
+
+    if config.group_by_sbom && matches!(format, ReportFormat::Json | ReportFormat::Csv) {
+        bail!(
+            "--group-by-sbom is only supported with table output; \
+             JSON output already lists per-SBOM sources in 'found_in' and 'sbom_summaries', \
+             and CSV lists them in the 'Found In' column"
+        );
+    }
+
+    if let Some(ref version_filter) = filter.version {
+        let trimmed = version_filter.trim();
+        if version_filter_is_range(trimmed)
+            && let Err(e) = semver::VersionReq::parse(trimmed)
+        {
+            bail!("invalid semver range '{version_filter}' for --version: {e}");
+        }
+    }
+
     // Stdin can only be consumed once, so at most one input may be "-".
     if config
         .sbom_paths
@@ -394,8 +459,12 @@ pub fn run_query(config: QueryConfig, filter: QueryFilter) -> Result<i32> {
     let mut total_components = 0;
     let mut sbom_summaries = Vec::with_capacity(sboms.len());
 
-    // Deduplicate matches by (name_lower, version)
-    let mut dedup_map: HashMap<(String, String), QueryMatch> = HashMap::new();
+    // Deduplicate matches by (name_lower, version, identity), where identity
+    // is the PURL (or the ecosystem when no PURL is present). Two components
+    // that share a name and version but come from different ecosystems (e.g.
+    // npm and pypi 'requests@2.0.0') are distinct and must not be collapsed
+    // into one row carrying the first one's purl/license.
+    let mut dedup_map: HashMap<(String, String, String), QueryMatch> = HashMap::new();
 
     for (sbom, path) in sboms.iter().zip(config.sbom_paths.iter()) {
         let sbom_name = super::multi::get_sbom_name(path);
@@ -419,6 +488,7 @@ pub fn run_query(config: QueryConfig, filter: QueryFilter) -> Result<i32> {
             let dedup_key = (
                 component.name.to_lowercase(),
                 component.version.clone().unwrap_or_default(),
+                component_identity(component),
             );
 
             let source = SbomSource {
@@ -475,10 +545,6 @@ pub fn run_query(config: QueryConfig, filter: QueryFilter) -> Result<i32> {
         sbom_summaries,
     };
 
-    // Determine output format
-    let target = OutputTarget::from_option(config.output.file.clone());
-    let format = auto_detect_format(config.output.format, &target);
-
     let output = match format {
         ReportFormat::Json => serde_json::to_string_pretty(&result)?,
         ReportFormat::Csv => format_csv_output(&result),
@@ -498,6 +564,24 @@ pub fn run_query(config: QueryConfig, filter: QueryFilter) -> Result<i32> {
     }
 
     Ok(exit_codes::SUCCESS)
+}
+
+/// Identity discriminator for deduplication beyond (name, version): the PURL
+/// when present, otherwise the ecosystem. Components with neither collapse
+/// together (matching the old behavior for purl-less, ecosystem-less entries).
+fn component_identity(component: &Component) -> String {
+    component
+        .identifiers
+        .purl
+        .as_ref()
+        .map(|p| p.to_lowercase())
+        .or_else(|| {
+            component
+                .ecosystem
+                .as_ref()
+                .map(|e| e.to_string().to_lowercase())
+        })
+        .unwrap_or_default()
 }
 
 /// Build a `QueryMatch` from a component and its source.
@@ -582,32 +666,33 @@ fn format_table_output(result: &QueryResult) -> String {
         return out;
     }
 
-    // Calculate column widths
+    // Calculate column widths (in characters, not bytes, so multi-byte
+    // UTF-8 names don't inflate the column or break truncation)
     let name_w = result
         .matches
         .iter()
-        .map(|m| m.name.len())
+        .map(|m| m.name.chars().count())
         .max()
         .unwrap_or(9)
         .clamp(9, 40);
     let ver_w = result
         .matches
         .iter()
-        .map(|m| m.version.len())
+        .map(|m| m.version.chars().count())
         .max()
         .unwrap_or(7)
         .clamp(7, 20);
     let eco_w = result
         .matches
         .iter()
-        .map(|m| m.ecosystem.len())
+        .map(|m| m.ecosystem.chars().count())
         .max()
         .unwrap_or(9)
         .clamp(9, 15);
     let lic_w = result
         .matches
         .iter()
-        .map(|m| m.license.len())
+        .map(|m| m.license.chars().count())
         .max()
         .unwrap_or(7)
         .clamp(7, 20);
@@ -726,14 +811,18 @@ fn csv_escape(s: &str) -> String {
     }
 }
 
-/// Truncate a string to the given width.
+/// Truncate a string to the given display width (in characters).
+///
+/// Operates on `char` boundaries, never byte offsets: slicing at a byte
+/// offset panics when it lands inside a multi-byte UTF-8 character.
 fn truncate(s: &str, max: usize) -> String {
-    if s.len() <= max {
+    if s.chars().count() <= max {
         s.to_string()
     } else if max > 3 {
-        format!("{}...", &s[..max - 3])
+        let kept: String = s.chars().take(max - 3).collect();
+        format!("{kept}...")
     } else {
-        s[..max].to_string()
+        s.chars().take(max).collect()
     }
 }
 
@@ -922,8 +1011,12 @@ mod tests {
 
         let comp = make_component("lodash", "4.17.21", None);
 
-        let mut dedup_map: HashMap<(String, String), QueryMatch> = HashMap::new();
-        let key = ("lodash".to_string(), "4.17.21".to_string());
+        let mut dedup_map: HashMap<(String, String, String), QueryMatch> = HashMap::new();
+        let key = (
+            "lodash".to_string(),
+            "4.17.21".to_string(),
+            component_identity(&comp),
+        );
 
         dedup_map.insert(key.clone(), build_query_match(&comp, source1));
         dedup_map.entry(key).and_modify(|existing| {
@@ -973,6 +1066,76 @@ mod tests {
         assert_eq!(truncate("short", 10), "short");
         assert_eq!(truncate("long string here", 10), "long st...");
         assert_eq!(truncate("ab", 2), "ab");
+    }
+
+    #[test]
+    fn test_truncate_multibyte_no_panic() {
+        // Regression: a byte-offset slice panicked when the cut landed inside
+        // a multi-byte UTF-8 char ('a'*36 + 'é' + 'x'*10 truncated to 40).
+        let name = format!("{}é{}", "a".repeat(36), "x".repeat(10));
+        let out = truncate(&name, 40);
+        assert!(out.ends_with("..."));
+        assert_eq!(out.chars().count(), 40);
+
+        // Cut exactly at the multi-byte char
+        let s = format!("{}é", "a".repeat(36));
+        assert_eq!(truncate(&s, 37), s);
+        assert_eq!(truncate("ééééé", 2), "éé");
+    }
+
+    #[test]
+    fn test_version_range_excludes_non_semver() {
+        let filter = QueryFilter {
+            version: Some("<2.0.0".to_string()),
+            ..Default::default()
+        };
+
+        // Non-semver version is excluded from a range match (with a one-time
+        // stderr warning), not string-compared.
+        let comp = make_component("foo", "1.5", None);
+        let key = ComponentSortKey::from_component(&comp);
+        assert!(!filter.matches(&comp, &key));
+
+        // Proper semver still matches the range.
+        let comp2 = make_component("foo", "1.5.0", None);
+        let key2 = ComponentSortKey::from_component(&comp2);
+        assert!(filter.matches(&comp2, &key2));
+
+        // A version string literally equal to the range expression must NOT
+        // exact-match (the old fallback compared version vs. range text).
+        let comp3 = make_component("foo", "<2.0.0", None);
+        let key3 = ComponentSortKey::from_component(&comp3);
+        assert!(!filter.matches(&comp3, &key3));
+    }
+
+    #[test]
+    fn test_version_filter_is_range() {
+        assert!(version_filter_is_range("<2.0.0"));
+        assert!(version_filter_is_range(">=1.0, <2.0"));
+        assert!(version_filter_is_range("^1.2"));
+        assert!(version_filter_is_range("~1.2"));
+        assert!(version_filter_is_range("=1.2.3"));
+        assert!(!version_filter_is_range("1.2.3"));
+        assert!(!version_filter_is_range("2.0.0-beta.1"));
+    }
+
+    #[test]
+    fn test_component_identity_purl_over_ecosystem() {
+        let npm = make_component("requests", "2.0.0", Some("pkg:npm/requests@2.0.0"));
+        let pypi = make_component("requests", "2.0.0", Some("pkg:pypi/requests@2.0.0"));
+        assert_ne!(component_identity(&npm), component_identity(&pypi));
+
+        // No purl: fall back to ecosystem
+        let mut a = make_component("requests", "2.0.0", None);
+        a.ecosystem = Some(crate::model::Ecosystem::Npm);
+        let mut b = make_component("requests", "2.0.0", None);
+        b.ecosystem = Some(crate::model::Ecosystem::PyPi);
+        assert_ne!(component_identity(&a), component_identity(&b));
+
+        // Neither: identical (collapse, matching old behavior)
+        let c = make_component("requests", "2.0.0", None);
+        let d = make_component("requests", "2.0.0", None);
+        assert_eq!(component_identity(&c), component_identity(&d));
     }
 
     #[test]

--- a/src/cli/tailor.rs
+++ b/src/cli/tailor.rs
@@ -2,23 +2,25 @@
 //!
 //! Filters an SBOM by removing components that don't match criteria.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 
-use crate::parsers::parse_sbom;
-use crate::pipeline::exit_codes;
+use crate::parsers::parse_sbom_str;
+use crate::pipeline::{exit_codes, read_input};
 use crate::serialization::{TailorConfig, tailor_sbom_json};
 
 /// Run the tailor command.
 pub fn run_tailor(
-    file: &PathBuf,
+    file: &Path,
     output_file: Option<&PathBuf>,
     config: TailorConfig,
     quiet: bool,
 ) -> Result<i32> {
-    let raw_json = std::fs::read_to_string(file)?;
-    let sbom = parse_sbom(file)?;
+    // Shared '-'-aware input path (same as view/validate): supports piping an
+    // SBOM via stdin and gives contextful errors instead of a raw ENOENT.
+    let raw_json = read_input(file)?;
+    let sbom = parse_sbom_str(&raw_json)?;
     let tailored = tailor_sbom_json(&raw_json, &sbom, &config)?;
 
     match output_file {

--- a/src/cli/verify.rs
+++ b/src/cli/verify.rs
@@ -99,7 +99,10 @@ pub fn run_verify(action: VerifyAction, quiet: bool) -> Result<i32> {
             if result.verified {
                 Ok(exit_codes::SUCCESS)
             } else {
-                Ok(exit_codes::ERROR)
+                // A failed verification is a VERDICT, not an operational
+                // error — exit 1 so scripts can distinguish "hash mismatch"
+                // from "could not verify" (exit 3).
+                Ok(exit_codes::CHANGES_DETECTED)
             }
         }
         VerifyAction::AuditHashes { file, format } => {
@@ -159,6 +162,12 @@ pub fn run_verify(action: VerifyAction, quiet: bool) -> Result<i32> {
             let sbom = parse_sbom(&file)?;
             let report = verify_model_dir(&sbom, &model_dir);
 
+            // A verification pass over zero models is vacuous — exiting 0
+            // would let CI believe weights were verified when nothing was.
+            if report.total_models == 0 {
+                anyhow::bail!("SBOM contains no model components; nothing to verify");
+            }
+
             if format == "json" {
                 println!("{}", serde_json::to_string_pretty(&report)?);
             } else {
@@ -204,7 +213,8 @@ pub fn run_verify(action: VerifyAction, quiet: bool) -> Result<i32> {
             }
 
             if report.has_failures() {
-                Ok(exit_codes::ERROR) // mismatch/missing weights → fail for CI gating
+                // Verdict, not operational error: exit 1 (see verify hash).
+                Ok(exit_codes::CHANGES_DETECTED)
             } else {
                 Ok(exit_codes::SUCCESS)
             }

--- a/src/cli/vex.rs
+++ b/src/cli/vex.rs
@@ -60,12 +60,28 @@ pub fn run_vex(config: VexConfig, action: VexAction) -> Result<i32> {
         }
     }
 
-    // Apply external VEX documents
+    // Apply external VEX documents. A missing or malformed --vex document is
+    // a hard error (exit 3): silently continuing would let CI believe the VEX
+    // statements were applied when they were not.
     #[cfg(feature = "enrichment")]
     if !config.vex_paths.is_empty() {
-        let stats = crate::pipeline::enrich_vex(parsed.sbom_mut(), &config.vex_paths, quiet);
-        if stats.is_none() && !quiet {
-            eprintln!("Warning: VEX enrichment failed");
+        if !quiet {
+            eprintln!(
+                "Enriching SBOM with VEX data from {} document(s)...",
+                config.vex_paths.len()
+            );
+        }
+        let mut enricher = crate::enrichment::VexEnricher::from_files(&config.vex_paths)
+            .map_err(|e| anyhow::anyhow!("failed to load VEX documents: {e}"))?;
+        let stats = enricher.enrich_sbom(parsed.sbom_mut());
+        if !quiet {
+            eprintln!(
+                "VEX enrichment: {} documents, {} statements, {} vulns matched, {} components",
+                stats.documents_loaded,
+                stats.statements_parsed,
+                stats.vulns_matched,
+                stats.components_with_vex,
+            );
         }
     }
 
@@ -82,13 +98,23 @@ pub fn run_vex(config: VexConfig, action: VexAction) -> Result<i32> {
         sbom.calculate_content_hash();
     }
 
-    // Warn if enrichment requested but feature not enabled
     #[cfg(not(feature = "enrichment"))]
-    if config.enrichment.enabled || config.enrichment.enable_eol || !config.vex_paths.is_empty() {
-        eprintln!(
-            "Warning: enrichment requested but the 'enrichment' feature is not enabled. \
-             Rebuild with: cargo build --features enrichment"
-        );
+    {
+        // --vex must not silently no-op: CI would believe the VEX documents
+        // were applied. Hard error instead.
+        if !config.vex_paths.is_empty() {
+            anyhow::bail!(
+                "--vex requires the 'enrichment' feature, which is not enabled in this build. \
+                 Rebuild with: cargo build --features enrichment"
+            );
+        }
+        // Warn if other enrichment was requested but the feature is not enabled
+        if config.enrichment.enabled || config.enrichment.enable_eol {
+            eprintln!(
+                "Warning: enrichment requested but the 'enrichment' feature is not enabled. \
+                 Rebuild with: cargo build --features enrichment"
+            );
+        }
     }
 
     match action {
@@ -119,17 +145,30 @@ fn run_vex_export(
 }
 
 /// Apply VEX documents and output the enriched SBOM vulnerability data as JSON.
+///
+/// `--state` and `--actionable-only` restrict the emitted vulnerability list
+/// (AND-composed); they do not affect the exit code here — `apply` is a
+/// transformation, gating belongs to `filter`/`status`.
 fn run_vex_apply(sbom: &NormalizedSbom, config: &VexConfig) -> Result<i32> {
     let vulns = collect_all_vulns(sbom);
-    let output = serde_json::to_string_pretty(&vulns)?;
+    let filtered = filter_entries(&vulns, config)?;
+    let output = serde_json::to_string_pretty(&filtered)?;
     let target = OutputTarget::from_option(config.output_file.clone());
     write_output(&output, &target, false)?;
     Ok(exit_codes::SUCCESS)
 }
 
 /// Show VEX coverage summary.
+///
+/// `--state` restricts the report to vulnerabilities in that state ("none" =
+/// vulnerabilities without a VEX statement). `--actionable-only` keeps its
+/// documented gate semantics: exit code 1 when actionable vulnerabilities
+/// exist (in the possibly state-filtered set).
 fn run_vex_status(sbom: &NormalizedSbom, config: &VexConfig) -> Result<i32> {
-    let vulns = collect_all_vulns(sbom);
+    let mut vulns = collect_all_vulns(sbom);
+    if let Some(target_state) = parsed_state_filter(config)? {
+        vulns.retain(|v| v.vex_state.as_ref() == target_state.as_ref());
+    }
     let total = vulns.len();
     let with_vex = vulns.iter().filter(|v| v.vex_state.is_some()).count();
     let without_vex = total - with_vex;
@@ -184,37 +223,43 @@ fn run_vex_status(sbom: &NormalizedSbom, config: &VexConfig) -> Result<i32> {
         let output = serde_json::to_string_pretty(&summary)?;
         write_output(&output, &output_target, false)?;
     } else {
-        // Table output for terminal
-        println!("VEX Coverage Summary");
-        println!("====================");
-        println!();
-        println!("Total vulnerabilities:  {total}");
-        println!("With VEX statement:     {with_vex}");
-        println!("Without VEX statement:  {without_vex}");
-        println!("Actionable:             {actionable}");
-        println!("Coverage:               {coverage_pct:.1}%");
-        println!();
+        // Table output — rendered into a buffer so `-O <file>` writes the
+        // table to the file instead of losing it to stdout.
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        writeln!(out, "VEX Coverage Summary")?;
+        writeln!(out, "====================")?;
+        writeln!(out)?;
+        writeln!(out, "Total vulnerabilities:  {total}")?;
+        writeln!(out, "With VEX statement:     {with_vex}")?;
+        writeln!(out, "Without VEX statement:  {without_vex}")?;
+        writeln!(out, "Actionable:             {actionable}")?;
+        writeln!(out, "Coverage:               {coverage_pct:.1}%")?;
+        writeln!(out)?;
 
         if !by_state.is_empty() {
-            println!("By VEX State:");
+            writeln!(out, "By VEX State:")?;
             for (state, count) in &by_state {
-                println!("  {state:<20} {count}");
+                writeln!(out, "  {state:<20} {count}")?;
             }
-            println!();
+            writeln!(out)?;
         }
 
         if without_vex > 0 {
-            println!("Gaps (vulnerabilities without VEX):");
+            writeln!(out, "Gaps (vulnerabilities without VEX):")?;
             for v in vulns.iter().filter(|v| v.vex_state.is_none()) {
-                println!(
+                writeln!(
+                    out,
                     "  {} [{}] — {} {}",
                     v.id,
                     v.severity,
                     v.component_name,
                     v.version.as_deref().unwrap_or("")
-                );
+                )?;
             }
         }
+
+        write_output(out.trim_end(), &output_target, config.quiet)?;
     }
 
     // Exit code 1 if actionable-only mode and actionable vulns exist
@@ -226,28 +271,12 @@ fn run_vex_status(sbom: &NormalizedSbom, config: &VexConfig) -> Result<i32> {
 }
 
 /// Filter vulnerabilities by VEX state.
+///
+/// `--actionable-only` and `--state` compose (AND): a vulnerability must
+/// satisfy both filters to be kept.
 fn run_vex_filter(sbom: &NormalizedSbom, config: &VexConfig) -> Result<i32> {
     let vulns = collect_all_vulns(sbom);
-
-    let filtered: Vec<&VulnEntry> = if config.actionable_only {
-        vulns
-            .iter()
-            .filter(|v| {
-                !matches!(
-                    v.vex_state,
-                    Some(VexState::NotAffected) | Some(VexState::Fixed)
-                )
-            })
-            .collect()
-    } else if let Some(ref state_filter) = config.filter_state {
-        let target_state = parse_vex_state_filter(state_filter)?;
-        vulns
-            .iter()
-            .filter(|v| v.vex_state.as_ref() == target_state.as_ref())
-            .collect()
-    } else {
-        vulns.iter().collect()
-    };
+    let filtered = filter_entries(&vulns, config)?;
 
     let output = serde_json::to_string_pretty(&filtered)?;
     let target = OutputTarget::from_option(config.output_file.clone());
@@ -283,6 +312,40 @@ struct VulnEntry {
     vex_state: Option<VexState>,
     vex_justification: Option<String>,
     vex_impact: Option<String>,
+}
+
+/// True when the vulnerability is actionable (not suppressed by a
+/// `NotAffected`/`Fixed` VEX statement). Consistent with
+/// `VulnerabilityDetail::is_vex_actionable`.
+fn is_actionable(v: &VulnEntry) -> bool {
+    !matches!(
+        v.vex_state,
+        Some(VexState::NotAffected) | Some(VexState::Fixed)
+    )
+}
+
+/// Parse the optional `--state` flag. Outer `None` = flag absent; inner
+/// `None` = "none"/"missing" (vulnerabilities without any VEX statement).
+fn parsed_state_filter(config: &VexConfig) -> Result<Option<Option<VexState>>> {
+    config
+        .filter_state
+        .as_deref()
+        .map(parse_vex_state_filter)
+        .transpose()
+}
+
+/// Apply the shared `--state` / `--actionable-only` filters (AND-composed).
+fn filter_entries<'a>(vulns: &'a [VulnEntry], config: &VexConfig) -> Result<Vec<&'a VulnEntry>> {
+    let state = parsed_state_filter(config)?;
+    Ok(vulns
+        .iter()
+        .filter(|v| {
+            (!config.actionable_only || is_actionable(v))
+                && state
+                    .as_ref()
+                    .is_none_or(|target| v.vex_state.as_ref() == target.as_ref())
+        })
+        .collect())
 }
 
 /// Collect all vulnerabilities from an SBOM into a flat list.
@@ -358,5 +421,90 @@ mod tests {
     fn test_parse_vex_state_filter_rejects_unknown() {
         assert!(parse_vex_state_filter("fixd").is_err());
         assert!(parse_vex_state_filter("notaffected_typo").is_err());
+    }
+
+    fn entry(id: &str, state: Option<VexState>) -> VulnEntry {
+        VulnEntry {
+            id: id.to_string(),
+            severity: "High".to_string(),
+            component_name: "comp".to_string(),
+            version: Some("1.0".to_string()),
+            vex_state: state,
+            vex_justification: None,
+            vex_impact: None,
+        }
+    }
+
+    fn config_with(actionable_only: bool, state: Option<&str>) -> VexConfig {
+        VexConfig {
+            sbom_path: std::path::PathBuf::from("sbom.json"),
+            vex_paths: Vec::new(),
+            output_format: crate::reports::ReportFormat::Auto,
+            output_file: None,
+            quiet: true,
+            actionable_only,
+            filter_state: state.map(str::to_string),
+            enrichment: crate::config::EnrichmentConfig::default(),
+        }
+    }
+
+    fn sample_vulns() -> Vec<VulnEntry> {
+        vec![
+            entry("CVE-1", None),
+            entry("CVE-2", Some(VexState::NotAffected)),
+            entry("CVE-3", Some(VexState::Affected)),
+            entry("CVE-4", Some(VexState::Fixed)),
+            entry("CVE-5", Some(VexState::UnderInvestigation)),
+        ]
+    }
+
+    #[test]
+    fn filter_entries_no_flags_keeps_all() {
+        let vulns = sample_vulns();
+        let filtered = filter_entries(&vulns, &config_with(false, None)).unwrap();
+        assert_eq!(filtered.len(), 5);
+    }
+
+    #[test]
+    fn filter_entries_actionable_only_excludes_not_affected_and_fixed() {
+        let vulns = sample_vulns();
+        let filtered = filter_entries(&vulns, &config_with(true, None)).unwrap();
+        let ids: Vec<&str> = filtered.iter().map(|v| v.id.as_str()).collect();
+        assert_eq!(ids, vec!["CVE-1", "CVE-3", "CVE-5"]);
+    }
+
+    #[test]
+    fn filter_entries_state_filter_matches_state() {
+        let vulns = sample_vulns();
+        let filtered = filter_entries(&vulns, &config_with(false, Some("affected"))).unwrap();
+        let ids: Vec<&str> = filtered.iter().map(|v| v.id.as_str()).collect();
+        assert_eq!(ids, vec!["CVE-3"]);
+    }
+
+    #[test]
+    fn filter_entries_state_none_matches_missing_vex() {
+        let vulns = sample_vulns();
+        let filtered = filter_entries(&vulns, &config_with(false, Some("none"))).unwrap();
+        let ids: Vec<&str> = filtered.iter().map(|v| v.id.as_str()).collect();
+        assert_eq!(ids, vec!["CVE-1"]);
+    }
+
+    #[test]
+    fn filter_entries_actionable_and_state_compose_with_and() {
+        let vulns = sample_vulns();
+        // fixed is excluded by --actionable-only even though --state matches it
+        let filtered = filter_entries(&vulns, &config_with(true, Some("fixed"))).unwrap();
+        assert!(filtered.is_empty());
+
+        // affected satisfies both filters
+        let filtered = filter_entries(&vulns, &config_with(true, Some("affected"))).unwrap();
+        let ids: Vec<&str> = filtered.iter().map(|v| v.id.as_str()).collect();
+        assert_eq!(ids, vec!["CVE-3"]);
+    }
+
+    #[test]
+    fn filter_entries_rejects_invalid_state() {
+        let vulns = sample_vulns();
+        assert!(filter_entries(&vulns, &config_with(false, Some("bogus"))).is_err());
     }
 }

--- a/src/cli/view.rs
+++ b/src/cli/view.rs
@@ -24,6 +24,12 @@ pub fn run_view(config: ViewConfig) -> Result<i32> {
         );
     }
 
+    // Validate --severity before any parsing or (network) enrichment work so
+    // a typo fails fast instead of after expensive I/O.
+    if let Some(s) = config.min_severity.as_deref() {
+        parse_severity(s)?;
+    }
+
     // Resolve the CRA sidecar once for both the TUI and report paths: an
     // explicit --cra-sidecar that fails to load is a hard error; auto-
     // discovery next to the SBOM stays best-effort.
@@ -189,8 +195,19 @@ pub fn run_view(config: ViewConfig) -> Result<i32> {
         );
     }
 
+    // Count vulnerabilities BEFORE display filters are applied: the
+    // --fail-on-vuln gate is documented as "if any vulnerabilities are
+    // present in the SBOM", so display filters (--severity / --ecosystem /
+    // --vulnerable-only) must not mask the exit code.
+    let vuln_count: usize = parsed
+        .sbom()
+        .components
+        .values()
+        .map(|c| c.vulnerabilities.len())
+        .sum();
+
     // Apply filters to SBOM
-    let filtered_count = apply_view_filters(parsed.sbom_mut(), &config);
+    let filtered_count = apply_view_filters(parsed.sbom_mut(), &config)?;
     if filtered_count > 0 {
         tracing::info!(
             "Filtered to {} components (removed {})",
@@ -207,14 +224,6 @@ pub fn run_view(config: ViewConfig) -> Result<i32> {
     // Output the result
     let output_target = OutputTarget::from_option(config.output.file.clone());
     let effective_output = auto_detect_format(config.output.format, &output_target);
-
-    // Check for vulnerabilities before rendering (for --fail-on-vuln exit code)
-    let vuln_count: usize = parsed
-        .sbom()
-        .components
-        .values()
-        .map(|c| c.vulnerabilities.len())
-        .sum();
 
     // Resolve BOM profile (CLI override or auto-detect)
     let bom_profile = config
@@ -263,12 +272,19 @@ pub fn run_view(config: ViewConfig) -> Result<i32> {
     Ok(crate::pipeline::exit_codes::SUCCESS)
 }
 
-/// Apply view filters to the SBOM, returns number of components removed
-pub fn apply_view_filters(sbom: &mut NormalizedSbom, config: &ViewConfig) -> usize {
+/// Apply view filters to the SBOM, returns number of components removed.
+///
+/// Errors if `--severity` carries an unrecognized value (which previously
+/// disabled severity filtering silently).
+pub fn apply_view_filters(sbom: &mut NormalizedSbom, config: &ViewConfig) -> Result<usize> {
     let original_count = sbom.component_count();
 
-    // Parse minimum severity if provided
-    let min_severity = config.min_severity.as_ref().map(|s| parse_severity(s));
+    // Parse minimum severity if provided (strict: unknown values hard-error)
+    let min_severity = config
+        .min_severity
+        .as_deref()
+        .map(parse_severity)
+        .transpose()?;
 
     // Parse ecosystem filter if provided
     let ecosystem_filter = config.ecosystem_filter.as_ref().map(|e| e.to_lowercase());
@@ -320,17 +336,22 @@ pub fn apply_view_filters(sbom: &mut NormalizedSbom, config: &ViewConfig) -> usi
         sbom.components.shift_remove(key);
     }
 
-    original_count - sbom.component_count()
+    Ok(original_count - sbom.component_count())
 }
 
-/// Parse severity string into Severity enum
-fn parse_severity(s: &str) -> Severity {
+/// Parse a `--severity` filter value strictly.
+///
+/// An unrecognized value used to map to [`Severity::Unknown`] (threshold
+/// order 0), which silently disabled the filter entirely — `--severity
+/// banana` behaved like no filter at all. It is now a hard error listing the
+/// valid values.
+fn parse_severity(s: &str) -> Result<Severity> {
     match s.to_lowercase().as_str() {
-        "critical" => Severity::Critical,
-        "high" => Severity::High,
-        "medium" => Severity::Medium,
-        "low" => Severity::Low,
-        _ => Severity::Unknown,
+        "critical" => Ok(Severity::Critical),
+        "high" => Ok(Severity::High),
+        "medium" => Ok(Severity::Medium),
+        "low" => Ok(Severity::Low),
+        _ => anyhow::bail!("invalid --severity '{s}'; valid values: critical, high, medium, low"),
     }
 }
 
@@ -393,12 +414,25 @@ mod tests {
 
     #[test]
     fn test_parse_severity() {
-        assert!(matches!(parse_severity("critical"), Severity::Critical));
-        assert!(matches!(parse_severity("HIGH"), Severity::High));
-        assert!(matches!(parse_severity("Medium"), Severity::Medium));
-        assert!(matches!(parse_severity("low"), Severity::Low));
-        assert!(matches!(parse_severity("unknown"), Severity::Unknown));
-        assert!(matches!(parse_severity("invalid"), Severity::Unknown));
+        assert!(matches!(parse_severity("critical"), Ok(Severity::Critical)));
+        assert!(matches!(parse_severity("HIGH"), Ok(Severity::High)));
+        assert!(matches!(parse_severity("Medium"), Ok(Severity::Medium)));
+        assert!(matches!(parse_severity("low"), Ok(Severity::Low)));
+    }
+
+    #[test]
+    fn test_parse_severity_rejects_unknown() {
+        // Regression: unknown values mapped to Severity::Unknown (order 0),
+        // which passed every vulnerability and silently disabled the filter.
+        for bad in ["banana", "unknown", "info", "none", ""] {
+            let err = parse_severity(bad).expect_err("should reject");
+            let msg = err.to_string();
+            assert!(msg.contains("invalid --severity"), "message: {msg}");
+            assert!(
+                msg.contains("critical, high, medium, low"),
+                "message should list valid values: {msg}"
+            );
+        }
     }
 
     #[test]
@@ -423,10 +457,8 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn test_apply_view_filters_no_filters() {
-        let mut sbom = NormalizedSbom::default();
-        let config = ViewConfig {
+    fn test_view_config(min_severity: Option<&str>) -> ViewConfig {
+        ViewConfig {
             sbom_path: std::path::PathBuf::from("test.json"),
             output: crate::config::OutputConfig {
                 format: ReportFormat::Summary,
@@ -437,7 +469,7 @@ mod tests {
                 export_template: None,
             },
             validate_ntia: false,
-            min_severity: None,
+            min_severity: min_severity.map(str::to_string),
             vulnerable_only: false,
             ecosystem_filter: None,
             fail_on_vuln: false,
@@ -445,9 +477,24 @@ mod tests {
             enrichment: crate::config::EnrichmentConfig::default(),
             cra_sidecar_path: None,
             cra_product_class: None,
-        };
+        }
+    }
 
-        let removed = apply_view_filters(&mut sbom, &config);
+    #[test]
+    fn test_apply_view_filters_no_filters() {
+        let mut sbom = NormalizedSbom::default();
+        let config = test_view_config(None);
+
+        let removed = apply_view_filters(&mut sbom, &config).expect("no filters should succeed");
         assert_eq!(removed, 0);
+    }
+
+    #[test]
+    fn test_apply_view_filters_invalid_severity_errors() {
+        let mut sbom = NormalizedSbom::default();
+        let config = test_view_config(Some("banana"));
+
+        let err = apply_view_filters(&mut sbom, &config).expect_err("should reject");
+        assert!(err.to_string().contains("invalid --severity"));
     }
 }

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -1,10 +1,17 @@
 //! CLI handler for the `watch` subcommand.
 
 use crate::config::WatchConfig;
+use crate::pipeline::exit_codes;
 use crate::watch::WatchError;
 use anyhow::Result;
 
 /// Run the watch command with the given configuration.
+///
+/// Exits the process with [`exit_codes::CHANGES_DETECTED`] (1) when the loop
+/// stops because `--exit-on-change` observed a change; returns `Ok(())` (exit
+/// 0) on a clean shutdown. Operational errors propagate as `Err` for `main()`
+/// to map to exit 3. The gate exit mirrors how `main()` handles the other
+/// verdict gates (`process::exit` on a non-zero code from the handler).
 pub fn run_watch(config: WatchConfig) -> Result<()> {
     // Validate that all watch directories exist
     for dir in &config.watch_dirs {
@@ -13,5 +20,9 @@ pub fn run_watch(config: WatchConfig) -> Result<()> {
         }
     }
 
-    crate::watch::run_watch_loop(&config)
+    let exit_code = crate::watch::run_watch_loop(&config)?;
+    if exit_code != exit_codes::SUCCESS {
+        std::process::exit(exit_code);
+    }
+    Ok(())
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -26,12 +26,15 @@ const CONFIG_FILE_NAMES: &[&str] = &[
 /// 3. Git repository root (if in a repo)
 /// 4. User config directory (~/.config/sbom-tools/)
 /// 5. Home directory
+///
+/// An explicit path is **authoritative**: it is returned as-is even when the
+/// file does not exist, so callers surface "config file not found" instead of
+/// silently falling back to a *different* discovered file (or defaults).
+/// Existence/parse failures are reported by [`load_config_file`].
 #[must_use]
 pub fn discover_config_file(explicit_path: Option<&Path>) -> Option<PathBuf> {
-    // 1. Use explicit path if provided
-    if let Some(path) = explicit_path
-        && path.exists()
-    {
+    // 1. Use explicit path if provided — never fall through to discovery.
+    if let Some(path) = explicit_path {
         return Some(path.to_path_buf());
     }
 
@@ -154,6 +157,12 @@ pub fn load_config_file(path: &Path) -> Result<AppConfig, ConfigFileError> {
 }
 
 /// Load config from discovered file, or return default.
+///
+/// Lenient: a file that fails to load is warned about and replaced with
+/// defaults. Note that an explicit path no longer falls through to discovery
+/// (see [`discover_config_file`]) — a missing/broken `--config` yields
+/// defaults with a warning here, and a hard error via [`load_strict`].
+/// Prefer [`load_strict`] anywhere the user passed `--config` explicitly.
 #[must_use]
 pub fn load_or_default(explicit_path: Option<&Path>) -> (AppConfig, Option<PathBuf>) {
     discover_config_file(explicit_path).map_or_else(
@@ -166,6 +175,25 @@ pub fn load_or_default(explicit_path: Option<&Path>) -> (AppConfig, Option<PathB
             }
         },
     )
+}
+
+/// Load config strictly: once a file is selected (explicitly via `--config`
+/// or through discovery), any failure to load it is a hard error.
+///
+/// Semantics (shared by *every* command, including `config show`/`path`):
+/// - explicit path missing      → `Err(NotFound)`, never discovery/defaults
+/// - selected file fails to parse → `Err(Parse)`, never "showing defaults"
+/// - no file anywhere            → built-in defaults (`loaded_from = None`)
+pub fn load_strict(
+    explicit_path: Option<&Path>,
+) -> Result<(AppConfig, Option<PathBuf>), ConfigFileError> {
+    match discover_config_file(explicit_path) {
+        None => Ok((AppConfig::default(), None)),
+        Some(path) => {
+            let config = load_config_file(&path)?;
+            Ok((config, Some(path)))
+        }
+    }
 }
 
 // ============================================================================
@@ -605,6 +633,79 @@ behavior:
         let example = generate_example_config();
         assert!(example.contains("matching:"));
         assert!(example.contains("fuzzy_preset"));
+    }
+
+    #[test]
+    fn unknown_top_level_section_is_a_parse_error_naming_the_key() {
+        // Regression: a typo'd section (`matchingg:`) used to be silently
+        // dropped while `config check` printed "# Valid".
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("typo.yaml");
+        std::fs::write(&path, "matchingg:\n  fuzzy_preset: strict\n").unwrap();
+
+        let err = load_config_file(&path).expect_err("typo'd section must fail to load");
+        assert!(
+            err.to_string().contains("matchingg"),
+            "error must name the unknown key: {err}"
+        );
+    }
+
+    #[test]
+    fn unknown_nested_key_is_a_parse_error_naming_the_key() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("typo-nested.yaml");
+        std::fs::write(&path, "behavior:\n  fail_on_vulns: true\n").unwrap();
+
+        let err = load_config_file(&path).expect_err("typo'd nested key must fail to load");
+        assert!(
+            err.to_string().contains("fail_on_vulns"),
+            "error must name the unknown key: {err}"
+        );
+
+        // Enrichment section too (it is Option-wrapped, not `default`-only).
+        let path2 = tmp.path().join("typo-enrichment.yaml");
+        std::fs::write(&path2, "enrichment:\n  cache_ttl: 3600\n").unwrap();
+        let err2 = load_config_file(&path2).expect_err("unknown enrichment key must fail");
+        assert!(err2.to_string().contains("cache_ttl"), "{err2}");
+    }
+
+    #[test]
+    fn discover_explicit_missing_path_is_authoritative() {
+        // A missing --config path must NOT silently fall back to discovery;
+        // it is returned as-is so loading reports NotFound.
+        let missing = Path::new("/nonexistent/sbom-tools-test.yaml");
+        assert_eq!(
+            discover_config_file(Some(missing)),
+            Some(missing.to_path_buf())
+        );
+    }
+
+    #[test]
+    fn load_strict_errors_on_missing_explicit_path() {
+        let result = load_strict(Some(Path::new("/nonexistent/sbom-tools-test.yaml")));
+        assert!(matches!(result, Err(ConfigFileError::NotFound(_))));
+    }
+
+    #[test]
+    fn load_strict_errors_on_broken_selected_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("broken.yaml");
+        std::fs::write(&path, "matching: [not, a, mapping\n").unwrap();
+        let result = load_strict(Some(&path));
+        assert!(matches!(result, Err(ConfigFileError::Parse(_))));
+    }
+
+    #[test]
+    fn load_strict_loads_valid_explicit_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("ok.yaml");
+        std::fs::write(&path, "matching:\n  fuzzy_preset: strict\n").unwrap();
+        let (config, loaded_from) = load_strict(Some(&path)).unwrap();
+        assert_eq!(
+            config.matching.fuzzy_preset,
+            crate::config::FuzzyPreset::Strict
+        );
+        assert_eq!(loaded_from.as_deref(), Some(path.as_path()));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -67,7 +67,7 @@ pub use validation::{ConfigError, Validatable};
 // Re-export file utilities
 pub use file::{
     ConfigFileError, discover_config_file, generate_example_config, generate_full_example_config,
-    load_config_file, load_or_default,
+    load_config_file, load_or_default, load_strict,
 };
 
 /// Generate a JSON Schema for the `AppConfig` configuration format.

--- a/src/config/types.rs
+++ b/src/config/types.rs
@@ -17,8 +17,16 @@ use std::path::PathBuf;
 /// This is the top-level configuration struct that aggregates all configuration
 /// options. It can be constructed from CLI arguments, config files, or both
 /// (with CLI overriding file settings).
+///
+/// `deny_unknown_fields` (here and on every nested section) makes a typo'd
+/// key or section a hard load error naming the offending field, instead of
+/// silently dropping the user's settings while `config check` reports the
+/// file as valid. This intentionally makes stale configs fail loudly
+/// (matches the CRA-sidecar precedent). Because the JSON Schema is generated
+/// from these types via `schemars`, `additionalProperties: false` follows
+/// automatically.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct AppConfig {
     /// Matching configuration (thresholds, presets)
     pub matching: MatchingConfig,
@@ -333,7 +341,7 @@ impl TuiPreferences {
 
 /// TUI-specific configuration.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct TuiConfig {
     /// Theme name
     pub theme: ThemeName,
@@ -539,7 +547,7 @@ pub struct VexConfig {
 
 /// Output-related configuration
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct OutputConfig {
     /// Output format
     pub format: ReportFormat,
@@ -579,7 +587,7 @@ impl Default for OutputConfig {
 /// to avoid loading entire SBOMs into memory. This is essential for SBOMs
 /// with thousands of components.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct StreamingConfig {
     /// Enable streaming mode automatically for files larger than this threshold (in bytes).
     /// Default: 10 MB (`10_485_760` bytes)
@@ -650,7 +658,7 @@ impl StreamingConfig {
 
 /// Matching and comparison configuration
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct MatchingConfig {
     /// Fuzzy matching preset
     pub fuzzy_preset: FuzzyPreset,
@@ -693,7 +701,7 @@ impl MatchingConfig {
 
 /// Filtering options for diff results
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct FilterConfig {
     /// Only show items with changes
     pub only_changes: bool,
@@ -711,7 +719,7 @@ pub struct FilterConfig {
 
 /// Behavior flags for diff operations
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct BehaviorConfig {
     /// Exit with code 2 if new vulnerabilities are introduced
     pub fail_on_vuln: bool,
@@ -730,7 +738,7 @@ pub struct BehaviorConfig {
 
 /// Graph-aware diffing configuration
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct GraphAwareDiffConfig {
     /// Enable graph-aware diffing
     pub enabled: bool,
@@ -763,7 +771,7 @@ impl GraphAwareDiffConfig {
 
 /// Custom matching rules configuration
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct MatchingRulesPathConfig {
     /// Path to matching rules YAML file
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -774,7 +782,7 @@ pub struct MatchingRulesPathConfig {
 
 /// Ecosystem-specific rules configuration
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct EcosystemRulesConfig {
     /// Path to ecosystem rules configuration file
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -797,7 +805,7 @@ pub struct EcosystemRulesConfig {
 /// so every CLI spelling works in the file too; invalid values are rejected
 /// at config-validation time with the list of valid options.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct ComplianceConfig {
     /// Default standard(s) for `validate --standard`
     /// (e.g. `[ntia, cra, cra-phase1]`; aliases accepted)
@@ -830,7 +838,7 @@ pub struct ComplianceConfig {
 /// This configuration is always defined regardless of the `enrichment` feature flag.
 /// When the feature is disabled, the configuration is silently ignored at runtime.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct EnrichmentConfig {
     /// Enable enrichment (if false, no enrichment is performed)
     pub enabled: bool,

--- a/src/config/validation.rs
+++ b/src/config/validation.rs
@@ -231,6 +231,23 @@ impl Validatable for EnrichmentConfig {
             });
         }
 
+        // Keep the validator in lockstep with the published JSON Schema
+        // (`schemars(range(min = 1))`): a TTL or timeout of 0 must fail
+        // `config check`, not silently disable caching / hang requests.
+        if self.cache_ttl_hours == 0 {
+            errors.push(ConfigError {
+                field: "enrichment.cache_ttl_hours".to_string(),
+                message: "Cache TTL must be at least 1 hour".to_string(),
+            });
+        }
+
+        if self.timeout_secs == 0 {
+            errors.push(ConfigError {
+                field: "enrichment.timeout_secs".to_string(),
+                message: "API timeout must be at least 1 second".to_string(),
+            });
+        }
+
         // Every URL override must be a well-formed http(s) URL with a host.
         // These point the enricher at a network endpoint that supplies
         // SECURITY data (which CVEs affect you); an unvalidated override could
@@ -553,6 +570,35 @@ mod tests {
             ..EnrichmentConfig::default()
         };
         assert!(!invalid.is_valid());
+    }
+
+    #[test]
+    fn enrichment_config_rejects_zero_ttl_and_timeout() {
+        // The JSON Schema declares minimum 1 for both; the runtime validator
+        // must agree so `config check` and the schema can't disagree.
+        let zero_ttl = EnrichmentConfig {
+            cache_ttl_hours: 0,
+            ..EnrichmentConfig::default()
+        };
+        assert!(
+            zero_ttl
+                .validate()
+                .iter()
+                .any(|e| e.field == "enrichment.cache_ttl_hours"),
+            "cache_ttl_hours: 0 must be a config error"
+        );
+
+        let zero_timeout = EnrichmentConfig {
+            timeout_secs: 0,
+            ..EnrichmentConfig::default()
+        };
+        assert!(
+            zero_timeout
+                .validate()
+                .iter()
+                .any(|e| e.field == "enrichment.timeout_secs"),
+            "timeout_secs: 0 must be a config error"
+        );
     }
 
     #[test]

--- a/src/license/policy.rs
+++ b/src/license/policy.rs
@@ -18,7 +18,13 @@ use crate::model::{LicenseExpression, LicenseFamily, NormalizedSbom};
 use serde::{Deserialize, Serialize};
 
 /// License policy configuration
+///
+/// `deny_unknown_fields` makes a typo'd key (e.g. `"denied"` instead of
+/// `"deny"`) a hard parse error naming the unknown field, instead of being
+/// silently ignored and yielding an allow-everything policy. Same precedent
+/// as the CRA sidecar.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct LicensePolicyConfig {
     /// Allowed license SPDX IDs (glob patterns supported: `BSD-*`)
     #[serde(default)]
@@ -207,10 +213,17 @@ fn evaluate_expression(expr: &LicenseExpression, config: &LicensePolicyConfig) -
 }
 
 /// Evaluate all component licenses against a policy.
+///
+/// When `strict` is true, licenses that would merely need review (copyleft
+/// families on the review list, or licenses missing from a non-empty allow
+/// list) are treated as denied, so they gate CI the same way as an explicit
+/// deny. When `strict` is false, review findings are reported but never fail
+/// the policy.
 #[must_use]
 pub fn evaluate_license_policy(
     sbom: &NormalizedSbom,
     config: &LicensePolicyConfig,
+    strict: bool,
 ) -> LicensePolicyResult {
     let mut allowed_count = 0;
     let mut denied_count = 0;
@@ -248,12 +261,20 @@ pub fn evaluate_license_policy(
                     });
                 }
                 PolicyDecision::NeedsReview => {
-                    component_review = true;
+                    // In strict mode, review-needed licenses are policy
+                    // failures — otherwise --strict can never gate.
+                    let decision = if strict {
+                        component_denied = true;
+                        PolicyDecision::Denied
+                    } else {
+                        component_review = true;
+                        PolicyDecision::NeedsReview
+                    };
                     violations.push(LicensePolicyViolation {
                         component: comp.name.clone(),
                         version: comp.version.clone(),
                         license: license.expression.clone(),
-                        decision: PolicyDecision::NeedsReview,
+                        decision,
                         family: license.family(),
                     });
                 }
@@ -337,7 +358,7 @@ mod tests {
     fn permissive_policy_allows_all() {
         let sbom = make_sbom_with_licenses(&["MIT", "Apache-2.0", "GPL-3.0-only"]);
         let config = LicensePolicyConfig::permissive();
-        let result = evaluate_license_policy(&sbom, &config);
+        let result = evaluate_license_policy(&sbom, &config, false);
         assert!(result.passed);
         assert_eq!(result.denied_count, 0);
     }
@@ -346,7 +367,7 @@ mod tests {
     fn strict_policy_denies_agpl() {
         let sbom = make_sbom_with_licenses(&["MIT", "AGPL-3.0-only"]);
         let config = LicensePolicyConfig::strict_permissive();
-        let result = evaluate_license_policy(&sbom, &config);
+        let result = evaluate_license_policy(&sbom, &config, false);
         assert!(!result.passed);
         assert_eq!(result.denied_count, 1);
     }
@@ -355,16 +376,66 @@ mod tests {
     fn strict_policy_flags_gpl_for_review() {
         let sbom = make_sbom_with_licenses(&["MIT", "GPL-3.0-only"]);
         let config = LicensePolicyConfig::strict_permissive();
-        let result = evaluate_license_policy(&sbom, &config);
+        let result = evaluate_license_policy(&sbom, &config, false);
         assert!(result.passed); // review doesn't fail
         assert_eq!(result.review_count, 1);
+    }
+
+    #[test]
+    fn strict_mode_denies_review_licenses() {
+        let sbom = make_sbom_with_licenses(&["MIT", "GPL-3.0-only"]);
+        let config = LicensePolicyConfig::strict_permissive();
+        let result = evaluate_license_policy(&sbom, &config, true);
+        assert!(!result.passed);
+        assert_eq!(result.denied_count, 1);
+        assert_eq!(result.review_count, 0);
+        assert!(
+            result
+                .violations
+                .iter()
+                .any(|v| v.license == "GPL-3.0-only" && v.decision == PolicyDecision::Denied)
+        );
+    }
+
+    #[test]
+    fn strict_mode_denies_off_allow_list_licenses() {
+        let sbom = make_sbom_with_licenses(&["Artistic-2.0"]);
+        let config = LicensePolicyConfig {
+            allow: vec!["MIT".to_string()],
+            ..Default::default()
+        };
+        let result = evaluate_license_policy(&sbom, &config, true);
+        assert!(!result.passed);
+        assert_eq!(result.denied_count, 1);
+    }
+
+    #[test]
+    fn policy_config_rejects_unknown_fields() {
+        let err = serde_json::from_str::<LicensePolicyConfig>(r#"{"denied": ["GPL-*"]}"#)
+            .expect_err("typo'd key must be a hard parse error");
+        let msg = err.to_string();
+        assert!(msg.contains("denied"), "error should name the field: {msg}");
+        assert!(
+            msg.contains("deny"),
+            "error should list valid fields: {msg}"
+        );
+    }
+
+    #[test]
+    fn policy_config_accepts_known_fields() {
+        let config: LicensePolicyConfig = serde_json::from_str(
+            r#"{"allow": ["MIT"], "deny": ["AGPL-*"], "review": ["GPL-*"], "fail_on_conflict": false}"#,
+        )
+        .expect("all documented keys must parse");
+        assert_eq!(config.allow, vec!["MIT"]);
+        assert!(!config.fail_on_conflict);
     }
 
     #[test]
     fn undeclared_licenses_flagged() {
         let sbom = make_sbom_with_licenses(&["MIT", ""]);
         let config = LicensePolicyConfig::strict_permissive();
-        let result = evaluate_license_policy(&sbom, &config);
+        let result = evaluate_license_policy(&sbom, &config, false);
         assert_eq!(result.undeclared_count, 1);
     }
 
@@ -385,7 +456,7 @@ mod tests {
             fail_on_conflict: true,
             ..Default::default()
         };
-        let result = evaluate_license_policy(&sbom, &config);
+        let result = evaluate_license_policy(&sbom, &config, false);
         assert!(!result.passed);
         assert_eq!(result.denied_count, 1);
         assert!(result.violations.iter().any(|v| {
@@ -400,7 +471,7 @@ mod tests {
             fail_on_conflict: false,
             ..Default::default()
         };
-        let result = evaluate_license_policy(&sbom, &config);
+        let result = evaluate_license_policy(&sbom, &config, false);
         assert!(result.passed);
         assert_eq!(result.denied_count, 0);
     }
@@ -409,7 +480,7 @@ mod tests {
     fn concluded_only_license_evaluated() {
         let sbom = make_sbom_with_component(&[], Some("AGPL-3.0-only"));
         let config = LicensePolicyConfig::strict_permissive();
-        let result = evaluate_license_policy(&sbom, &config);
+        let result = evaluate_license_policy(&sbom, &config, false);
         assert!(!result.passed);
         assert_eq!(result.denied_count, 1);
         assert_eq!(result.undeclared_count, 0);
@@ -423,12 +494,12 @@ mod tests {
         };
 
         let choice = make_sbom_with_component(&["MIT OR GPL-3.0-only"], None);
-        let result = evaluate_license_policy(&choice, &config);
+        let result = evaluate_license_policy(&choice, &config, false);
         assert!(result.passed);
         assert_eq!(result.denied_count, 0);
 
         let no_choice = make_sbom_with_component(&["GPL-2.0-only OR GPL-3.0-only"], None);
-        let result = evaluate_license_policy(&no_choice, &config);
+        let result = evaluate_license_policy(&no_choice, &config, false);
         assert!(!result.passed);
         assert_eq!(result.denied_count, 1);
     }
@@ -440,7 +511,7 @@ mod tests {
             ..Default::default()
         };
         let sbom = make_sbom_with_component(&["MIT AND GPL-3.0-only"], None);
-        let result = evaluate_license_policy(&sbom, &config);
+        let result = evaluate_license_policy(&sbom, &config, false);
         assert!(!result.passed);
         assert_eq!(result.denied_count, 1);
     }
@@ -453,7 +524,7 @@ mod tests {
             ..Default::default()
         };
         let sbom = make_sbom_with_component(&["MIT OR GPL-3.0-only"], None);
-        let result = evaluate_license_policy(&sbom, &config);
+        let result = evaluate_license_policy(&sbom, &config, false);
         assert!(result.passed);
         assert_eq!(result.allowed_count, 1);
         assert_eq!(result.review_count, 0);
@@ -467,14 +538,14 @@ mod tests {
             allow: vec!["Apache-2.0".to_string()],
             ..Default::default()
         };
-        let result = evaluate_license_policy(&sbom, &allow_config);
+        let result = evaluate_license_policy(&sbom, &allow_config, false);
         assert_eq!(result.allowed_count, 1);
 
         let deny_config = LicensePolicyConfig {
             deny: vec!["Apache-2.0".to_string()],
             ..Default::default()
         };
-        let result = evaluate_license_policy(&sbom, &deny_config);
+        let result = evaluate_license_policy(&sbom, &deny_config, false);
         assert_eq!(result.denied_count, 1);
     }
 
@@ -485,7 +556,7 @@ mod tests {
             ..Default::default()
         };
         let sbom = make_sbom_with_component(&["Commercial EULA v2"], None);
-        let result = evaluate_license_policy(&sbom, &config);
+        let result = evaluate_license_policy(&sbom, &config, false);
         assert!(!result.passed);
         assert_eq!(result.denied_count, 1);
     }
@@ -497,7 +568,7 @@ mod tests {
             allow: vec!["MIT".to_string()],
             ..Default::default()
         };
-        let result = evaluate_license_policy(&sbom, &config);
+        let result = evaluate_license_policy(&sbom, &config, false);
         assert_eq!(result.review_count, 1); // Artistic-2.0 not on allow list
         assert_eq!(result.allowed_count, 1);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ use sbom_tools::{
     reports::{ReportFormat, ReportType},
     watch::parse_duration,
 };
-use std::io::{self, Write as _};
+use std::io::{self, IsTerminal as _, Write as _};
 use std::path::{Path, PathBuf};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -51,13 +51,17 @@ const fn build_long_version() -> &'static str {
 #[command(version, long_version = build_long_version())]
 #[command(about = "Semantic SBOM diff and analysis tool", long_about = None)]
 #[command(after_help = "EXIT CODES:
-    0  No changes detected (or --no-fail-on-change)
-    1  Changes detected / no query matches
-    2  Vulnerabilities introduced
-    3  Error occurred
+    0  Success / gate passed
+    1  Gate failed: --fail-on-change, --min-score, --fail-on-noncompliant,
+       query with no matches, vex status/filter --actionable-only,
+       verify audit-hashes gate
+    2  Command-line usage error; also vulnerabilities introduced
+       (diff/view --fail-on-vuln)
+    3  Operational error (I/O, parse, config, invalid values)
     4  VEX gaps found (--fail-on-vex-gap)
-    5  License policy violations found
+    5  License policy violations found (license-check)
     6  Actively exploited (KEV) vulnerability introduced (--fail-on-kev)
+    7  ML performance metric regressed (diff --fail-on-ml-regression)
 
 EXAMPLES:
   Comparing SBOMs:
@@ -92,8 +96,8 @@ EXAMPLES:
     sbom-tools license-check app.cdx.json --strict
 
   VEX operations:
-    sbom-tools vex status --sbom app.json --vex vex.json
-    sbom-tools vex apply --sbom app.json --vex vex.json -O enriched.json
+    sbom-tools vex status app.json --vex vex.json
+    sbom-tools vex apply app.json --vex vex.json -O enriched.json
 
   SBOM operations (enrich, filter, merge):
     sbom-tools enrich app.cdx.json --enrich-vulns --enrich-eol -O enriched.json
@@ -102,7 +106,7 @@ EXAMPLES:
 
   Monitoring:
     sbom-tools watch --dir ./sboms --enrich-vulns --exit-on-change
-    sbom-tools verify hash app.cdx.json --algorithm sha256
+    sbom-tools verify hash app.cdx.json --hash-file app.cdx.json.sha256
 
 For more details on any command: sbom-tools <command> --help")]
 struct Cli {
@@ -134,8 +138,14 @@ struct Cli {
 
     /// Offline mode: never make network calls; enrichment is served purely from
     /// cache (including TTL-expired entries, with a staleness warning). For
-    /// air-gapped environments. Also settable via `SBOM_TOOLS_OFFLINE`.
-    #[arg(long, global = true, env = "SBOM_TOOLS_OFFLINE")]
+    /// air-gapped environments. Also settable via `SBOM_TOOLS_OFFLINE`
+    /// (accepted values, case-insensitive: 1/0, true/false, yes/no, on/off).
+    #[arg(
+        long,
+        global = true,
+        env = "SBOM_TOOLS_OFFLINE",
+        value_parser = parse_env_bool
+    )]
     offline: bool,
 
     #[command(subcommand)]
@@ -276,15 +286,66 @@ fn seed_enrichment(
     config
 }
 
+/// Build the effective `EnrichmentConfig` for `vex apply|status|filter`,
+/// layering the CLI enrichment flags over the config file's `enrichment:`
+/// block — the same precedence [`seed_enrichment`] applies for diff/view/
+/// query. (`vex` has its own flat argument struct instead of
+/// [`SharedEnrichmentArgs`], so it needs a dedicated seeder.)
+///
+/// `vex export` never routes through here: it exposes no enrichment flags and
+/// always runs with enrichment disabled.
+fn seed_vex_enrichment(
+    args: &VexArgs,
+    sub: Option<&ArgMatches>,
+    app: &AppConfig,
+    offline: bool,
+) -> EnrichmentConfig {
+    let cli = EnrichmentConfig {
+        enabled: args.enrich_vulns,
+        provider: "osv".to_string(),
+        cache_ttl_hours: args.vuln_cache_ttl,
+        max_concurrent: 10,
+        cache_dir: args
+            .vuln_cache_dir
+            .clone()
+            .or_else(|| Some(dirs::osv_cache_dir())),
+        bypass_cache: args.refresh_vulns,
+        timeout_secs: args.api_timeout,
+        enable_eol: args.enrich_eol,
+        vex_paths: Vec::new(),
+        ..Default::default()
+    };
+    let cli_touched = cli.enabled
+        || cli.enable_eol
+        || arg_was_set_sub(sub, "vuln_cache_dir")
+        || arg_was_set_sub(sub, "vuln_cache_ttl")
+        || arg_was_set_sub(sub, "api_timeout")
+        || arg_was_set_sub(sub, "refresh_vulns");
+    let mut config = match (&app.enrichment, cli_touched) {
+        (Some(file), false) => {
+            let mut file = file.clone();
+            // VEX documents are threaded separately via `VexConfig::vex_paths`
+            // (the CLI `--vex` flags); keeping the file's paths here would
+            // apply the overlay twice.
+            file.vex_paths = Vec::new();
+            file
+        }
+        _ => cli,
+    };
+    config.offline = offline || config.offline;
+    config
+}
+
 /// Arguments for the `diff` subcommand
 #[derive(Parser)]
 #[command(after_help = "EXIT CODES:
-    0  No changes detected (or --no-fail-on-change)
+    0  Success (changes alone exit 0 without --fail-on-change)
     1  Changes detected (--fail-on-change)
-    2  Vulnerabilities introduced (--fail-on-vuln)
-    3  Error occurred
+    2  Vulnerabilities introduced (--fail-on-vuln); also CLI usage errors
+    3  Operational error (I/O, parse, config, invalid values)
     4  VEX gaps found (--fail-on-vex-gap)
     6  Actively exploited (KEV) vulnerability introduced (--fail-on-kev)
+    7  ML performance metric regressed (--fail-on-ml-regression)
 
 EXAMPLES:
     sbom-tools diff old.cdx.json new.cdx.json                    # Interactive TUI
@@ -354,7 +415,7 @@ struct DiffArgs {
     graph_max_depth: u32,
 
     /// Minimum impact level to include in graph diff output (low, medium, high, critical)
-    #[arg(long, default_value = "low")]
+    #[arg(long, default_value = "low", value_parser = ["low", "medium", "high", "critical"])]
     graph_impact_threshold: String,
 
     /// Comma-separated list of relationship types to include in graph diff
@@ -378,7 +439,7 @@ struct DiffArgs {
     #[arg(long, alias = "exclude-vex-not-affected")]
     exclude_vex_resolved: bool,
 
-    /// Exit with error if introduced vulnerabilities lack VEX statements (CI gate)
+    /// Exit with code 4 if introduced vulnerabilities lack VEX statements (CI gate)
     #[arg(long)]
     fail_on_vex_gap: bool,
 
@@ -450,8 +511,8 @@ struct ViewArgs {
     fail_on_vuln: bool,
 
     /// BOM type override (sbom, cbom, aibom). Auto-detected from content if omitted
-    #[arg(long, value_name = "TYPE")]
-    bom_type: Option<String>,
+    #[arg(long, value_name = "TYPE", value_parser = parse_bom_type)]
+    bom_type: Option<sbom_tools::BomProfile>,
 
     /// Path to a CRA sidecar metadata file (JSON or YAML).
     /// If omitted, auto-discovers `<sbom>.cra.json|yaml` next to the SBOM.
@@ -473,13 +534,14 @@ struct ViewArgs {
 #[command(after_help = "EXIT CODES:
     0  Compliant (no errors; no warnings with --fail-on-warning)
     1  Compliance errors found (non-compliant)
-    2  Compliance warnings found (only with --fail-on-warning)
+    2  Compliance warnings found (only with --fail-on-warning); also
+       command-line parse errors
+    3  Operational error (unsupported output format, invalid --as-of /
+       --cra-product-class / --cra-sidecar, broken config file, I/O)
 
-    The gate codes above only apply to runs that completed a validation.
-    Usage and configuration errors (unsupported output format, invalid
-    --as-of / --cra-product-class / --cra-sidecar, broken config file)
-    also exit 1, and command-line parse errors exit 2 — so a nonzero exit
-    is only a compliance verdict when the expected report was produced.
+    The gate codes (0/1/warning-2) only apply to runs that completed a
+    validation — a nonzero exit is only a compliance verdict when the
+    expected report was produced.
 
 EXAMPLES:
     sbom-tools validate app.cdx.json                              # NTIA minimum
@@ -548,7 +610,11 @@ struct ValidateArgs {
 
 /// Arguments for the `diff-multi` subcommand
 #[derive(Parser)]
-#[command(after_help = "EXAMPLES:
+#[command(after_help = "EXIT CODES:
+    Gates: 1 changes (--fail-on-change), 2 vulnerabilities (--fail-on-vuln),
+    4 VEX gaps (--fail-on-vex-gap). Operational errors exit 3.
+
+EXAMPLES:
     sbom-tools diff-multi baseline.json target1.json target2.json
     sbom-tools diff-multi baseline.json devices/*.json -o json
     sbom-tools diff-multi base.json t1.json t2.json --enrich-vulns --fail-on-vuln")]
@@ -585,7 +651,7 @@ struct DiffMultiArgs {
     graph_max_depth: u32,
 
     /// Minimum impact level for graph diff output (low, medium, high, critical)
-    #[arg(long, default_value = "low")]
+    #[arg(long, default_value = "low", value_parser = ["low", "medium", "high", "critical"])]
     graph_impact_threshold: String,
 
     /// Relationship types to include in graph diff (comma-separated, e.g., "DependsOn,DevDependsOn")
@@ -608,7 +674,7 @@ struct DiffMultiArgs {
     #[arg(long)]
     exclude_vex_resolved: bool,
 
-    /// Exit with error if introduced vulnerabilities lack VEX statements
+    /// Exit with code 4 if introduced vulnerabilities lack VEX statements
     #[arg(long)]
     fail_on_vex_gap: bool,
 
@@ -618,7 +684,11 @@ struct DiffMultiArgs {
 
 /// Arguments for the `timeline` subcommand
 #[derive(Parser)]
-#[command(after_help = "EXAMPLES:
+#[command(after_help = "EXIT CODES:
+    Gates: 1 changes (--fail-on-change), 2 vulnerabilities (--fail-on-vuln),
+    4 VEX gaps (--fail-on-vex-gap). Operational errors exit 3.
+
+EXAMPLES:
     sbom-tools timeline v1.0.json v1.1.json v1.2.json             # Version evolution
     sbom-tools timeline releases/*.json --enrich-vulns -o json     # Vuln trend report
     sbom-tools timeline *.json --fail-on-vuln --fail-on-change     # CI gate")]
@@ -648,7 +718,7 @@ struct TimelineArgs {
     graph_max_depth: u32,
 
     /// Minimum impact level for graph diff output (low, medium, high, critical)
-    #[arg(long, default_value = "low")]
+    #[arg(long, default_value = "low", value_parser = ["low", "medium", "high", "critical"])]
     graph_impact_threshold: String,
 
     /// Relationship types to include in graph diff (comma-separated, e.g., "DependsOn,DevDependsOn")
@@ -671,7 +741,7 @@ struct TimelineArgs {
     #[arg(long)]
     exclude_vex_resolved: bool,
 
-    /// Exit with error if introduced vulnerabilities lack VEX statements
+    /// Exit with code 4 if introduced vulnerabilities lack VEX statements
     #[arg(long)]
     fail_on_vex_gap: bool,
 
@@ -681,7 +751,11 @@ struct TimelineArgs {
 
 /// Arguments for the `matrix` subcommand
 #[derive(Parser)]
-#[command(after_help = "EXAMPLES:
+#[command(after_help = "EXIT CODES:
+    Gates: 1 changes (--fail-on-change), 2 vulnerabilities (--fail-on-vuln),
+    4 VEX gaps (--fail-on-vex-gap). Operational errors exit 3.
+
+EXAMPLES:
     sbom-tools matrix v1.json v2.json v3.json                     # NxN comparison
     sbom-tools matrix *.cdx.json --cluster-threshold 0.9 -o json  # Clustering
     sbom-tools matrix *.json --enrich-vulns --fail-on-vuln         # CI with enrichment")]
@@ -702,8 +776,8 @@ struct MatrixArgs {
     #[arg(long, value_enum, default_value_t = FuzzyPreset::Balanced)]
     fuzzy_preset: FuzzyPreset,
 
-    /// Similarity threshold for clustering (0.0-1.0)
-    #[arg(long, default_value = "0.8")]
+    /// Similarity threshold for clustering (finite, 0.0-1.0)
+    #[arg(long, default_value = "0.8", value_parser = parse_cluster_threshold)]
     cluster_threshold: f64,
 
     /// Enable graph-aware diffing for matrix comparison
@@ -715,7 +789,7 @@ struct MatrixArgs {
     graph_max_depth: u32,
 
     /// Minimum impact level for graph diff output (low, medium, high, critical)
-    #[arg(long, default_value = "low")]
+    #[arg(long, default_value = "low", value_parser = ["low", "medium", "high", "critical"])]
     graph_impact_threshold: String,
 
     /// Relationship types to include in graph diff (comma-separated, e.g., "DependsOn,DevDependsOn")
@@ -738,7 +812,7 @@ struct MatrixArgs {
     #[arg(long)]
     exclude_vex_resolved: bool,
 
-    /// Exit with error if introduced vulnerabilities lack VEX statements
+    /// Exit with code 4 if introduced vulnerabilities lack VEX statements
     #[arg(long)]
     fail_on_vex_gap: bool,
 
@@ -751,14 +825,14 @@ struct MatrixArgs {
 #[command(after_help = "EXIT CODES:
     0  Score meets --min-score (or no threshold) and, with --fail-on-noncompliant, the SBOM is compliant
     1  Overall score below --min-score, OR (with --fail-on-noncompliant) the SBOM is non-compliant
+    2  Command-line parse errors
+    3  Operational error (unsupported output format, invalid --as-of /
+       --cra-product-class / --cra-sidecar, broken config file, I/O)
 
-    The gate codes above only apply to runs that completed an assessment.
-    Usage and configuration errors (unsupported output format, invalid
-    --as-of / --cra-product-class / --cra-sidecar, broken config file)
-    also exit 1, and command-line parse errors exit 2 — so a nonzero exit
-    is only a quality/compliance verdict when the expected report was
-    produced. N/A runs (e.g. --profile ai-readiness on an SBOM without ML
-    components) never trip either gate.
+    The gate codes (0/1) only apply to runs that completed an assessment —
+    a nonzero exit is only a quality/compliance verdict when the expected
+    report was produced. N/A runs (e.g. --profile ai-readiness on an SBOM
+    without ML components) never trip either gate.
 
 EXAMPLES:
     sbom-tools quality app.cdx.json                                # Score overview
@@ -890,7 +964,7 @@ struct QueryArgs {
     #[arg(long, conflicts_with = "quantum_safe")]
     quantum_vulnerable: bool,
 
-    /// Output format (table, json, csv)
+    /// Output format (auto, table, json, csv, summary); unsupported formats error
     #[arg(short, long, default_value = "auto")]
     output: ReportFormat,
 
@@ -929,7 +1003,8 @@ struct WatchArgs {
     #[arg(long, default_value = "6h")]
     enrich_interval: String,
 
-    /// Output format (summary for human, json for NDJSON streaming)
+    /// Output format: auto, summary (human), or json (NDJSON streaming);
+    /// other formats error
     #[arg(short, long, default_value = "auto")]
     output: ReportFormat,
 
@@ -1239,7 +1314,13 @@ enum VerifyAction {
 
 /// Arguments for the `license-check` subcommand
 #[derive(Parser)]
-#[command(after_help = "EXAMPLES:
+#[command(after_help = "EXIT CODES:
+    0    License policy passed
+    3    Operational error (unreadable SBOM, parse failure, invalid policy file)
+    5    License policy violations (denied licenses; review-needed under --strict;
+         propagation conflicts under --check-propagation)
+
+EXAMPLES:
     sbom-tools license-check app.cdx.json                         # Default policy
     sbom-tools license-check app.cdx.json --strict                 # Permissive-only
     sbom-tools license-check app.cdx.json --policy policy.json     # Custom policy
@@ -1354,7 +1435,7 @@ struct MergeArgs {
 #[command(after_help = "EXAMPLES:
     sbom-tools convert app.spdx.json --to cyclonedx                # SPDX → CycloneDX (stdout)
     sbom-tools convert app.cdx.json  --to spdx                     # CycloneDX → SPDX 2.3
-    sbom-tools convert app.spdx.json --to cyclonedx -o out.cdx.json
+    sbom-tools convert app.spdx.json --to cyclonedx -O out.cdx.json
     sbom-tools convert app.cdx.json --to cyclonedx --preserve      # Keep format-specific blocks
 
 NOTE: Supported targets are --to cyclonedx (1.7 JSON) and --to spdx (2.3 JSON).
@@ -1368,7 +1449,10 @@ struct ConvertArgs {
     to: String,
 
     /// Output file (stdout if not specified)
-    #[arg(short = 'o', long)]
+    // -O like every sibling; -o here previously meant the output FILE while
+    // meaning output FORMAT everywhere else, so `-o json` silently wrote a
+    // file literally named "json".
+    #[arg(short = 'O', long)]
     output_file: Option<PathBuf>,
 
     /// Capture verbatim source JSON before conversion so format-specific blocks
@@ -1424,6 +1508,11 @@ struct CraDocsArgs {
     /// Sidecar `productClass` wins.
     #[arg(long, value_name = "CLASS")]
     cra_product_class: Option<String>,
+
+    /// Overwrite existing dossier files (by default a re-run refuses to
+    /// clobber hand-completed documents)
+    #[arg(long)]
+    force: bool,
 }
 
 /// Dedicated table/json output format for commands that only emit those two
@@ -1544,6 +1633,49 @@ fn supported_config_format(
     None
 }
 
+/// Parse a boolean environment/flag value leniently.
+///
+/// `SBOM_TOOLS_OFFLINE=1` (the natural spelling) used to hard-fail every
+/// invocation because clap's default bool parser only accepts `true`/`false`.
+/// Accepts 1/0, true/false, yes/no, on/off — case-insensitively. An empty
+/// value (`SBOM_TOOLS_OFFLINE=`) counts as unset/false.
+fn parse_env_bool(s: &str) -> std::result::Result<bool, String> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "y" | "on" => Ok(true),
+        "" | "0" | "false" | "no" | "n" | "off" => Ok(false),
+        other => Err(format!(
+            "invalid boolean value '{other}' \
+             (accepted, case-insensitive: 1/0, true/false, yes/no, on/off)"
+        )),
+    }
+}
+
+/// Parse and validate `--cluster-threshold`: a finite similarity in 0.0..=1.0.
+///
+/// NaN, infinities, and out-of-range values used to be accepted silently and
+/// produced nonsensical clustering.
+fn parse_cluster_threshold(s: &str) -> std::result::Result<f64, String> {
+    let value: f64 = s
+        .parse()
+        .map_err(|e| format!("invalid number '{s}': {e}"))?;
+    if !value.is_finite() || !(0.0..=1.0).contains(&value) {
+        return Err(format!(
+            "cluster threshold must be a finite value between 0.0 and 1.0, got '{s}'"
+        ));
+    }
+    Ok(value)
+}
+
+/// Parse and validate `--bom-type` at the CLI boundary.
+///
+/// An unrecognized value used to be silently dropped (falling back to content
+/// auto-detection); it is now a hard error listing the valid spellings.
+fn parse_bom_type(s: &str) -> std::result::Result<sbom_tools::BomProfile, String> {
+    sbom_tools::BomProfile::from_str_opt(s).ok_or_else(|| {
+        format!("invalid BOM type '{s}' (valid values: sbom, cbom, aibom; aliases: ai, mlbom)")
+    })
+}
+
 /// Validate VEX state filter values at the CLI boundary.
 fn validate_vex_state(s: &str) -> std::result::Result<String, String> {
     match s.to_lowercase().as_str() {
@@ -1563,11 +1695,57 @@ fn validate_vex_state(s: &str) -> std::result::Result<String, String> {
     }
 }
 
-fn main() -> Result<()> {
+/// Restore the default `SIGPIPE` disposition.
+///
+/// Rust's runtime ignores `SIGPIPE`, so writes to a closed pipe surface as
+/// `EPIPE` errors — which `println!`/`generate` turn into a panic (exit 101)
+/// for pipelines like `sbom-tools completions bash | head`. Restoring
+/// `SIG_DFL` makes the process terminate quietly (conventional exit 141),
+/// matching standard CLI behaviour.
+#[cfg(unix)]
+fn reset_sigpipe() {
+    unsafe extern "C" {
+        fn signal(signum: std::ffi::c_int, handler: usize) -> usize;
+    }
+    /// `SIGPIPE` is 13 on every supported Unix (Linux, macOS, BSDs).
+    const SIGPIPE: std::ffi::c_int = 13;
+    /// `SIG_DFL` is 0 on every supported Unix.
+    const SIG_DFL: usize = 0;
+    // SAFETY: setting SIGPIPE back to its default disposition cannot violate
+    // memory safety; this runs at the top of main() before any other threads
+    // are spawned.
+    unsafe {
+        signal(SIGPIPE, SIG_DFL);
+    }
+}
+
+fn main() {
+    #[cfg(unix)]
+    reset_sigpipe();
+
+    // Central operational-error exit: every anyhow error (I/O, parse, config,
+    // unsupported output format, invalid flag values) leaves with code 3, so
+    // it can never collide with gate codes (1 = verdict gates, 2 = clap usage
+    // errors and diff/view --fail-on-vuln, 4 = --fail-on-vex-gap, 5 =
+    // license-check denial, 6 = --fail-on-kev, 7 = diff ML regression).
+    if let Err(err) = run() {
+        // Mirror the format the default `fn main() -> Result` termination
+        // prints: message plus the "Caused by:" chain.
+        eprintln!("Error: {err:?}");
+        std::process::exit(3);
+    }
+}
+
+fn run() -> Result<()> {
     let matches = Cli::command().get_matches();
     let cli = Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.exit());
 
-    // Initialize logging
+    // Initialize logging. ANSI escapes only when stderr is a live terminal
+    // and neither --no-color nor the NO_COLOR convention (set to a non-empty
+    // value) asked for monochrome — piped/redirected stderr stays clean.
+    let ansi = std::io::stderr().is_terminal()
+        && !cli.no_color
+        && std::env::var_os("NO_COLOR").is_none_or(|v| v.is_empty());
     let log_level = if cli.verbose { "debug" } else { "info" };
     tracing_subscriber::registry()
         .with(tracing_subscriber::EnvFilter::new(
@@ -1578,6 +1756,7 @@ fn main() -> Result<()> {
         .with(
             tracing_subscriber::fmt::layer()
                 .with_target(false)
+                .with_ansi(ansi)
                 .with_writer(std::io::stderr),
         )
         .init();
@@ -1745,10 +1924,7 @@ fn main() -> Result<()> {
                 vulnerable_only: args.vulnerable_only,
                 ecosystem_filter: args.ecosystem,
                 fail_on_vuln: resolve_bool(args.fail_on_vuln, app.behavior.fail_on_vuln),
-                bom_profile: args
-                    .bom_type
-                    .as_deref()
-                    .and_then(sbom_tools::BomProfile::from_str_opt),
+                bom_profile: args.bom_type,
                 enrichment,
                 cra_sidecar_path: args
                     .cra_sidecar
@@ -2158,6 +2334,9 @@ fn main() -> Result<()> {
         }
 
         Commands::Vex { action } => {
+            // Argument matches of the nested vex sub-subcommand
+            // (apply/status/filter/export), for CLI-explicitness detection.
+            let vex_sub = sub_matches.and_then(|m| m.subcommand()).map(|(_, m)| m);
             let (args, cli_action) = match action {
                 VexAction::Apply(args) => (args, cli::VexAction::Apply),
                 VexAction::Status(args) => (args, cli::VexAction::Status),
@@ -2184,17 +2363,29 @@ fn main() -> Result<()> {
                 }
             };
 
-            let enrichment = EnrichmentConfig {
-                enabled: args.enrich_vulns,
-                provider: "osv".to_string(),
-                cache_ttl_hours: args.vuln_cache_ttl,
-                max_concurrent: 10,
-                cache_dir: args.vuln_cache_dir.or_else(|| Some(dirs::osv_cache_dir())),
-                bypass_cache: args.refresh_vulns,
-                timeout_secs: args.api_timeout,
-                enable_eol: args.enrich_eol,
-                vex_paths: Vec::new(), // VEX paths handled separately
-                ..Default::default()
+            // `vex export` exposes no enrichment flags (it exports existing
+            // state), so it always runs with enrichment disabled. The other
+            // vex actions honor the config file's `enrichment:` block exactly
+            // like diff/view/query, with explicit CLI flags winning.
+            let enrichment = if matches!(cli_action, cli::VexAction::Export(_)) {
+                EnrichmentConfig {
+                    enabled: false,
+                    provider: "osv".to_string(),
+                    cache_ttl_hours: args.vuln_cache_ttl,
+                    max_concurrent: 10,
+                    cache_dir: args
+                        .vuln_cache_dir
+                        .clone()
+                        .or_else(|| Some(dirs::osv_cache_dir())),
+                    bypass_cache: args.refresh_vulns,
+                    timeout_secs: args.api_timeout,
+                    enable_eol: false,
+                    vex_paths: Vec::new(), // VEX paths handled separately
+                    offline,
+                    ..Default::default()
+                }
+            } else {
+                seed_vex_enrichment(&args, vex_sub, &app, offline)
             };
 
             let config = sbom_tools::config::VexConfig {
@@ -2271,10 +2462,14 @@ fn main() -> Result<()> {
 
         Commands::Config { action } => match action {
             ConfigAction::Show => {
+                // Strict like every consuming command: an explicit --config
+                // that is missing or unparseable is an error, never a silent
+                // fallback to a different discovered file or defaults.
                 let (config, loaded_from) = if cli.no_config {
                     (AppConfig::default(), None)
                 } else {
-                    sbom_tools::config::load_or_default(cli.config.as_deref())
+                    sbom_tools::config::load_strict(cli.config.as_deref())
+                        .context("failed to load config")?
                 };
                 if let Some(path) = &loaded_from {
                     eprintln!("# Loaded from: {}", path.display());
@@ -2313,7 +2508,12 @@ fn main() -> Result<()> {
                 }
                 eprintln!();
                 match sbom_tools::config::discover_config_file(cli.config.as_deref()) {
-                    Some(path) => eprintln!("Active config file: {}", path.display()),
+                    Some(path) => {
+                        if cli.config.is_some() && !path.exists() {
+                            anyhow::bail!("config file not found: {}", path.display());
+                        }
+                        eprintln!("Active config file: {}", path.display());
+                    }
                     None => eprintln!("No config file found."),
                 }
                 Ok(())
@@ -2412,8 +2612,9 @@ fn main() -> Result<()> {
 
         #[cfg(feature = "enrichment")]
         Commands::Enrich(args) => {
-            let mut enrichment = args.enrichment.to_enrichment_config();
-            enrichment.offline = offline || enrichment.offline;
+            // Same layering as diff/view/query: the config file's `enrichment:`
+            // block is the base and explicit CLI flags win.
+            let enrichment = seed_enrichment(&args.enrichment, sub_matches, &app, offline);
 
             let exit_code =
                 cli::run_enrich(&args.file, args.output_file.as_ref(), enrichment, cli.quiet)?;
@@ -2483,13 +2684,14 @@ fn main() -> Result<()> {
         // section supplies the sidecar path and product class when the CLI
         // flags are absent, so the dossier agrees with the validate verdict
         // produced under the same config.
-        Commands::CraDocs(args) => cli::run_cra_docs(
+        Commands::CraDocs(args) => cli::run_cra_docs_with_force(
             args.sbom,
             args.output,
             args.cra_sidecar
                 .or_else(|| app.compliance.cra_sidecar.clone()),
             args.cra_product_class
                 .or_else(|| app.compliance.cra_product_class.clone()),
+            args.force,
         ),
 
         Commands::CraStandardsWatch(args) => cli::run_cra_standards_watch(
@@ -2547,4 +2749,88 @@ fn has_sbom_extension(s: &str) -> bool {
         || lower.ends_with(".yaml")
         || lower.ends_with(".yml")
         || lower.ends_with(".rdf")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_definition_is_consistent() {
+        Cli::command().debug_assert();
+    }
+
+    #[test]
+    fn parse_env_bool_accepts_common_spellings_case_insensitively() {
+        for truthy in ["1", "true", "TRUE", "Yes", "y", "ON"] {
+            assert_eq!(parse_env_bool(truthy), Ok(true), "{truthy}");
+        }
+        for falsy in ["0", "false", "False", "NO", "n", "off", "", " "] {
+            assert_eq!(parse_env_bool(falsy), Ok(false), "{falsy:?}");
+        }
+    }
+
+    #[test]
+    fn parse_env_bool_rejects_garbage_with_accepted_values_listed() {
+        let err = parse_env_bool("banana").unwrap_err();
+        assert!(err.contains("banana"), "{err}");
+        assert!(err.contains("1/0") && err.contains("true/false"), "{err}");
+    }
+
+    #[test]
+    fn parse_cluster_threshold_accepts_finite_unit_interval() {
+        assert_eq!(parse_cluster_threshold("0"), Ok(0.0));
+        assert_eq!(parse_cluster_threshold("0.8"), Ok(0.8));
+        assert_eq!(parse_cluster_threshold("1.0"), Ok(1.0));
+    }
+
+    #[test]
+    fn parse_cluster_threshold_rejects_nan_infinite_and_out_of_range() {
+        for bad in ["NaN", "nan", "-0.5", "1.5", "inf", "-inf", "1e300", "x"] {
+            assert!(parse_cluster_threshold(bad).is_err(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn parse_bom_type_is_strict_and_lists_valid_values() {
+        assert_eq!(parse_bom_type("sbom"), Ok(sbom_tools::BomProfile::Sbom));
+        assert_eq!(parse_bom_type("CBOM"), Ok(sbom_tools::BomProfile::Cbom));
+        assert_eq!(parse_bom_type("aibom"), Ok(sbom_tools::BomProfile::AiBom));
+        let err = parse_bom_type("banana").unwrap_err();
+        assert!(err.contains("banana"), "{err}");
+        for valid in ["sbom", "cbom", "aibom"] {
+            assert!(err.contains(valid), "must list '{valid}': {err}");
+        }
+    }
+
+    /// The phantom `--no-fail-on-change` flag must not be advertised anywhere
+    /// (it never existed), and the root exit-code table must document the
+    /// central operational-error code 3.
+    #[test]
+    fn help_text_matches_reality() {
+        let mut cmd = Cli::command();
+        cmd.build();
+        let root = cmd.render_long_help().to_string();
+        assert!(
+            !root.contains("--no-fail-on-change"),
+            "phantom flag in root help"
+        );
+        assert!(
+            root.contains("Operational error"),
+            "root help must document exit 3"
+        );
+        let diff = cmd
+            .find_subcommand_mut("diff")
+            .expect("diff subcommand")
+            .render_long_help()
+            .to_string();
+        assert!(
+            !diff.contains("--no-fail-on-change"),
+            "phantom flag in diff help"
+        );
+        assert!(
+            diff.contains("--fail-on-ml-regression"),
+            "diff help must document exit 7 gate"
+        );
+    }
 }

--- a/src/model/cra_sidecar.rs
+++ b/src/model/cra_sidecar.rs
@@ -404,17 +404,33 @@ impl CraSidecarMetadata {
         }
     }
 
-    /// Try to find a sidecar file for the given SBOM path.
+    /// Try to find and load a sidecar file for the given SBOM path.
     ///
-    /// Looks for `<stem>.cra.{json,yaml,yml}` and `<stem>-cra.{json,yaml}`
+    /// Looks for `<stem>.cra.{json,yaml,yml}` and `<stem>-cra.{json,yaml,yml}`
     /// alongside the SBOM. Multi-extension stems (`app.cdx.json`,
     /// `app.spdx.json`, `app.spdx3.json`) also try the inner stem
     /// (`app.cra.json`) so the common SBOM naming conventions work
     /// without forcing operators to repeat the format suffix.
-    #[must_use]
-    pub fn find_for_sbom(sbom_path: &Path) -> Option<Self> {
-        let parent = sbom_path.parent()?;
-        let stem = sbom_path.file_stem()?.to_str()?;
+    ///
+    /// Discovery is **strict**: once a candidate file exists, it must load.
+    /// A broken discovered sidecar (typo'd field, bad YAML) is a hard error
+    /// naming the file and field — exactly like an explicitly passed
+    /// `--cra-sidecar` — instead of a stderr warning that silently shifts
+    /// the compliance verdict.
+    ///
+    /// Stdin input (`-`) has no adjacent files, so it never resolves a
+    /// sidecar (previously this probed a literal `-.cra.json`).
+    pub fn discover_for_sbom(sbom_path: &Path) -> Result<Option<Self>, CraSidecarError> {
+        // Stdin: no directory to discover in.
+        if sbom_path.as_os_str() == "-" {
+            return Ok(None);
+        }
+        let Some(parent) = sbom_path.parent() else {
+            return Ok(None);
+        };
+        let Some(stem) = sbom_path.file_stem().and_then(|s| s.to_str()) else {
+            return Ok(None);
+        };
 
         // Build the list of stems to try. Strip well-known SBOM format
         // suffixes (`.cdx`, `.spdx`, `.spdx3`, `.cyclonedx`) so e.g.
@@ -436,24 +452,38 @@ impl CraSidecarMetadata {
                 format!("{s}.cra.yml"),
                 format!("{s}-cra.json"),
                 format!("{s}-cra.yaml"),
+                format!("{s}-cra.yml"),
             ] {
                 let sidecar_path = parent.join(&pattern);
                 if sidecar_path.exists() {
-                    match Self::from_file(&sidecar_path) {
-                        Ok(metadata) => return Some(metadata),
-                        // Auto-discovery is best-effort: a broken candidate is
-                        // surfaced as a warning, not an abort (an *explicitly*
-                        // requested sidecar hard-errors at the CLI layer).
-                        Err(e) => tracing::warn!(
-                            "Ignoring auto-discovered CRA sidecar {}: {e}",
-                            sidecar_path.display()
-                        ),
-                    }
+                    // First existing candidate is authoritative: it either
+                    // loads or the command fails naming the broken file.
+                    return Self::from_file(&sidecar_path)
+                        .map(Some)
+                        .map_err(|e| e.with_path(&sidecar_path));
                 }
             }
         }
 
-        None
+        Ok(None)
+    }
+
+    /// Lenient wrapper around [`Self::discover_for_sbom`] that downgrades a
+    /// broken discovered sidecar to a warning.
+    ///
+    /// Transitional: call sites should migrate to [`Self::discover_for_sbom`]
+    /// so a broken sidecar aborts the command instead of silently shifting
+    /// the verdict; this wrapper only exists to keep the old signature alive
+    /// until they do.
+    #[must_use]
+    pub fn find_for_sbom(sbom_path: &Path) -> Option<Self> {
+        match Self::discover_for_sbom(sbom_path) {
+            Ok(found) => found,
+            Err(e) => {
+                tracing::warn!("Ignoring auto-discovered CRA sidecar: {e}");
+                None
+            }
+        }
     }
 
     /// Whether the sidecar carries live EUCC evidence: a non-empty
@@ -571,6 +601,20 @@ impl std::fmt::Display for CraSidecarError {
 
 impl std::error::Error for CraSidecarError {}
 
+impl CraSidecarError {
+    /// Prefix the error message with the sidecar path so discovery errors
+    /// name the exact file that failed (serde already names the field).
+    #[must_use]
+    pub fn with_path(self, path: &Path) -> Self {
+        let p = path.display();
+        match self {
+            Self::IoError(e) => Self::IoError(format!("{p}: {e}")),
+            Self::ParseError(e) => Self::ParseError(format!("{p}: {e}")),
+            Self::UnsupportedFormat(e) => Self::UnsupportedFormat(format!("{e} ({p})")),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -670,9 +714,10 @@ mod tests {
     }
 
     #[test]
-    fn find_for_sbom_soft_fails_on_broken_candidate() {
-        // Auto-discovery must skip (warn about) a broken adjacent sidecar
-        // rather than returning it or erroring.
+    fn discover_for_sbom_hard_fails_on_broken_candidate_naming_file_and_field() {
+        // Strict discovery: a broken adjacent sidecar is a hard error that
+        // names the file and the offending field — the same treatment an
+        // explicit --cra-sidecar gets — never a silent verdict shift.
         let dir = tempfile::tempdir().unwrap();
         let sbom_path = dir.path().join("app.cdx.json");
         std::fs::write(&sbom_path, "{}").unwrap();
@@ -681,7 +726,59 @@ mod tests {
             r#"{"security_contact": "typo"}"#,
         )
         .unwrap();
+        let err = CraSidecarMetadata::discover_for_sbom(&sbom_path)
+            .expect_err("broken discovered sidecar must hard-error");
+        let msg = err.to_string();
+        assert!(msg.contains("app.cra.json"), "must name the file: {msg}");
+        assert!(
+            msg.contains("security_contact"),
+            "must name the field: {msg}"
+        );
+
+        // The transitional lenient wrapper still downgrades to None.
         assert!(CraSidecarMetadata::find_for_sbom(&sbom_path).is_none());
+    }
+
+    #[test]
+    fn discover_for_sbom_skips_stdin() {
+        // Stdin input previously probed a literal `-.cra.json` in the cwd.
+        assert!(
+            CraSidecarMetadata::discover_for_sbom(Path::new("-"))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn discover_for_sbom_finds_hyphen_yml_variant() {
+        let dir = tempfile::tempdir().unwrap();
+        let sbom_path = dir.path().join("app.cdx.json");
+        std::fs::write(&sbom_path, "{}").unwrap();
+        std::fs::write(
+            dir.path().join("app-cra.yml"),
+            "securityContact: sec@example.com\n",
+        )
+        .unwrap();
+        let found = CraSidecarMetadata::discover_for_sbom(&sbom_path)
+            .unwrap()
+            .expect("hyphen .yml sidecar must be discovered");
+        assert_eq!(found.security_contact.as_deref(), Some("sec@example.com"));
+    }
+
+    #[test]
+    fn discover_for_sbom_loads_valid_candidate() {
+        let dir = tempfile::tempdir().unwrap();
+        let sbom_path = dir.path().join("app.cdx.json");
+        std::fs::write(&sbom_path, "{}").unwrap();
+        std::fs::write(
+            dir.path().join("app.cra.json"),
+            r#"{"securityContact": "sec@example.com"}"#,
+        )
+        .unwrap();
+        let found = CraSidecarMetadata::discover_for_sbom(&sbom_path)
+            .unwrap()
+            .expect("valid sidecar must be discovered");
+        assert_eq!(found.security_contact.as_deref(), Some("sec@example.com"));
     }
 
     #[test]

--- a/src/pipeline/diff_stage.rs
+++ b/src/pipeline/diff_stage.rs
@@ -7,7 +7,42 @@ use crate::config::{DiffConfig, FilterConfig, GraphAwareDiffConfig};
 use crate::diff::{DiffEngine, DiffResult, GraphDiffConfig};
 use crate::matching::{FuzzyMatchConfig, MatchingRulesConfig};
 use crate::model::NormalizedSbom;
-use anyhow::Result;
+use anyhow::{Result, bail};
+
+/// Labels accepted by `--severity` and `--graph-impact-threshold`.
+const VALID_LEVELS: [&str; 4] = ["critical", "high", "medium", "low"];
+
+/// Validate user-supplied post-diff filter values up front.
+///
+/// Previously an unknown `--severity` value silently filtered nothing (an
+/// unrecognized label coerces to rank 0, so every vulnerability passes the
+/// `>=` check) and an unknown `--graph-impact-threshold` silently coerced to
+/// `low`. Both are now hard errors (operational error, exit 3 via `main`)
+/// listing the valid values.
+///
+/// # Errors
+///
+/// Returns an error if `filtering.min_severity` or `graph.impact_threshold`
+/// is not one of `critical`, `high`, `medium`, `low`.
+pub fn validate_post_diff_filters(
+    filtering: &FilterConfig,
+    graph: &GraphAwareDiffConfig,
+) -> Result<()> {
+    if let Some(ref sev) = filtering.min_severity
+        && !VALID_LEVELS.contains(&sev.to_lowercase().as_str())
+    {
+        bail!("invalid --severity value '{sev}'; valid values: critical, high, medium, low");
+    }
+    if let Some(ref threshold) = graph.impact_threshold
+        && !VALID_LEVELS.contains(&threshold.to_lowercase().as_str())
+    {
+        bail!(
+            "invalid --graph-impact-threshold value '{threshold}'; \
+             valid values: critical, high, medium, low"
+        );
+    }
+    Ok(())
+}
 
 /// Convert a [`GraphAwareDiffConfig`] (CLI/config representation) into the
 /// engine-level [`GraphDiffConfig`] consumed by the diff engine.
@@ -83,6 +118,11 @@ pub fn compute_diff(
 ) -> Result<DiffResult> {
     let quiet = config.behavior.quiet;
     let fuzzy_config = config.matching.to_fuzzy_config();
+
+    // Reject unknown filter values before doing any work. Callers that want
+    // to fail before parsing validate earlier as well; this is the backstop
+    // for any path that reaches the diff stage directly.
+    validate_post_diff_filters(&config.filtering, &config.graph_diff)?;
 
     // Load matching rules if specified
     let matching_rules = load_matching_rules(config)?;
@@ -205,21 +245,23 @@ fn load_matching_rules(config: &DiffConfig) -> Result<Option<MatchingRulesConfig
     )
 }
 
-/// Print match explanations for modified components to stdout.
+/// Print match explanations for modified components to STDERR.
 ///
-/// Uses `println!()` intentionally — this is user-facing CLI diagnostic output
-/// triggered by `--explain-matches`, not a log message.
+/// This is user-facing CLI diagnostic output triggered by `--explain-matches`.
+/// It must go to stderr: the report itself (including `-o json`/`sarif`/`csv`)
+/// is written to stdout, and interleaving these blocks there corrupts
+/// machine-parseable output.
 fn print_match_explanations(result: &DiffResult) {
-    println!("\n=== Match Explanations ===\n");
+    eprintln!("\n=== Match Explanations ===\n");
     for change in &result.components.modified {
         if let Some(ref match_info) = change.match_info {
-            println!("Component: {}", change.name);
-            println!("  Score: {:.2} ({})", match_info.score, match_info.method);
-            println!("  Reason: {}", match_info.reason);
+            eprintln!("Component: {}", change.name);
+            eprintln!("  Score: {:.2} ({})", match_info.score, match_info.method);
+            eprintln!("  Reason: {}", match_info.reason);
             if !match_info.score_breakdown.is_empty() {
-                println!("  Score breakdown:");
+                eprintln!("  Score breakdown:");
                 for component in &match_info.score_breakdown {
-                    println!(
+                    eprintln!(
                         "    - {}: {:.2} x {:.2} = {:.2}",
                         component.name,
                         component.raw_score,
@@ -229,17 +271,19 @@ fn print_match_explanations(result: &DiffResult) {
                 }
             }
             if !match_info.normalizations.is_empty() {
-                println!("  Normalizations: {}", match_info.normalizations.join(", "));
+                eprintln!("  Normalizations: {}", match_info.normalizations.join(", "));
             }
-            println!();
+            eprintln!();
         }
     }
 }
 
-/// Print threshold recommendation based on SBOMs to stdout.
+/// Print threshold recommendation based on SBOMs to STDERR.
 ///
-/// Uses `println!()` intentionally — this is user-facing CLI diagnostic output
-/// triggered by `--recommend-threshold`, not a log message.
+/// This is user-facing CLI diagnostic output triggered by
+/// `--recommend-threshold`. It must go to stderr: the report itself (including
+/// `-o json`/`sarif`/`csv`) is written to stdout, and interleaving this block
+/// there corrupts machine-parseable output.
 fn print_threshold_recommendation(
     old_sbom: &NormalizedSbom,
     new_sbom: &NormalizedSbom,
@@ -251,22 +295,78 @@ fn print_threshold_recommendation(
     let matcher = FuzzyMatcher::new(fuzzy_config);
 
     let recommendation = adaptive.compute_threshold(old_sbom, new_sbom, &matcher);
-    println!("\n=== Threshold Recommendation ===\n");
-    println!("Recommended threshold: {:.2}", recommendation.threshold);
-    println!("Confidence: {:.0}%", recommendation.confidence * 100.0);
-    println!("Method used: {:?}", recommendation.method);
-    println!("Samples analyzed: {}", recommendation.samples);
-    println!(
+    eprintln!("\n=== Threshold Recommendation ===\n");
+    eprintln!("Recommended threshold: {:.2}", recommendation.threshold);
+    eprintln!("Confidence: {:.0}%", recommendation.confidence * 100.0);
+    eprintln!("Method used: {:?}", recommendation.method);
+    eprintln!("Samples analyzed: {}", recommendation.samples);
+    eprintln!(
         "Match ratio at threshold: {:.1}%",
         recommendation.match_ratio * 100.0
     );
-    println!("\nScore distribution:");
-    println!("  Mean: {:.3}", recommendation.score_stats.mean);
-    println!("  Std dev: {:.3}", recommendation.score_stats.std_dev);
-    println!("  Median: {:.3}", recommendation.score_stats.median);
-    println!(
+    eprintln!("\nScore distribution:");
+    eprintln!("  Mean: {:.3}", recommendation.score_stats.mean);
+    eprintln!("  Std dev: {:.3}", recommendation.score_stats.std_dev);
+    eprintln!("  Median: {:.3}", recommendation.score_stats.median);
+    eprintln!(
         "  Min: {:.3}, Max: {:.3}",
         recommendation.score_stats.min, recommendation.score_stats.max
     );
-    println!();
+    eprintln!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn filtering(min_severity: Option<&str>) -> FilterConfig {
+        FilterConfig {
+            min_severity: min_severity.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    fn graph(threshold: Option<&str>) -> GraphAwareDiffConfig {
+        GraphAwareDiffConfig {
+            impact_threshold: threshold.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn validate_accepts_known_severity_labels_case_insensitively() {
+        for sev in ["critical", "high", "medium", "low", "HIGH", "Critical"] {
+            validate_post_diff_filters(&filtering(Some(sev)), &graph(None)).unwrap();
+        }
+        // No filters at all is fine.
+        validate_post_diff_filters(&filtering(None), &graph(None)).unwrap();
+    }
+
+    #[test]
+    fn validate_rejects_unknown_severity() {
+        let err = validate_post_diff_filters(&filtering(Some("bogus")), &graph(None)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("--severity"), "{msg}");
+        assert!(msg.contains("bogus"), "{msg}");
+        assert!(msg.contains("critical, high, medium, low"), "{msg}");
+    }
+
+    #[test]
+    fn validate_rejects_unknown_graph_impact_threshold() {
+        // The threshold must be validated even when graph diffing is not
+        // enabled — the old behavior silently coerced unknown labels to
+        // `low`, which is exactly the silent no-op being fixed.
+        let err = validate_post_diff_filters(&filtering(None), &graph(Some("bogus"))).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("--graph-impact-threshold"), "{msg}");
+        assert!(msg.contains("bogus"), "{msg}");
+        assert!(msg.contains("critical, high, medium, low"), "{msg}");
+    }
+
+    #[test]
+    fn validate_accepts_known_graph_impact_thresholds() {
+        for level in ["critical", "high", "medium", "low"] {
+            validate_post_diff_filters(&filtering(None), &graph(Some(level))).unwrap();
+        }
+    }
 }

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -9,7 +9,9 @@ mod output;
 mod parse;
 mod report_stage;
 
-pub use diff_stage::{apply_post_diff_filters, compute_diff, graph_diff_config_from};
+pub use diff_stage::{
+    apply_post_diff_filters, compute_diff, graph_diff_config_from, validate_post_diff_filters,
+};
 pub use enrich::{AggregatedEnrichmentStats, enrich_sbom_full, enrich_sboms};
 pub use output::{OutputTarget, auto_detect_format, should_use_color, write_output};
 pub use parse::{ParsedSbom, STDIN_PATH, is_stdin_path, parse_sbom_with_context, read_input};
@@ -48,6 +50,16 @@ pub enum PipelineError {
 }
 
 /// Exit codes for CI/CD integration
+///
+/// Contract: `0` = success / gate passed, `1` = gate/verdict failure,
+/// `2` = clap usage errors, `3` = ANY operational error (I/O, parse, config,
+/// unsupported output format, invalid flag values) — routed centrally in
+/// `main()` by mapping every `anyhow` error to [`ERROR`]. Command-specific
+/// gates keep their documented codes (diff/view `--fail-on-vuln` = 2,
+/// `--fail-on-vex-gap` = 4, license-check denial = 5, `--fail-on-kev` = 6,
+/// diff ML regression = 7). Command handlers must return errors (or exit
+/// codes) to `main()` rather than calling `process::exit` on error paths, so
+/// operational failures cannot leak out as exit 1.
 pub mod exit_codes {
     /// Success - no changes detected (or --no-fail-on-change)
     pub const SUCCESS: i32 = 0;
@@ -55,7 +67,8 @@ pub mod exit_codes {
     pub const CHANGES_DETECTED: i32 = 1;
     /// Vulnerabilities were introduced
     pub const VULNS_INTRODUCED: i32 = 2;
-    /// An error occurred
+    /// An operational error occurred (I/O, parse, config, invalid flag
+    /// values). `main()` maps every `anyhow` error to this code.
     pub const ERROR: i32 = 3;
     /// Introduced vulnerabilities lack VEX statements (--fail-on-vex-gap)
     pub const VEX_GAPS_FOUND: i32 = 4;

--- a/src/pipeline/output.rs
+++ b/src/pipeline/output.rs
@@ -47,10 +47,13 @@ pub fn auto_detect_format(format: ReportFormat, target: &OutputTarget) -> Report
     }
 }
 
-/// Determine if color should be used based on flags and environment
+/// Determine if color should be used based on flags, environment, and
+/// whether stdout is actually a terminal — piped/redirected output must not
+/// receive ANSI escapes.
 #[must_use]
 pub fn should_use_color(no_color_flag: bool) -> bool {
-    !no_color_flag && std::env::var("NO_COLOR").is_err()
+    use std::io::IsTerminal;
+    !no_color_flag && std::env::var("NO_COLOR").is_err() && std::io::stdout().is_terminal()
 }
 
 /// Write output to the target (stdout or file)
@@ -121,8 +124,11 @@ mod tests {
 
     #[test]
     fn test_should_use_color_without_flag() {
-        // This depends on NO_COLOR env var
-        let expected = std::env::var("NO_COLOR").is_err();
+        // Depends on NO_COLOR and whether the test harness stdout is a
+        // terminal — under `cargo test` stdout is captured (not a TTY), so
+        // color must be off regardless of env.
+        use std::io::IsTerminal;
+        let expected = std::env::var("NO_COLOR").is_err() && std::io::stdout().is_terminal();
         assert_eq!(should_use_color(false), expected);
     }
 }

--- a/src/pipeline/report_stage.rs
+++ b/src/pipeline/report_stage.rs
@@ -46,8 +46,8 @@ pub fn output_report(
     // sarif` renders the same sidecar-driven verdicts as the interactive TUI.
     let (old_cra, new_cra) = if !use_streaming && format_uses_compliance(effective_output) {
         (
-            Some(cra_phase2_check(&config.paths.old, old_sbom)),
-            Some(cra_phase2_check(&config.paths.new, new_sbom)),
+            Some(cra_phase2_check(&config.paths.old, old_sbom)?),
+            Some(cra_phase2_check(&config.paths.new, new_sbom)?),
         )
     } else {
         (None, None)
@@ -88,8 +88,11 @@ pub fn output_report(
 /// Auto-discover the CRA sidecar adjacent to an SBOM path.
 ///
 /// Looks for `<sbom>.cra.{json,yaml,yml}` (and the `-cra.*` / inner-stem
-/// variants handled by [`CraSidecarMetadata::find_for_sbom`]) next to the
+/// variants handled by [`CraSidecarMetadata::discover_for_sbom`]) next to the
 /// SBOM. Stdin (`-`) has no adjacent file, so it never resolves a sidecar.
+/// A discovered-but-invalid sidecar is a hard error, matching the explicit
+/// `--cra-sidecar` contract — the trust decision must not depend on how the
+/// file was found.
 ///
 /// The `diff` command has no `--cra-sidecar` / `--cra-product-class` flags, so
 /// auto-discovery is the only sidecar channel for diffs; the sidecar's own
@@ -97,16 +100,16 @@ pub fn output_report(
 /// Shared by the diff TUI path (`cli/diff.rs`) and this report stage so both
 /// resolve sidecars identically.
 ///
-/// [`CraSidecarMetadata::find_for_sbom`]: crate::model::CraSidecarMetadata::find_for_sbom
+/// [`CraSidecarMetadata::discover_for_sbom`]: crate::model::CraSidecarMetadata::discover_for_sbom
 /// [`ComplianceChecker::effective_product_class`]: crate::quality::ComplianceChecker::effective_product_class
-#[must_use]
 pub fn discover_cra_sidecar(
     sbom_path: &std::path::Path,
-) -> Option<crate::model::CraSidecarMetadata> {
+) -> Result<Option<crate::model::CraSidecarMetadata>> {
     if super::is_stdin_path(sbom_path) {
-        None
+        Ok(None)
     } else {
-        crate::model::CraSidecarMetadata::find_for_sbom(sbom_path)
+        crate::model::CraSidecarMetadata::discover_for_sbom(sbom_path)
+            .map_err(|e| anyhow::anyhow!("Failed to load auto-discovered CRA sidecar: {e}"))
     }
 }
 
@@ -118,13 +121,13 @@ pub fn discover_cra_sidecar(
 fn cra_phase2_check(
     sbom_path: &std::path::Path,
     sbom: &NormalizedSbom,
-) -> crate::quality::ComplianceResult {
+) -> Result<crate::quality::ComplianceResult> {
     let mut checker =
         crate::quality::ComplianceChecker::new(crate::quality::ComplianceLevel::CraPhase2);
-    if let Some(sidecar) = discover_cra_sidecar(sbom_path) {
+    if let Some(sidecar) = discover_cra_sidecar(sbom_path)? {
         checker = checker.with_sidecar(sidecar);
     }
-    checker.check(sbom)
+    Ok(checker.check(sbom))
 }
 
 /// Whether a report format renders the pre-computed CRA compliance results.

--- a/src/serialization/enricher.rs
+++ b/src/serialization/enricher.rs
@@ -3,8 +3,9 @@
 //! Injects vulnerability, EOL, and VEX data into the raw SBOM JSON,
 //! producing an enriched SBOM in its original format.
 
-use crate::model::NormalizedSbom;
+use crate::model::{NormalizedSbom, VexJustification, VexState, VexStatus, VulnerabilityRef};
 use serde_json::Value;
+use std::collections::{HashMap, HashSet};
 
 use super::ValueExt;
 
@@ -36,78 +37,316 @@ pub fn enrich_sbom_json(raw_json: &str, sbom: &NormalizedSbom) -> anyhow::Result
     Ok(serde_json::to_string_pretty(&doc)?)
 }
 
+/// The CycloneDX `analysis.state` spelling for a model [`VexState`].
+///
+/// Every emitted string is a valid CycloneDX `impactAnalysisState` AND parses
+/// back to the same model state through the CycloneDX parser (which reads
+/// unknown states as `UnderInvestigation`), so VEX suppression survives a
+/// round-trip. The previous Debug-lowercase spellings ("notaffected",
+/// "underinvestigation") were spec-invalid and round-tripped every state to
+/// `UnderInvestigation`, resurfacing suppressed CVEs.
+const fn vex_state_cdx_str(state: &VexState) -> &'static str {
+    match state {
+        VexState::NotAffected => "not_affected",
+        VexState::Affected => "exploitable",
+        VexState::Fixed => "resolved",
+        VexState::UnderInvestigation => "in_triage",
+    }
+}
+
+/// The CycloneDX `analysis.justification` spelling for a model
+/// [`VexJustification`]. Each string round-trips through the parser; the model
+/// has no CycloneDX-native `component_not_present`, so `ComponentNotPresent`
+/// emits the closest valid claim (`code_not_present`).
+const fn vex_justification_cdx_str(justification: &VexJustification) -> &'static str {
+    match justification {
+        VexJustification::ComponentNotPresent | VexJustification::VulnerableCodeNotPresent => {
+            "code_not_present"
+        }
+        VexJustification::VulnerableCodeNotInExecutePath => "code_not_reachable",
+        VexJustification::VulnerableCodeCannotBeControlledByAdversary => "requires_configuration",
+        VexJustification::InlineMitigationsAlreadyExist => "protected_by_mitigating_control",
+    }
+}
+
+/// Mirror of the CycloneDX parser's `analysis.state` reading (see
+/// `parsers/cyclonedx.rs`), used to decide whether an existing entry's state
+/// already expresses the model's status. When it does, the input spelling
+/// (e.g. `false_positive`) is preserved verbatim instead of being rewritten.
+fn parse_cdx_analysis_state(state: Option<&str>) -> VexState {
+    match state {
+        Some("not_affected" | "false_positive") => VexState::NotAffected,
+        Some("affected" | "exploitable") => VexState::Affected,
+        Some("fixed" | "resolved" | "resolved_with_pedigree") => VexState::Fixed,
+        _ => VexState::UnderInvestigation,
+    }
+}
+
+/// Build a CycloneDX `analysis` object from a model VEX status.
+fn build_cdx_analysis(vex: &VexStatus) -> Value {
+    let mut analysis = serde_json::json!({
+        "state": vex_state_cdx_str(&vex.status),
+    });
+    if let Some(justification) = &vex.justification {
+        analysis["justification"] = Value::String(vex_justification_cdx_str(justification).into());
+    }
+    analysis
+}
+
+/// KEV / EPSS overlay properties for a vulnerability, surfaced so the enriched
+/// output SBOM actually carries the data the `--kev` / `--epss` flags produced
+/// (it would otherwise be dropped on serialization).
+fn enrichment_properties(vuln: &VulnerabilityRef) -> Vec<Value> {
+    let mut props = Vec::new();
+    if vuln.is_kev {
+        props.push(serde_json::json!({
+            "name": "sbom-tools:kev",
+            "value": "true",
+        }));
+        if let Some(kev) = &vuln.kev_info {
+            props.push(serde_json::json!({
+                "name": "sbom-tools:kev:ransomware",
+                "value": kev.known_ransomware_use.to_string(),
+            }));
+        }
+    }
+    if let Some(score) = vuln.epss_score {
+        props.push(serde_json::json!({
+            "name": "sbom-tools:epss:score",
+            "value": score.to_string(),
+        }));
+    }
+    props
+}
+
+/// A vulnerability aggregated across every component it affects, with the
+/// bom-ref to emit per component plus that component's other identifiers
+/// (name, purl) for the "already referenced?" check.
+struct AggregatedVuln<'a> {
+    vuln: &'a VulnerabilityRef,
+    /// `(bom-ref to emit, all identifiers of that component)`
+    targets: Vec<(String, Vec<String>)>,
+}
+
 /// Inject vulnerability data into CycloneDX format.
 ///
-/// Adds/updates the top-level `vulnerabilities` array.
+/// MERGES into the input's own `vulnerabilities` array: every field of a
+/// pre-existing entry (cwes, source, CVSS score/vector/method,
+/// `affects[].versions`, ...) is preserved verbatim, and only data enrichment
+/// actually added is appended or patched in. The previous implementation
+/// rebuilt the array from the minimal normalized model, silently dropping
+/// everything the model doesn't carry.
 fn inject_cyclonedx_vulns(doc: &mut Value, sbom: &NormalizedSbom) {
-    let mut vulns = Vec::new();
+    // Aggregate model vulnerabilities by id: a vulnerability shared by N
+    // components becomes ONE entry with N affects refs, not N duplicates.
+    let mut aggs: Vec<(String, AggregatedVuln)> = Vec::new();
+    let mut agg_index: HashMap<String, usize> = HashMap::new();
 
     for comp in sbom.components.values() {
+        let emit_ref = if comp.identifiers.format_id.is_empty() {
+            comp.name.clone()
+        } else {
+            comp.identifiers.format_id.clone()
+        };
+        let mut aliases = vec![emit_ref.clone(), comp.name.clone()];
+        if let Some(purl) = &comp.identifiers.purl {
+            aliases.push(purl.clone());
+        }
+
         for vuln in &comp.vulnerabilities {
-            let mut vuln_obj = serde_json::json!({
-                "id": vuln.id,
+            let idx = *agg_index.entry(vuln.id.clone()).or_insert_with(|| {
+                aggs.push((
+                    vuln.id.clone(),
+                    AggregatedVuln {
+                        vuln,
+                        targets: Vec::new(),
+                    },
+                ));
+                aggs.len() - 1
             });
-
-            if let Some(desc) = &vuln.description {
-                vuln_obj["description"] = Value::String(desc.clone());
+            let agg = &mut aggs[idx].1;
+            // Prefer an occurrence that carries a VEX status so `--vex`
+            // overlays are never lost to per-component clone ordering.
+            if agg.vuln.vex_status.is_none() && vuln.vex_status.is_some() {
+                agg.vuln = vuln;
             }
-
-            if let Some(severity) = &vuln.severity {
-                vuln_obj["ratings"] = serde_json::json!([{
-                    "severity": format!("{severity:?}").to_lowercase(),
-                }]);
+            if !agg.targets.iter().any(|(r, _)| r == &emit_ref) {
+                agg.targets.push((emit_ref.clone(), aliases.clone()));
             }
+        }
+    }
 
-            // Link to affected component via bom-ref
-            let bom_ref = if comp.identifiers.format_id.is_empty() {
-                &comp.name
-            } else {
-                &comp.identifiers.format_id
-            };
-            vuln_obj["affects"] = serde_json::json!([{
-                "ref": bom_ref,
-            }]);
+    // Start from the input's own vulnerabilities array (verbatim baseline).
+    let mut vulns: Vec<Value> = doc
+        .get("vulnerabilities")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let index_by_id: HashMap<String, usize> = vulns
+        .iter()
+        .enumerate()
+        .filter_map(|(i, v)| {
+            v.get("id")
+                .and_then(Value::as_str)
+                .map(|id| (id.to_string(), i))
+        })
+        .collect();
 
-            if let Some(vex) = &vuln.vex_status {
-                vuln_obj["analysis"] = serde_json::json!({
-                    "state": format!("{:?}", vex.status).to_lowercase(),
-                });
-            }
-
-            // Surface KEV / EPSS overlays as vulnerability properties so the
-            // enriched output SBOM actually carries the data the `--kev` /
-            // `--epss` flags produced (it would otherwise be dropped on
-            // serialization).
-            let mut props = Vec::new();
-            if vuln.is_kev {
-                props.push(serde_json::json!({
-                    "name": "sbom-tools:kev",
-                    "value": "true",
-                }));
-                if let Some(kev) = &vuln.kev_info {
-                    props.push(serde_json::json!({
-                        "name": "sbom-tools:kev:ransomware",
-                        "value": kev.known_ransomware_use.to_string(),
-                    }));
-                }
-            }
-            if let Some(score) = vuln.epss_score {
-                props.push(serde_json::json!({
-                    "name": "sbom-tools:epss:score",
-                    "value": score.to_string(),
-                }));
-            }
-            if !props.is_empty() {
-                vuln_obj["properties"] = Value::Array(props);
-            }
-
-            vulns.push(vuln_obj);
+    for (id, agg) in &aggs {
+        if let Some(&i) = index_by_id.get(id) {
+            patch_existing_vuln(&mut vulns[i], agg);
+        } else {
+            vulns.push(build_new_vuln(id, agg));
         }
     }
 
     if !vulns.is_empty() {
         doc["vulnerabilities"] = Value::Array(vulns);
     }
+}
+
+/// Patch enrichment data into a pre-existing vulnerability entry without
+/// disturbing anything the input already declared.
+fn patch_existing_vuln(entry: &mut Value, agg: &AggregatedVuln) {
+    let vuln = agg.vuln;
+    let Some(obj) = entry.as_object_mut() else {
+        return;
+    };
+
+    // Fill description / ratings only when absent — never overwrite.
+    if !obj.contains_key("description")
+        && let Some(desc) = &vuln.description
+    {
+        obj.insert("description".into(), Value::String(desc.clone()));
+    }
+    if !obj.contains_key("ratings")
+        && let Some(severity) = &vuln.severity
+    {
+        obj.insert(
+            "ratings".into(),
+            serde_json::json!([{
+                "severity": format!("{severity:?}").to_lowercase(),
+            }]),
+        );
+    }
+
+    // Append affects refs only for components not already referenced by ANY
+    // of their identifiers (bom-ref, name, purl) — existing entries (and
+    // their `versions`) are left untouched.
+    let existing_refs: HashSet<String> = obj
+        .get("affects")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|a| a.get("ref").and_then(Value::as_str))
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default();
+    let missing: Vec<&String> = agg
+        .targets
+        .iter()
+        .filter(|(_, aliases)| !aliases.iter().any(|alias| existing_refs.contains(alias)))
+        .map(|(emit_ref, _)| emit_ref)
+        .collect();
+    if !missing.is_empty()
+        && let Some(affects) = obj
+            .entry("affects")
+            .or_insert_with(|| Value::Array(Vec::new()))
+            .as_array_mut()
+    {
+        for r in missing {
+            affects.push(serde_json::json!({ "ref": r }));
+        }
+    }
+
+    // Analysis: insert when absent; when present, rewrite the state only if
+    // enrichment actually changed the parsed status (e.g. a `--vex` overlay),
+    // so the input's own spelling ("false_positive", ...) round-trips.
+    if let Some(vex) = &vuln.vex_status {
+        match obj.get_mut("analysis") {
+            None => {
+                obj.insert("analysis".into(), build_cdx_analysis(vex));
+            }
+            Some(analysis) => {
+                let current =
+                    parse_cdx_analysis_state(analysis.get("state").and_then(Value::as_str));
+                if current != vex.status {
+                    analysis["state"] = Value::String(vex_state_cdx_str(&vex.status).into());
+                    if let Some(justification) = &vex.justification {
+                        analysis["justification"] =
+                            Value::String(vex_justification_cdx_str(justification).into());
+                    }
+                }
+            }
+        }
+    }
+
+    // KEV / EPSS overlay properties — append only those not already present.
+    let new_props = enrichment_properties(vuln);
+    if new_props.is_empty() {
+        return;
+    }
+    let existing_names: HashSet<String> = obj
+        .get("properties")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|p| p.get("name").and_then(Value::as_str))
+                .map(String::from)
+                .collect()
+        })
+        .unwrap_or_default();
+    let to_add: Vec<Value> = new_props
+        .into_iter()
+        .filter(|p| {
+            p.get("name")
+                .and_then(Value::as_str)
+                .is_none_or(|n| !existing_names.contains(n))
+        })
+        .collect();
+    if !to_add.is_empty()
+        && let Some(props) = obj
+            .entry("properties")
+            .or_insert_with(|| Value::Array(Vec::new()))
+            .as_array_mut()
+    {
+        props.extend(to_add);
+    }
+}
+
+/// Build a brand-new vulnerability entry for data enrichment discovered.
+fn build_new_vuln(id: &str, agg: &AggregatedVuln) -> Value {
+    let vuln = agg.vuln;
+    let mut vuln_obj = serde_json::json!({ "id": id });
+
+    if let Some(desc) = &vuln.description {
+        vuln_obj["description"] = Value::String(desc.clone());
+    }
+
+    if let Some(severity) = &vuln.severity {
+        vuln_obj["ratings"] = serde_json::json!([{
+            "severity": format!("{severity:?}").to_lowercase(),
+        }]);
+    }
+
+    let affects: Vec<Value> = agg
+        .targets
+        .iter()
+        .map(|(emit_ref, _)| serde_json::json!({ "ref": emit_ref }))
+        .collect();
+    vuln_obj["affects"] = Value::Array(affects);
+
+    if let Some(vex) = &vuln.vex_status {
+        vuln_obj["analysis"] = build_cdx_analysis(vex);
+    }
+
+    let props = enrichment_properties(vuln);
+    if !props.is_empty() {
+        vuln_obj["properties"] = Value::Array(props);
+    }
+
+    vuln_obj
 }
 
 /// Inject EOL data as properties on CycloneDX components.
@@ -222,5 +461,213 @@ mod tests {
         let sbom = NormalizedSbom::default();
         let result = enrich_sbom_json(raw, &sbom).unwrap();
         assert!(result.contains("spdxVersion"));
+    }
+
+    /// A no-flag enrich run (model parsed straight from the input) must
+    /// preserve every pre-existing vulnerability field verbatim: cwes,
+    /// source, CVSS score/vector/method, affects[].versions.
+    #[test]
+    fn enrich_preserves_existing_vuln_fields_verbatim() {
+        let raw = r#"{
+            "bomFormat": "CycloneDX", "specVersion": "1.5", "version": 1,
+            "components": [
+                {"bom-ref": "pkg-a", "type": "library", "name": "pkg-a",
+                 "version": "1.0.0", "purl": "pkg:npm/pkg-a@1.0.0"}
+            ],
+            "vulnerabilities": [{
+                "id": "CVE-2024-0001",
+                "source": {"name": "NVD", "url": "https://nvd.example/CVE-2024-0001"},
+                "description": "A bad bug",
+                "cwes": [79, 89],
+                "ratings": [{"severity": "high", "score": 8.1, "method": "CVSSv31",
+                             "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:N"}],
+                "affects": [{"ref": "pkg-a",
+                             "versions": [{"version": "1.0.0", "status": "affected"}]}]
+            }]
+        }"#;
+        let sbom = crate::parsers::parse_sbom_str(raw).unwrap();
+        let enriched = enrich_sbom_json(raw, &sbom).unwrap();
+
+        let input: Value = serde_json::from_str(raw).unwrap();
+        let output: Value = serde_json::from_str(&enriched).unwrap();
+        assert_eq!(
+            output["vulnerabilities"], input["vulnerabilities"],
+            "no-flag enrichment must not alter pre-existing vulnerability entries"
+        );
+    }
+
+    /// `--vex` suppression must survive a round-trip: the emitted
+    /// analysis.state must be a spelling the parser reads back as the same
+    /// state (the old Debug-lowercase "notaffected" parsed as
+    /// UnderInvestigation, resurfacing suppressed CVEs).
+    #[test]
+    fn enrich_vex_states_round_trip_through_parser() {
+        use crate::model::{Component, VulnerabilitySource};
+
+        let states = [
+            (VexState::NotAffected, "not_affected"),
+            (VexState::Affected, "exploitable"),
+            (VexState::Fixed, "resolved"),
+            (VexState::UnderInvestigation, "in_triage"),
+        ];
+        for (state, expected) in states {
+            let raw = r#"{
+                "bomFormat": "CycloneDX", "specVersion": "1.5", "version": 1,
+                "components": [{"bom-ref": "c", "type": "library", "name": "c", "version": "1.0"}]
+            }"#;
+            let mut sbom = crate::parsers::parse_sbom_str(raw).unwrap();
+            let vuln = VulnerabilityRef::new("CVE-1".into(), VulnerabilitySource::Cve)
+                .with_vex_status(VexStatus::new(state.clone()));
+            sbom.components.values_mut().for_each(|c: &mut Component| {
+                c.vulnerabilities.push(vuln.clone());
+            });
+
+            let enriched = enrich_sbom_json(raw, &sbom).unwrap();
+            let doc: Value = serde_json::from_str(&enriched).unwrap();
+            assert_eq!(
+                doc["vulnerabilities"][0]["analysis"]["state"],
+                Value::String(expected.into()),
+                "emitted state must be the CycloneDX spec spelling"
+            );
+
+            let reparsed = crate::parsers::parse_sbom_str(&enriched).unwrap();
+            let comp = reparsed.components.values().next().unwrap();
+            assert_eq!(
+                comp.vulnerabilities[0]
+                    .vex_status
+                    .as_ref()
+                    .expect("vex status must survive round-trip")
+                    .status,
+                state,
+                "state must parse back to the same model state"
+            );
+        }
+    }
+
+    /// Justification must be emitted alongside the state and round-trip.
+    #[test]
+    fn enrich_vex_justification_round_trips() {
+        use crate::model::{Component, VulnerabilitySource};
+
+        let raw = r#"{
+            "bomFormat": "CycloneDX", "specVersion": "1.5", "version": 1,
+            "components": [{"bom-ref": "c", "type": "library", "name": "c", "version": "1.0"}]
+        }"#;
+        let mut sbom = crate::parsers::parse_sbom_str(raw).unwrap();
+        let mut vex = VexStatus::new(VexState::NotAffected);
+        vex.justification = Some(VexJustification::VulnerableCodeNotInExecutePath);
+        let vuln =
+            VulnerabilityRef::new("CVE-1".into(), VulnerabilitySource::Cve).with_vex_status(vex);
+        sbom.components.values_mut().for_each(|c: &mut Component| {
+            c.vulnerabilities.push(vuln.clone());
+        });
+
+        let enriched = enrich_sbom_json(raw, &sbom).unwrap();
+        let doc: Value = serde_json::from_str(&enriched).unwrap();
+        assert_eq!(
+            doc["vulnerabilities"][0]["analysis"]["justification"],
+            Value::String("code_not_reachable".into()),
+        );
+
+        let reparsed = crate::parsers::parse_sbom_str(&enriched).unwrap();
+        let comp = reparsed.components.values().next().unwrap();
+        assert_eq!(
+            comp.vulnerabilities[0]
+                .vex_status
+                .as_ref()
+                .unwrap()
+                .justification,
+            Some(VexJustification::VulnerableCodeNotInExecutePath),
+        );
+    }
+
+    /// A VEX overlay that CHANGES the status of a pre-existing entry must
+    /// rewrite analysis.state (while an unchanged status leaves the input's
+    /// own spelling alone — covered by the verbatim test above, where
+    /// "false_positive" style spellings are preserved).
+    #[test]
+    fn enrich_vex_overlay_updates_existing_analysis() {
+        let raw = r#"{
+            "bomFormat": "CycloneDX", "specVersion": "1.5", "version": 1,
+            "components": [{"bom-ref": "c", "type": "library", "name": "c", "version": "1.0"}],
+            "vulnerabilities": [{
+                "id": "CVE-1",
+                "affects": [{"ref": "c"}],
+                "analysis": {"state": "exploitable"}
+            }]
+        }"#;
+        let mut sbom = crate::parsers::parse_sbom_str(raw).unwrap();
+        // Simulate a --vex overlay flipping the status to not_affected.
+        for comp in sbom.components.values_mut() {
+            for vuln in &mut comp.vulnerabilities {
+                vuln.vex_status = Some(VexStatus::new(VexState::NotAffected));
+            }
+        }
+
+        let enriched = enrich_sbom_json(raw, &sbom).unwrap();
+        let doc: Value = serde_json::from_str(&enriched).unwrap();
+        assert_eq!(
+            doc["vulnerabilities"][0]["analysis"]["state"],
+            Value::String("not_affected".into()),
+        );
+    }
+
+    /// New vulnerabilities from enrichment are appended (deduped by id across
+    /// components), and existing entries gain affects refs for newly-found
+    /// components without their original affects entries being touched.
+    #[test]
+    fn enrich_appends_new_vulns_and_patches_affects() {
+        use crate::model::VulnerabilitySource;
+
+        let raw = r#"{
+            "bomFormat": "CycloneDX", "specVersion": "1.5", "version": 1,
+            "components": [
+                {"bom-ref": "a", "type": "library", "name": "a", "version": "1.0"},
+                {"bom-ref": "b", "type": "library", "name": "b", "version": "2.0"}
+            ],
+            "vulnerabilities": [{
+                "id": "CVE-1",
+                "affects": [{"ref": "a", "versions": [{"version": "1.0", "status": "affected"}]}]
+            }]
+        }"#;
+        let mut sbom = crate::parsers::parse_sbom_str(raw).unwrap();
+        // Simulate enrichment: CVE-1 also affects b; CVE-2 is newly found on
+        // both components.
+        for comp in sbom.components.values_mut() {
+            if comp.name == "b" {
+                comp.vulnerabilities.push(VulnerabilityRef::new(
+                    "CVE-1".into(),
+                    VulnerabilitySource::Cve,
+                ));
+            }
+            comp.vulnerabilities.push(VulnerabilityRef::new(
+                "CVE-2".into(),
+                VulnerabilitySource::Cve,
+            ));
+        }
+
+        let enriched = enrich_sbom_json(raw, &sbom).unwrap();
+        let doc: Value = serde_json::from_str(&enriched).unwrap();
+        let vulns = doc["vulnerabilities"].as_array().unwrap();
+        assert_eq!(vulns.len(), 2, "CVE-2 appended once, not per-component");
+
+        let cve1 = vulns.iter().find(|v| v["id"] == "CVE-1").unwrap();
+        let affects = cve1["affects"].as_array().unwrap();
+        assert_eq!(affects.len(), 2);
+        assert_eq!(
+            affects[0]["versions"][0]["version"],
+            Value::String("1.0".into()),
+            "original affects entry (with versions) preserved verbatim"
+        );
+        assert_eq!(affects[1]["ref"], Value::String("b".into()));
+
+        let cve2 = vulns.iter().find(|v| v["id"] == "CVE-2").unwrap();
+        let refs: Vec<&str> = cve2["affects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|a| a["ref"].as_str())
+            .collect();
+        assert_eq!(refs, vec!["a", "b"]);
     }
 }

--- a/src/serialization/merger.rs
+++ b/src/serialization/merger.rs
@@ -5,7 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use super::ValueExt;
 
@@ -79,12 +79,16 @@ pub fn merge_sbom_json(
         return Err(MergeError::FormatMismatch);
     }
 
+    // SPDX 2.x and SPDX 3.0 are incompatible in BOTH directions. The old
+    // check only caught SPDX3-primary + SPDX2-secondary; the reverse silently
+    // emitted the primary unchanged.
+    if primary_is_spdx3 != secondary_is_spdx3 {
+        return Err(MergeError::SpdxVersionMismatch);
+    }
+
     if primary_is_cdx {
         merge_cyclonedx(&mut primary, &secondary, config)?;
     } else if primary_is_spdx3 {
-        if !secondary_is_spdx3 {
-            return Err(MergeError::SpdxVersionMismatch);
-        }
         merge_spdx3(&mut primary, &secondary, config)?;
     } else {
         merge_spdx2(&mut primary, &secondary, config)?;
@@ -98,11 +102,12 @@ fn merge_cyclonedx(
     secondary: &Value,
     config: &MergeConfig,
 ) -> Result<(), MergeError> {
-    let primary_components = primary.get_mut("components").and_then(Value::as_array_mut);
-
-    let secondary_components = secondary.get("components").and_then(Value::as_array);
-
-    if let (Some(p_comps), Some(s_comps)) = (primary_components, secondary_components) {
+    // The primary may legitimately lack a `components` array (metadata-only
+    // shell document): create it from the secondary rather than silently
+    // dropping every secondary component.
+    if let Some(s_comps) = secondary.get("components").and_then(Value::as_array)
+        && let Some(p_comps) = ensure_array(primary, "components")
+    {
         if config.dedup_strategy == DeduplicationStrategy::None {
             // No deduplication — keep all components
             for comp in s_comps {
@@ -123,13 +128,9 @@ fn merge_cyclonedx(
     }
 
     // Merge dependencies
-    let primary_deps = primary
-        .get_mut("dependencies")
-        .and_then(Value::as_array_mut);
-
-    let secondary_deps = secondary.get("dependencies").and_then(Value::as_array);
-
-    if let (Some(p_deps), Some(s_deps)) = (primary_deps, secondary_deps) {
+    if let Some(s_deps) = secondary.get("dependencies").and_then(Value::as_array)
+        && let Some(p_deps) = ensure_array(primary, "dependencies")
+    {
         let existing_refs: HashSet<String> = p_deps
             .iter()
             .filter_map(|d| d.get("ref").and_then(Value::as_str).map(String::from))
@@ -143,10 +144,123 @@ fn merge_cyclonedx(
         }
     }
 
-    // Merge vulnerabilities
-    merge_array_field(primary, secondary, "vulnerabilities");
+    // Merge vulnerabilities, deduplicating by id (affects refs are unioned)
+    merge_vulnerabilities(primary, secondary);
 
     Ok(())
+}
+
+/// Get a mutable reference to `primary[field]` as an array, creating an empty
+/// array when the field is absent. Returns `None` only when `primary` is not
+/// an object or the existing field is not an array.
+fn ensure_array<'a>(primary: &'a mut Value, field: &str) -> Option<&'a mut Vec<Value>> {
+    primary.as_object_mut().and_then(|o| {
+        o.entry(field)
+            .or_insert_with(|| Value::Array(Vec::new()))
+            .as_array_mut()
+    })
+}
+
+/// Merge the secondary's `vulnerabilities` into the primary, deduplicating by
+/// vulnerability id. When both documents carry the same id, the entries are
+/// merged by unioning `affects` refs (the primary's entry wins for every
+/// other field). Entries without an id cannot be identified and are appended.
+fn merge_vulnerabilities(primary: &mut Value, secondary: &Value) {
+    let Some(s_vulns) = secondary.get("vulnerabilities").and_then(Value::as_array) else {
+        return;
+    };
+    if s_vulns.is_empty() {
+        return;
+    }
+    let Some(p_vulns) = ensure_array(primary, "vulnerabilities") else {
+        return;
+    };
+
+    let mut index_by_id: HashMap<String, usize> = p_vulns
+        .iter()
+        .enumerate()
+        .filter_map(|(i, v)| {
+            v.get("id")
+                .and_then(Value::as_str)
+                .map(|id| (id.to_string(), i))
+        })
+        .collect();
+
+    for vuln in s_vulns {
+        let id = vuln.str_field("id");
+        if id.is_empty() {
+            p_vulns.push(vuln.clone());
+            continue;
+        }
+        if let Some(&i) = index_by_id.get(id) {
+            // Union affects refs into the primary's entry.
+            let Some(s_affects) = vuln.get("affects").and_then(Value::as_array) else {
+                continue;
+            };
+            let Some(existing) = p_vulns[i].as_object_mut() else {
+                continue;
+            };
+            let existing_refs: HashSet<String> = existing
+                .get("affects")
+                .and_then(Value::as_array)
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|a| a.get("ref").and_then(Value::as_str))
+                        .map(String::from)
+                        .collect()
+                })
+                .unwrap_or_default();
+            let to_add: Vec<Value> = s_affects
+                .iter()
+                .filter(|a| {
+                    a.get("ref")
+                        .and_then(Value::as_str)
+                        .is_none_or(|r| !existing_refs.contains(r))
+                })
+                .cloned()
+                .collect();
+            if !to_add.is_empty()
+                && let Some(affects) = existing
+                    .entry("affects")
+                    .or_insert_with(|| Value::Array(Vec::new()))
+                    .as_array_mut()
+            {
+                affects.extend(to_add);
+            }
+        } else {
+            index_by_id.insert(id.to_string(), p_vulns.len());
+            p_vulns.push(vuln.clone());
+        }
+    }
+}
+
+/// Merge the secondary's SPDX `relationships` into the primary, deduplicating
+/// by the `(relationshipType, spdxElementId, relatedSpdxElement)` triple.
+fn merge_relationships(primary: &mut Value, secondary: &Value) {
+    let Some(s_rels) = secondary.get("relationships").and_then(Value::as_array) else {
+        return;
+    };
+    if s_rels.is_empty() {
+        return;
+    }
+    let Some(p_rels) = ensure_array(primary, "relationships") else {
+        return;
+    };
+
+    fn rel_key(rel: &Value) -> (String, String, String) {
+        (
+            rel.str_field("relationshipType").to_string(),
+            rel.str_field("spdxElementId").to_string(),
+            rel.str_field("relatedSpdxElement").to_string(),
+        )
+    }
+
+    let mut seen: HashSet<(String, String, String)> = p_rels.iter().map(rel_key).collect();
+    for rel in s_rels {
+        if seen.insert(rel_key(rel)) {
+            p_rels.push(rel.clone());
+        }
+    }
 }
 
 fn merge_spdx3(
@@ -159,7 +273,6 @@ fn merge_spdx3(
     } else {
         "@graph"
     };
-    let primary_elements = primary.get_mut(primary_key).and_then(Value::as_array_mut);
 
     let secondary_key = if secondary.get("element").is_some() {
         "element"
@@ -168,7 +281,9 @@ fn merge_spdx3(
     };
     let secondary_elements = secondary.get(secondary_key).and_then(Value::as_array);
 
-    if let (Some(p_elems), Some(s_elems)) = (primary_elements, secondary_elements) {
+    if let Some(s_elems) = secondary_elements
+        && let Some(p_elems) = ensure_array(primary, primary_key)
+    {
         let mut seen: HashSet<String> = p_elems
             .iter()
             .filter_map(|e| e.get("spdxId").and_then(Value::as_str).map(String::from))
@@ -200,11 +315,10 @@ fn merge_spdx2(
     secondary: &Value,
     config: &MergeConfig,
 ) -> Result<(), MergeError> {
-    // Merge packages
-    if let (Some(p_pkgs), Some(s_pkgs)) = (
-        primary.get_mut("packages").and_then(Value::as_array_mut),
-        secondary.get("packages").and_then(Value::as_array),
-    ) {
+    // Merge packages (creating the array when the primary lacks one)
+    if let Some(s_pkgs) = secondary.get("packages").and_then(Value::as_array)
+        && let Some(p_pkgs) = ensure_array(primary, "packages")
+    {
         if config.dedup_strategy == DeduplicationStrategy::None {
             for pkg in s_pkgs {
                 p_pkgs.push(pkg.clone());
@@ -220,8 +334,8 @@ fn merge_spdx2(
         }
     }
 
-    // Merge relationships
-    merge_array_field(primary, secondary, "relationships");
+    // Merge relationships, deduplicating by (type, source, target)
+    merge_relationships(primary, secondary);
 
     Ok(())
 }
@@ -279,22 +393,6 @@ fn name_version_key(comp: &Value) -> String {
     format!("{name}@{version}")
 }
 
-/// Merge an array field from secondary into primary (append new entries)
-fn merge_array_field(primary: &mut Value, secondary: &Value, field: &str) {
-    if let Some(s_arr) = secondary.get(field).and_then(Value::as_array) {
-        let p_arr = primary.as_object_mut().and_then(|o| {
-            o.entry(field)
-                .or_insert_with(|| Value::Array(Vec::new()))
-                .as_array_mut()
-        });
-        if let Some(p) = p_arr {
-            for item in s_arr {
-                p.push(item.clone());
-            }
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -343,6 +441,106 @@ mod tests {
         let components = doc["components"].as_array().unwrap();
         // None strategy keeps all components, including duplicates
         assert_eq!(components.len(), 2);
+    }
+
+    /// A metadata-only primary (no `components` array) must still receive
+    /// every secondary component.
+    #[test]
+    fn merge_creates_components_when_primary_lacks_array() {
+        let primary = r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+            "metadata":{"component":{"type":"application","name":"shell"}}}"#;
+        let secondary = r#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[
+            {"name":"foo","version":"1.0"},
+            {"name":"bar","version":"2.0"}
+        ]}"#;
+
+        let result = merge_sbom_json(primary, secondary, &MergeConfig::default()).unwrap();
+        let doc: Value = serde_json::from_str(&result).unwrap();
+        let components = doc["components"].as_array().unwrap();
+        assert_eq!(
+            components.len(),
+            2,
+            "secondary components must not be dropped"
+        );
+    }
+
+    /// SPDX 2.x primary + SPDX 3.0 secondary must error, exactly like the
+    /// reverse direction (it previously emitted the primary unchanged).
+    #[test]
+    fn merge_spdx2_primary_spdx3_secondary_errors() {
+        let spdx2 = r#"{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT","packages":[]}"#;
+        let spdx3 = r#"{"@context":"https://spdx.org/rdf/3.0.1/spdx-context.jsonld","@graph":[]}"#;
+
+        let result = merge_sbom_json(spdx2, spdx3, &MergeConfig::default());
+        assert!(matches!(result, Err(MergeError::SpdxVersionMismatch)));
+
+        // And the reverse direction still errors too.
+        let result = merge_sbom_json(spdx3, spdx2, &MergeConfig::default());
+        assert!(matches!(result, Err(MergeError::SpdxVersionMismatch)));
+    }
+
+    /// Overlapping vulnerabilities are deduplicated by id, with affects refs
+    /// unioned into the primary's entry.
+    #[test]
+    fn merge_dedups_vulnerabilities_by_id_and_unions_affects() {
+        let primary = r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+            "components":[{"bom-ref":"a","name":"a","version":"1.0"}],
+            "vulnerabilities":[{"id":"CVE-1","description":"keep me","affects":[{"ref":"a"}]}]}"#;
+        let secondary = r#"{"bomFormat":"CycloneDX","specVersion":"1.5",
+            "components":[{"bom-ref":"b","name":"b","version":"2.0"}],
+            "vulnerabilities":[
+                {"id":"CVE-1","description":"secondary copy","affects":[{"ref":"a"},{"ref":"b"}]},
+                {"id":"CVE-2","affects":[{"ref":"b"}]}
+            ]}"#;
+
+        let result = merge_sbom_json(primary, secondary, &MergeConfig::default()).unwrap();
+        let doc: Value = serde_json::from_str(&result).unwrap();
+        let vulns = doc["vulnerabilities"].as_array().unwrap();
+        assert_eq!(vulns.len(), 2, "CVE-1 must not be duplicated");
+
+        let cve1 = vulns.iter().find(|v| v["id"] == "CVE-1").unwrap();
+        assert_eq!(cve1["description"], "keep me", "primary entry wins");
+        let refs: Vec<&str> = cve1["affects"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|a| a["ref"].as_str())
+            .collect();
+        assert_eq!(refs, vec!["a", "b"], "affects refs unioned without dupes");
+    }
+
+    /// Overlapping SPDX relationships are deduplicated by
+    /// (type, source, target).
+    #[test]
+    fn merge_dedups_relationships_by_triple() {
+        let primary = r#"{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT",
+            "packages":[{"SPDXID":"SPDXRef-a","name":"a"}],
+            "relationships":[
+                {"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-a"}
+            ]}"#;
+        let secondary = r#"{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT",
+            "packages":[{"SPDXID":"SPDXRef-b","name":"b"}],
+            "relationships":[
+                {"spdxElementId":"SPDXRef-DOCUMENT","relationshipType":"DESCRIBES","relatedSpdxElement":"SPDXRef-a"},
+                {"spdxElementId":"SPDXRef-a","relationshipType":"DEPENDS_ON","relatedSpdxElement":"SPDXRef-b"}
+            ]}"#;
+
+        let result = merge_sbom_json(primary, secondary, &MergeConfig::default()).unwrap();
+        let doc: Value = serde_json::from_str(&result).unwrap();
+        let rels = doc["relationships"].as_array().unwrap();
+        assert_eq!(rels.len(), 2, "duplicate DESCRIBES must be dropped");
+    }
+
+    /// SPDX2 primary without a packages array still receives secondary packages.
+    #[test]
+    fn merge_spdx2_creates_packages_when_primary_lacks_array() {
+        let primary = r#"{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT"}"#;
+        let secondary = r#"{"spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT",
+            "packages":[{"SPDXID":"SPDXRef-a","name":"a"}]}"#;
+
+        let result = merge_sbom_json(primary, secondary, &MergeConfig::default()).unwrap();
+        let doc: Value = serde_json::from_str(&result).unwrap();
+        assert_eq!(doc["packages"].as_array().unwrap().len(), 1);
     }
 
     #[test]

--- a/src/serialization/pruner.rs
+++ b/src/serialization/pruner.rs
@@ -6,6 +6,7 @@
 use crate::model::{LicenseFamily, NormalizedSbom};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::HashSet;
 
 use super::ValueExt;
 
@@ -42,8 +43,11 @@ pub fn tailor_sbom_json(
 ) -> anyhow::Result<String> {
     let mut doc: Value = serde_json::from_str(raw_json)?;
 
-    // Collect component names/IDs to remove
-    let mut remove_ids: Vec<String> = Vec::new();
+    // Canonical identities (bom-ref / SPDXID / spdxId via format_id, plus
+    // purl) of components to remove. NEVER bare names: a same-named component
+    // from another ecosystem must survive (e.g. excluding foo@npm must keep
+    // foo@pypi).
+    let mut removal = RemovalSet::default();
 
     for comp in sbom.components.values() {
         let mut keep = true;
@@ -75,24 +79,26 @@ pub fn tailor_sbom_json(
             }
         }
 
-        // Filter by component type
+        // Filter by component type: accept CycloneDX spec values
+        // ("cryptographic-asset", "machine-learning-model", ...) as well as
+        // the internal Debug spellings, case-insensitively.
         if !config.include_types.is_empty() {
-            let type_str = format!("{:?}", comp.component_type).to_lowercase();
+            let comp_type = normalize_type_token(&comp.component_type.to_string());
             if !config
                 .include_types
                 .iter()
-                .any(|t| t.to_lowercase() == type_str)
+                .any(|t| normalize_type_token(t) == comp_type)
             {
                 keep = false;
             }
         }
 
-        // Filter by name pattern
-        if let Some(pattern) = &config.include_name_pattern {
-            let pattern_lower = pattern.to_lowercase();
-            if !comp.name.to_lowercase().contains(&pattern_lower) {
-                keep = false;
-            }
+        // Filter by name pattern (glob when the pattern contains `*`,
+        // substring otherwise)
+        if let Some(pattern) = &config.include_name_pattern
+            && !name_matches_pattern(&comp.name, pattern)
+        {
+            keep = false;
         }
 
         // Filter by crypto asset type
@@ -113,50 +119,164 @@ pub fn tailor_sbom_json(
         }
 
         if !keep {
-            // Track both format_id and name for removal
-            if !comp.identifiers.format_id.is_empty() {
-                remove_ids.push(comp.identifiers.format_id.clone());
-            }
-            remove_ids.push(comp.name.clone());
+            removal.add(comp);
         }
     }
 
     // Prune from CycloneDX
     if doc.get("bomFormat").is_some() {
-        prune_cyclonedx(&mut doc, &remove_ids, config);
+        prune_cyclonedx(&mut doc, &removal, config);
     } else if doc.get("@context").is_some() {
-        prune_spdx3(&mut doc, &remove_ids, config);
+        prune_spdx3(&mut doc, &removal, config);
     } else {
-        prune_spdx2(&mut doc, &remove_ids, config);
+        prune_spdx2(&mut doc, &removal, config);
     }
 
     Ok(serde_json::to_string_pretty(&doc)?)
 }
 
-fn prune_cyclonedx(doc: &mut Value, remove_ids: &[String], config: &TailorConfig) {
+/// Identities of components selected for removal.
+///
+/// Matching is by canonical identity (format-native id via `format_id`, or
+/// purl) — never bare name alone. A name-based fallback exists ONLY for model
+/// components that carry no distinguishing identity at all, and it is applied
+/// only to raw components that also lack canonical identifiers, so a
+/// same-named component from another ecosystem is never removed collaterally.
+#[derive(Default)]
+struct RemovalSet {
+    /// bom-ref / SPDXID / spdxId (format_id) and purl values
+    ids: HashSet<String>,
+    /// Names of removed components with no identity beyond their name
+    name_fallback: HashSet<String>,
+}
+
+impl RemovalSet {
+    fn add(&mut self, comp: &crate::model::Component) {
+        if !comp.identifiers.format_id.is_empty() {
+            self.ids.insert(comp.identifiers.format_id.clone());
+        }
+        if let Some(purl) = &comp.identifiers.purl {
+            self.ids.insert(purl.clone());
+        }
+        // Parsers fall back to the bare name for format_id when the source
+        // has no native id; only such identity-poor components may use the
+        // name fallback.
+        if comp.identifiers.purl.is_none()
+            && (comp.identifiers.format_id.is_empty() || comp.identifiers.format_id == comp.name)
+        {
+            self.name_fallback.insert(comp.name.clone());
+        }
+    }
+
+    /// Does this raw CycloneDX component match a removed identity?
+    fn matches_cyclonedx(&self, comp: &Value) -> bool {
+        let bom_ref = comp.str_field("bom-ref");
+        let purl = comp.str_field("purl");
+        (!bom_ref.is_empty() && self.ids.contains(bom_ref))
+            || (!purl.is_empty() && self.ids.contains(purl))
+            || (bom_ref.is_empty()
+                && purl.is_empty()
+                && self.name_fallback.contains(comp.str_field("name")))
+    }
+
+    /// Does this raw SPDX 2.x package match a removed identity?
+    fn matches_spdx2(&self, pkg: &Value) -> bool {
+        let spdx_id = pkg.str_field("SPDXID");
+        (!spdx_id.is_empty() && self.ids.contains(spdx_id))
+            || (spdx_id.is_empty() && self.name_fallback.contains(pkg.str_field("name")))
+    }
+
+    /// Does this raw SPDX 3.0 element match a removed identity?
+    fn matches_spdx3(&self, elem: &Value) -> bool {
+        let spdx_id = elem.str_field("spdxId");
+        (!spdx_id.is_empty() && self.ids.contains(spdx_id))
+            || (spdx_id.is_empty() && self.name_fallback.contains(elem.str_field("name")))
+    }
+
+    /// Does a dependency/relationship reference point at a removed identity?
+    fn matches_ref(&self, reference: &str) -> bool {
+        !reference.is_empty() && self.ids.contains(reference)
+    }
+}
+
+/// Match a component name against an `--include-name` pattern.
+///
+/// A pattern containing `*` uses glob semantics (each `*` matches any run of
+/// characters, anchored at both ends); without `*` it is a plain substring
+/// match. Both are case-insensitive. The literal-`*` substring matching this
+/// replaces made the documented `--include-name "my-org/*"` example keep 0
+/// components.
+fn name_matches_pattern(name: &str, pattern: &str) -> bool {
+    let name = name.to_lowercase();
+    let pattern = pattern.to_lowercase();
+
+    if !pattern.contains('*') {
+        return name.contains(&pattern);
+    }
+
+    let segments: Vec<&str> = pattern.split('*').collect();
+    let last = segments.len() - 1;
+    let mut pos = 0usize;
+    for (i, seg) in segments.iter().enumerate() {
+        if seg.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            // No leading `*`: segment is anchored at the start.
+            if !name.starts_with(seg) {
+                return false;
+            }
+            pos = seg.len();
+        } else if i == last {
+            // No trailing `*`: segment is anchored at the end (and must not
+            // overlap already-consumed input).
+            if !name.ends_with(seg) || name.len() - seg.len() < pos {
+                return false;
+            }
+            pos = name.len();
+        } else {
+            // Interior segment: first occurrence at or after `pos`.
+            match name[pos..].find(seg) {
+                Some(idx) => pos = pos + idx + seg.len(),
+                None => return false,
+            }
+        }
+    }
+    true
+}
+
+/// Normalize a component-type token so CycloneDX spec values
+/// ("machine-learning-model"), internal Debug spellings
+/// ("MachineLearningModel"), and the model's Display strings all compare
+/// equal. `cryptographic-asset` (the CycloneDX 1.6 spec value) maps to the
+/// internal `cryptographic`.
+fn normalize_type_token(token: &str) -> String {
+    let normalized: String = token
+        .chars()
+        .filter(|c| *c != '-' && *c != '_')
+        .collect::<String>()
+        .to_lowercase();
+    if normalized == "cryptographicasset" {
+        "cryptographic".to_string()
+    } else {
+        normalized
+    }
+}
+
+fn prune_cyclonedx(doc: &mut Value, removal: &RemovalSet, config: &TailorConfig) {
     // Remove components
     if let Some(components) = doc.get_mut("components").and_then(Value::as_array_mut) {
-        components.retain(|comp| {
-            let name = comp.str_field("name");
-            let bom_ref = comp.str_field("bom-ref");
-            !remove_ids.iter().any(|id| id == name || id == bom_ref)
-        });
+        components.retain(|comp| !removal.matches_cyclonedx(comp));
     }
 
     // Remove corresponding dependency entries
     if let Some(deps) = doc.get_mut("dependencies").and_then(Value::as_array_mut) {
-        deps.retain(|dep| {
-            let ref_val = dep.str_field("ref");
-            !remove_ids.iter().any(|id| id == ref_val)
-        });
+        deps.retain(|dep| !removal.matches_ref(dep.str_field("ref")));
 
         // Also remove from dependsOn arrays
         for dep in deps.iter_mut() {
             if let Some(depends_on) = dep.get_mut("dependsOn").and_then(Value::as_array_mut) {
-                depends_on.retain(|d| {
-                    let s = d.as_str().unwrap_or("");
-                    !remove_ids.iter().any(|id| id == s)
-                });
+                depends_on.retain(|d| !removal.matches_ref(d.as_str().unwrap_or("")));
             }
         }
     }
@@ -176,7 +296,7 @@ fn prune_cyclonedx(doc: &mut Value, remove_ids: &[String], config: &TailorConfig
     }
 }
 
-fn prune_spdx3(doc: &mut Value, remove_ids: &[String], config: &TailorConfig) {
+fn prune_spdx3(doc: &mut Value, removal: &RemovalSet, config: &TailorConfig) {
     let key = if doc.get("element").is_some() {
         "element"
     } else {
@@ -186,7 +306,6 @@ fn prune_spdx3(doc: &mut Value, remove_ids: &[String], config: &TailorConfig) {
 
     if let Some(elems) = elements {
         elems.retain(|elem| {
-            let name = elem.str_field("name");
             let elem_type = elem.str_field("type");
 
             // Only filter software packages, keep relationships and other elements
@@ -198,19 +317,15 @@ fn prune_spdx3(doc: &mut Value, remove_ids: &[String], config: &TailorConfig) {
                 return true;
             }
 
-            !remove_ids.iter().any(|id| id == name)
+            !removal.matches_spdx3(elem)
         });
     }
 }
 
-fn prune_spdx2(doc: &mut Value, remove_ids: &[String], config: &TailorConfig) {
+fn prune_spdx2(doc: &mut Value, removal: &RemovalSet, config: &TailorConfig) {
     // Remove packages
     if let Some(packages) = doc.get_mut("packages").and_then(Value::as_array_mut) {
-        packages.retain(|pkg| {
-            let name = pkg.str_field("name");
-            let spdx_id = pkg.str_field("SPDXID");
-            !remove_ids.iter().any(|id| id == name || id == spdx_id)
-        });
+        packages.retain(|pkg| !removal.matches_spdx2(pkg));
     }
 
     // Remove relationships referencing removed packages
@@ -224,12 +339,24 @@ fn prune_spdx2(doc: &mut Value, remove_ids: &[String], config: &TailorConfig) {
                 .get("relatedSpdxElement")
                 .and_then(Value::as_str)
                 .unwrap_or("");
-            !remove_ids.iter().any(|id| id == elem || id == related)
+            !removal.matches_ref(elem) && !removal.matches_ref(related)
         });
     }
 
-    if config.strip_vulns {
-        doc.as_object_mut().map(|o| o.remove("annotations"));
+    // SPDX 2.x has no native vulnerability field; this tool's enricher
+    // records vulnerabilities as annotations shaped
+    // `annotator: "Tool: sbom-tools"` + `comment: "Vulnerability <id>: ..."`.
+    // Strip exactly that class — deleting the whole `annotations` array
+    // destroyed unrelated data (e.g. human REVIEW notes).
+    if config.strip_vulns
+        && let Some(annots) = doc.get_mut("annotations").and_then(Value::as_array_mut)
+    {
+        annots.retain(|annotation| {
+            !(annotation.str_field("annotator") == "Tool: sbom-tools"
+                && annotation
+                    .str_field("comment")
+                    .starts_with("Vulnerability "))
+        });
     }
 }
 
@@ -241,8 +368,8 @@ mod tests {
     #[test]
     fn tailor_by_name_pattern() {
         let raw = r#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[
-            {"name":"keep-me","version":"1.0"},
-            {"name":"remove-me","version":"2.0"}
+            {"bom-ref":"id-keep","name":"keep-me","version":"1.0"},
+            {"bom-ref":"id-remove","name":"remove-me","version":"2.0"}
         ]}"#;
 
         let mut sbom = NormalizedSbom::default();
@@ -272,5 +399,132 @@ mod tests {
 
         let result = tailor_sbom_json(raw, &sbom, &config).unwrap();
         assert!(!result.contains("vulnerabilities"));
+    }
+
+    /// Excluding an ecosystem must remove only that ecosystem's component,
+    /// never a same-named component from another ecosystem.
+    #[test]
+    fn exclude_ecosystem_keeps_same_name_other_ecosystem() {
+        use crate::model::Ecosystem;
+
+        let raw = r#"{"bomFormat":"CycloneDX","specVersion":"1.5","components":[
+            {"bom-ref":"foo-npm","name":"foo","version":"1.0","purl":"pkg:npm/foo@1.0"},
+            {"bom-ref":"foo-pypi","name":"foo","version":"2.0","purl":"pkg:pypi/foo@2.0"}
+        ]}"#;
+
+        let mut sbom = NormalizedSbom::default();
+        let mut foo_npm = Component::new("foo".to_string(), "foo-npm".to_string())
+            .with_purl("pkg:npm/foo@1.0".to_string());
+        foo_npm.ecosystem = Some(Ecosystem::Npm);
+        let mut foo_pypi = Component::new("foo".to_string(), "foo-pypi".to_string())
+            .with_purl("pkg:pypi/foo@2.0".to_string());
+        foo_pypi.ecosystem = Some(Ecosystem::PyPi);
+        sbom.components
+            .insert(foo_npm.canonical_id.clone(), foo_npm);
+        sbom.components
+            .insert(foo_pypi.canonical_id.clone(), foo_pypi);
+
+        let config = TailorConfig {
+            exclude_ecosystems: vec!["npm".to_string()],
+            ..Default::default()
+        };
+
+        let result = tailor_sbom_json(raw, &sbom, &config).unwrap();
+        let doc: Value = serde_json::from_str(&result).unwrap();
+        let kept: Vec<&str> = doc["components"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|c| c["purl"].as_str())
+            .collect();
+        assert_eq!(
+            kept,
+            vec!["pkg:pypi/foo@2.0"],
+            "foo@pypi must survive excluding npm"
+        );
+    }
+
+    /// The documented `--include-name "my-org/*"` example must keep matching
+    /// components (previously the `*` was matched literally, keeping 0).
+    #[test]
+    fn include_name_glob_pattern() {
+        assert!(name_matches_pattern("my-org/pkg-a", "my-org/*"));
+        assert!(name_matches_pattern("my-org/pkg-b", "MY-ORG/*"));
+        assert!(!name_matches_pattern("other/pkg-c", "my-org/*"));
+        assert!(name_matches_pattern("libfoo-core", "*foo*"));
+        assert!(name_matches_pattern("foo-middle-bar", "foo*bar"));
+        assert!(!name_matches_pattern("foo-middle-baz", "foo*bar"));
+        assert!(!name_matches_pattern("xfoobar", "foo*bar"));
+        // Overlap guard: prefix and suffix may not share characters.
+        assert!(!name_matches_pattern("foob", "foo*ob"));
+        // No `*` keeps plain substring semantics.
+        assert!(name_matches_pattern("my-org/pkg-a", "org/pkg"));
+        assert!(!name_matches_pattern("my-org/pkg-a", "other"));
+    }
+
+    /// `--include-types` must accept CycloneDX spec values case-insensitively
+    /// while the internal Debug spellings keep working.
+    #[test]
+    fn include_types_accepts_spec_and_debug_spellings() {
+        use crate::model::ComponentType;
+
+        let raw = r#"{"bomFormat":"CycloneDX","specVersion":"1.6","components":[
+            {"bom-ref":"lib1","name":"libfoo","version":"1.0"},
+            {"bom-ref":"mlm","name":"bert-base","version":"1.0"}
+        ]}"#;
+
+        let mut sbom = NormalizedSbom::default();
+        let lib = Component::new("libfoo".to_string(), "lib1".to_string());
+        let mut mlm = Component::new("bert-base".to_string(), "mlm".to_string());
+        mlm.component_type = ComponentType::MachineLearningModel;
+        sbom.components.insert(lib.canonical_id.clone(), lib);
+        sbom.components.insert(mlm.canonical_id.clone(), mlm);
+
+        for spelling in ["machine-learning-model", "MachineLearningModel"] {
+            let config = TailorConfig {
+                include_types: vec![spelling.to_string()],
+                ..Default::default()
+            };
+            let result = tailor_sbom_json(raw, &sbom, &config).unwrap();
+            let doc: Value = serde_json::from_str(&result).unwrap();
+            let kept: Vec<&str> = doc["components"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .filter_map(|c| c["name"].as_str())
+                .collect();
+            assert_eq!(kept, vec!["bert-base"], "spelling {spelling} must match");
+        }
+
+        // cryptographic-asset (spec) maps to the internal cryptographic
+        assert_eq!(normalize_type_token("cryptographic-asset"), "cryptographic");
+        assert_eq!(normalize_type_token("Cryptographic"), "cryptographic");
+    }
+
+    /// `--strip-vulns` on SPDX 2.x must remove only this tool's
+    /// vulnerability-shaped annotations, keeping human REVIEW notes.
+    #[test]
+    fn strip_vulns_spdx2_keeps_non_vuln_annotations() {
+        let raw = r#"{
+            "spdxVersion":"SPDX-2.3","SPDXID":"SPDXRef-DOCUMENT",
+            "packages":[{"SPDXID":"SPDXRef-a","name":"a"}],
+            "annotations":[
+                {"annotator":"Person: Jane Reviewer","annotationType":"REVIEW",
+                 "comment":"Manually reviewed licensing"},
+                {"annotator":"Tool: sbom-tools","annotationType":"REVIEW",
+                 "comment":"Vulnerability CVE-2024-0001: A bad bug"}
+            ]
+        }"#;
+        let sbom = NormalizedSbom::default();
+        let config = TailorConfig {
+            strip_vulns: true,
+            ..Default::default()
+        };
+
+        let result = tailor_sbom_json(raw, &sbom, &config).unwrap();
+        let doc: Value = serde_json::from_str(&result).unwrap();
+        let annots = doc["annotations"].as_array().unwrap();
+        assert_eq!(annots.len(), 1, "only the vuln annotation is removed");
+        assert_eq!(annots[0]["annotator"], "Person: Jane Reviewer");
     }
 }

--- a/src/watch/alerts.rs
+++ b/src/watch/alerts.rs
@@ -51,16 +51,26 @@ pub(crate) enum CraEventKind {
 }
 
 // ============================================================================
-// Stdout sink — human-readable colored output to stderr
+// Summary sink — human-readable output to stderr or a file (-O)
 // ============================================================================
 
 pub(crate) struct StdoutAlertSink {
     quiet: bool,
+    /// Where summary lines go: stderr by default, or the `-O` output file.
+    writer: Box<dyn Write + Send>,
 }
 
 impl StdoutAlertSink {
-    pub(crate) fn new(quiet: bool) -> Self {
-        Self { quiet }
+    /// Summary sink writing to an explicit writer: stderr by default, or the
+    /// `-O` output file (previously silently ignored unless `-o json`).
+    pub(crate) fn with_writer(quiet: bool, writer: Box<dyn Write + Send>) -> Self {
+        Self { quiet, writer }
+    }
+
+    fn write_line(&mut self, line: &str) -> anyhow::Result<()> {
+        writeln!(self.writer, "{line}")?;
+        self.writer.flush()?;
+        Ok(())
     }
 }
 
@@ -119,8 +129,7 @@ impl AlertSink for StdoutAlertSink {
             parts.join(", ")
         };
 
-        eprintln!("[{ts}] {name}: {detail}");
-        Ok(())
+        self.write_line(&format!("[{ts}] {name}: {detail}"))
     }
 
     fn on_new_vulns(&mut self, path: &Path, vuln_ids: &[String]) -> anyhow::Result<()> {
@@ -129,12 +138,11 @@ impl AlertSink for StdoutAlertSink {
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");
         let ts = chrono::Local::now().format("%H:%M:%S");
-        eprintln!(
+        self.write_line(&format!(
             "[{ts}] {name}: enrichment found {} new vuln(s): {}",
             vuln_ids.len(),
             vuln_ids.join(", ")
-        );
-        Ok(())
+        ))
     }
 
     fn on_sbom_removed(&mut self, path: &Path) -> anyhow::Result<()> {
@@ -143,8 +151,7 @@ impl AlertSink for StdoutAlertSink {
             .and_then(|n| n.to_str())
             .unwrap_or("unknown");
         let ts = chrono::Local::now().format("%H:%M:%S");
-        eprintln!("[{ts}] {name}: file removed");
-        Ok(())
+        self.write_line(&format!("[{ts}] {name}: file removed"))
     }
 
     fn on_status(&mut self, summary: &WatchSummary) -> anyhow::Result<()> {
@@ -152,15 +159,14 @@ impl AlertSink for StdoutAlertSink {
             return Ok(());
         }
         let ts = chrono::Local::now().format("%H:%M:%S");
-        eprintln!(
+        self.write_line(&format!(
             "[{ts}] Watching {} SBOMs | {} healthy | {} error | {} vulns | uptime {}s",
             summary.tracked_count,
             summary.healthy_count,
             summary.error_count,
             summary.total_vulns,
             summary.uptime_secs,
-        );
-        Ok(())
+        ))
     }
 
     fn on_cra_standard(&mut self, event: &CraStandardEvent) -> anyhow::Result<()> {
@@ -168,17 +174,17 @@ impl AlertSink for StdoutAlertSink {
         match &event.kind {
             CraEventKind::InitialBaseline { status } => {
                 if !self.quiet {
-                    eprintln!(
+                    self.write_line(&format!(
                         "[{ts}] cra-standard {}: baseline {} ({})",
                         event.id, status, event.title
-                    );
+                    ))?;
                 }
             }
             CraEventKind::StatusChanged { from, to } => {
-                eprintln!(
+                self.write_line(&format!(
                     "[{ts}] cra-standard {}: status drift {from} -> {to} ({})",
                     event.id, event.title
-                );
+                ))?;
             }
         }
         Ok(())
@@ -371,6 +377,11 @@ impl AlertSink for WebhookAlertSink {
 // ============================================================================
 
 /// Build alert sinks from the watch configuration.
+///
+/// `watch` emits an event stream, not a report, so only two formats exist:
+/// `summary` (human-readable lines; the `auto` default) and `json` (NDJSON).
+/// Any other `-o` value is an error instead of silently behaving like
+/// `summary`. The `-O` output file is honoured by both sinks.
 pub(crate) fn build_alert_sinks(
     config: &super::config::WatchConfig,
 ) -> anyhow::Result<Vec<Box<dyn AlertSink>>> {
@@ -378,23 +389,37 @@ pub(crate) fn build_alert_sinks(
 
     let mut sinks: Vec<Box<dyn AlertSink>> = Vec::new();
 
-    match config.output.format {
-        ReportFormat::Json => {
-            let writer: Box<dyn Write + Send> = match &config.output.file {
+    // Writer for the configured output target (used by both formats):
+    // append to `-O <file>` when given, else the format's default stream.
+    let open_output =
+        |default_stream: fn() -> Box<dyn Write + Send>| -> anyhow::Result<Box<dyn Write + Send>> {
+            match &config.output.file {
                 Some(path) => {
                     let file = std::fs::OpenOptions::new()
                         .create(true)
                         .append(true)
-                        .open(path)?;
-                    Box::new(file)
+                        .open(path)
+                        .map_err(|e| {
+                            anyhow::anyhow!("cannot open output file {}: {e}", path.display())
+                        })?;
+                    Ok(Box::new(file))
                 }
-                None => Box::new(std::io::stdout()),
-            };
+                None => Ok(default_stream()),
+            }
+        };
+
+    match config.output.format {
+        ReportFormat::Json => {
+            let writer = open_output(|| Box::new(std::io::stdout()))?;
             sinks.push(Box::new(NdjsonAlertSink::new(writer)));
         }
-        _ => {
-            sinks.push(Box::new(StdoutAlertSink::new(config.quiet)));
+        ReportFormat::Auto | ReportFormat::Summary => {
+            let writer = open_output(|| Box::new(std::io::stderr()))?;
+            sinks.push(Box::new(StdoutAlertSink::with_writer(config.quiet, writer)));
         }
+        other => anyhow::bail!(
+            "watch supports only --output summary or json (NDJSON stream); got '{other}'"
+        ),
     }
 
     #[cfg(feature = "enrichment")]
@@ -408,6 +433,93 @@ pub(crate) fn build_alert_sinks(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn watch_config_with_output(
+        format: crate::reports::ReportFormat,
+        file: Option<std::path::PathBuf>,
+    ) -> super::super::config::WatchConfig {
+        super::super::config::WatchConfig {
+            watch_dirs: vec![],
+            poll_interval: std::time::Duration::from_secs(1),
+            enrich_interval: std::time::Duration::from_secs(1),
+            debounce: std::time::Duration::ZERO,
+            output: crate::config::OutputConfig {
+                format,
+                file,
+                ..Default::default()
+            },
+            enrichment: crate::config::EnrichmentConfig::default(),
+            webhook_url: None,
+            exit_on_change: false,
+            max_snapshots: 10,
+            quiet: false,
+            dry_run: false,
+            cra_standards_enabled: false,
+            cra_standards_interval: std::time::Duration::from_secs(1),
+            cra_standards_timeout: std::time::Duration::from_secs(1),
+        }
+    }
+
+    #[test]
+    fn build_alert_sinks_rejects_unsupported_formats() {
+        use crate::reports::ReportFormat;
+        for format in [
+            ReportFormat::Sarif,
+            ReportFormat::Html,
+            ReportFormat::Csv,
+            ReportFormat::Table,
+            ReportFormat::Markdown,
+            ReportFormat::Ndjson,
+        ] {
+            let err = build_alert_sinks(&watch_config_with_output(format, None))
+                .err()
+                .unwrap_or_else(|| panic!("format {format} must be rejected for watch"));
+            assert!(
+                err.to_string().contains("summary or json"),
+                "error must name the supported formats: {err}"
+            );
+        }
+        // Supported: auto (default), summary, json.
+        for format in [
+            ReportFormat::Auto,
+            ReportFormat::Summary,
+            ReportFormat::Json,
+        ] {
+            assert!(build_alert_sinks(&watch_config_with_output(format, None)).is_ok());
+        }
+    }
+
+    #[test]
+    fn summary_sink_honours_output_file() {
+        // Regression: `-O <file>` was silently ignored unless `-o json`.
+        let dir = tempfile::tempdir().unwrap();
+        let out = dir.path().join("alerts.log");
+        let config =
+            watch_config_with_output(crate::reports::ReportFormat::Summary, Some(out.clone()));
+        let mut sinks = build_alert_sinks(&config).unwrap();
+
+        let snapshot = DiffSnapshot {
+            timestamp: chrono::Utc::now(),
+            components_added: 2,
+            components_removed: 0,
+            components_modified: 0,
+            new_vulns: vec![],
+            resolved_vulns: vec![],
+            new_kev: vec![],
+            new_eol: vec![],
+            crypto_changes: vec![],
+            crypto_downgrades: vec![],
+        };
+        sinks[0]
+            .on_change(Path::new("app.cdx.json"), &snapshot)
+            .unwrap();
+
+        let contents = std::fs::read_to_string(&out).unwrap();
+        assert!(
+            contents.contains("app.cdx.json") && contents.contains("+2 added"),
+            "summary alert must land in the -O file: {contents:?}"
+        );
+    }
 
     #[test]
     fn test_ndjson_sink_produces_valid_json() {
@@ -508,7 +620,7 @@ mod tests {
 
     #[test]
     fn test_stdout_sink_cra_standard_does_not_panic() {
-        let mut sink = StdoutAlertSink::new(false);
+        let mut sink = StdoutAlertSink::with_writer(false, Box::new(std::io::stderr()));
         let event = CraStandardEvent {
             id: "STAN4CRA",
             title: "STAN4CRA hub",
@@ -532,7 +644,7 @@ mod tests {
 
     #[test]
     fn test_stdout_sink_does_not_panic() {
-        let mut sink = StdoutAlertSink::new(true);
+        let mut sink = StdoutAlertSink::with_writer(true, Box::new(std::io::stderr()));
         let snapshot = DiffSnapshot {
             timestamp: chrono::Utc::now(),
             components_added: 1,

--- a/src/watch/config.rs
+++ b/src/watch/config.rs
@@ -69,12 +69,25 @@ pub fn parse_duration(s: &str) -> Result<Duration, WatchError> {
         .parse()
         .map_err(|_| WatchError::InvalidInterval(s.to_string()))?;
 
+    // Overflow-safe unit conversion: an absurd interval like
+    // `300000000000000d` must be a clean error, not a multiply panic
+    // (debug) or a silently wrapped duration (release).
+    let too_large = || WatchError::InvalidInterval(format!("{s} (interval too large)"));
     match unit {
         "ms" => Ok(Duration::from_millis(value)),
         "s" => Ok(Duration::from_secs(value)),
-        "m" => Ok(Duration::from_secs(value * 60)),
-        "h" => Ok(Duration::from_secs(value * 3600)),
-        "d" => Ok(Duration::from_secs(value * 86400)),
+        "m" => value
+            .checked_mul(60)
+            .map(Duration::from_secs)
+            .ok_or_else(too_large),
+        "h" => value
+            .checked_mul(3600)
+            .map(Duration::from_secs)
+            .ok_or_else(too_large),
+        "d" => value
+            .checked_mul(86400)
+            .map(Duration::from_secs)
+            .ok_or_else(too_large),
         _ => Err(WatchError::InvalidInterval(s.to_string())),
     }
 }
@@ -131,5 +144,26 @@ mod tests {
     #[test]
     fn test_parse_duration_no_unit() {
         assert!(parse_duration("100").is_err());
+    }
+
+    #[test]
+    fn test_parse_duration_overflow_is_clean_error() {
+        // Used to panic with "attempt to multiply with overflow".
+        for s in [
+            "300000000000000d",
+            "18446744073709551615h",
+            "18446744073709551615m",
+        ] {
+            let err = parse_duration(s).expect_err("overflowing interval must error");
+            assert!(
+                err.to_string().contains("interval too large"),
+                "error must say the interval is too large: {err}"
+            );
+        }
+        // Large but representable values still parse.
+        assert_eq!(
+            parse_duration("10000d").unwrap(),
+            Duration::from_secs(10_000 * 86_400)
+        );
     }
 }

--- a/src/watch/loop_impl.rs
+++ b/src/watch/loop_impl.rs
@@ -22,7 +22,17 @@ use std::time::Instant;
 /// Polls directories for SBOM file changes at `config.poll_interval` and
 /// optionally re-enriches on `config.enrich_interval`. Returns only when
 /// the process is interrupted or `exit_on_change` triggers.
-pub fn run_watch_loop(config: &WatchConfig) -> anyhow::Result<()> {
+///
+/// Returns the process exit code: [`exit_codes::SUCCESS`] for a normal
+/// shutdown (interrupt, dry-run) and [`exit_codes::CHANGES_DETECTED`] when
+/// exiting because `--exit-on-change` observed a change — the change gate is
+/// a verdict (exit 1), not a success.
+///
+/// [`exit_codes::SUCCESS`]: crate::pipeline::exit_codes::SUCCESS
+/// [`exit_codes::CHANGES_DETECTED`]: crate::pipeline::exit_codes::CHANGES_DETECTED
+pub fn run_watch_loop(config: &WatchConfig) -> anyhow::Result<i32> {
+    use crate::pipeline::exit_codes;
+
     let mut monitor = FileMonitor::new(config.watch_dirs.clone());
     let mut state = WatchState::new(config.max_snapshots);
     let mut sinks = build_alert_sinks(config)?;
@@ -84,7 +94,7 @@ pub fn run_watch_loop(config: &WatchConfig) -> anyhow::Result<()> {
                 eprintln!("  {} — {}", path.display(), status);
             }
         }
-        return Ok(());
+        return Ok(exit_codes::SUCCESS);
     }
 
     // If exit_on_change and we already discovered files, we wait for _changes_
@@ -98,7 +108,7 @@ pub fn run_watch_loop(config: &WatchConfig) -> anyhow::Result<()> {
                 eprintln!("Shutting down gracefully...");
             }
             emit_status(&state, &mut sinks);
-            return Ok(());
+            return Ok(exit_codes::SUCCESS);
         }
 
         std::thread::sleep(config.poll_interval);
@@ -159,12 +169,14 @@ pub fn run_watch_loop(config: &WatchConfig) -> anyhow::Result<()> {
             emit_status(&state, &mut sinks);
         }
 
-        // CI mode: exit after detecting a real change
+        // CI mode: exit after detecting a real change. The change gate maps
+        // to exit code 1 (like diff --fail-on-change), not 0 — CI must be
+        // able to distinguish "change seen" from "shut down cleanly".
         if config.exit_on_change && state.total_changes > 0 {
             if !config.quiet {
                 eprintln!("Change detected, exiting (--exit-on-change)");
             }
-            return Ok(());
+            return Ok(exit_codes::CHANGES_DETECTED);
         }
 
         // Check stop flag again after processing
@@ -173,7 +185,7 @@ pub fn run_watch_loop(config: &WatchConfig) -> anyhow::Result<()> {
                 eprintln!("Shutting down gracefully...");
             }
             emit_status(&state, &mut sinks);
-            return Ok(());
+            return Ok(exit_codes::SUCCESS);
         }
     }
 }

--- a/tests/showcase_cli_tests.rs
+++ b/tests/showcase_cli_tests.rs
@@ -56,9 +56,13 @@ fn cli_diff_summary_supports_match_explanations_and_threshold_recommendation() {
         .expect("diff command should run");
 
     assert!(output.status.success(), "{}", stderr(&output));
+    // Explanations go to STDERR so machine-readable stdout (-o json/sarif)
+    // stays parseable; the report itself stays on stdout.
+    let err = stderr(&output);
+    assert!(err.contains("=== Match Explanations ==="));
+    assert!(err.contains("=== Threshold Recommendation ==="));
     let text = stdout(&output);
-    assert!(text.contains("=== Match Explanations ==="));
-    assert!(text.contains("=== Threshold Recommendation ==="));
+    assert!(!text.contains("=== Match Explanations ==="));
     assert!(text.contains("SBOM Diff Summary"));
 }
 


### PR DESCRIPTION
## Summary

A dedicated audit of the CLI layer (all 22 subcommands, ~9,200 lines) found ~64 repro-confirmed issues (~13 high). This PR fixes them across five clusters. Every fix was verified against the real binary using the audit's exact repros, before and after.

### 1. Exit-code contract (the systemic one)
The documented exit code 3 ("Error occurred") was unreachable — `main()` exited 1 on every error, colliding with verdict codes: a missing file in `diff` was indistinguishable from "--fail-on-change fired", and in `query` from "no matches" (`query --affected-by CVE || echo not-affected` read I/O errors as *not affected*). The contract is now real: **0** success, **1** gate/verdict, **2** clap usage, **3** operational error, plus documented specials (vuln=2, vex-gap=4, license=5, KEV=6, ML=7). `verify` mismatches move 3→1 (they're verdicts). Every EXIT CODES help section rewritten to match reality; phantom `--no-fail-on-change` and broken root examples removed.

### 2. Security gates fail closed
- `license-check`: typo'd policy files (e.g. `"denied"` for `"deny"`) hard-error instead of silently allowing everything; `--strict` actually denies copyleft; propagation conflicts are in the JSON body and gate at 5
- `vex`: malformed/missing VEX documents are hard errors, not warning + un-overlaid report at exit 0; ignored flags (`--state`, `--actionable-only`) now implemented
- `diff --fail-on-kev`: errors when KEV data can't load instead of silently passing
- `verify model-weights`: errors on zero model components instead of a vacuous pass

### 3. Data integrity
- `enrich` no longer strips CWEs/source/CVSS detail from existing vulnerabilities, and emits spec-valid VEX states (`not_affected`, `in_triage`) so suppressions survive round-trips
- `merge` no longer drops all secondary components on metadata-only primaries, errors on SPDX2+SPDX3, and dedups vulnerabilities/relationships
- `tailor` prunes by identity not bare name (no more cross-ecosystem collateral removal), `--include-name` gets real `*` wildcards, spec-valued `--include-types`

### 4. Config & trust consistency
Unknown config keys hard-error everywhere including `config check`; explicit `--config` paths are authoritative in every command; auto-discovered CRA sidecars get the same strict treatment as `--cra-sidecar`; cache export can't recurse into itself; watch interval overflow is an error not a panic; `cra-docs` refuses to clobber hand-edited dossiers without `--force`.

### 5. Panics & polish
`query` UTF-8 truncation panic, `completions | head` SIGPIPE panic, and the watch overflow panic are gone; `--explain-matches` no longer corrupts JSON stdout; unsupported formats and unknown filter values error consistently instead of silently no-oping; ANSI respects `--no-color`/`NO_COLOR`/non-TTY; `matrix --fail-on-vuln` is argument-order independent; convert's file flag is `-O` like every sibling; stdin `-` works uniformly.

## Breaking changes (deliberate, all fixing documented-vs-actual gaps)
- Error exit codes move 1→3 across commands (matching what the help always claimed); `verify` mismatch 3→1
- Typo'd config files, policy files, and auto-discovered sidecars now hard-error instead of being silently ignored
- `convert -o` (output file) is now `-O`; `watch -o` limited to summary/json; unsupported `query -o` values error
- `watch --exit-on-change` exits 1 on change (was 0)

## Verification
- 6 fix agents + central integration pass; ~50 new unit tests, each verified fail-before/pass-after
- Full `cargo test --all-features`: 54/54 suites green; clippy `--all-features -D warnings` clean; fmt clean
- ~20 of the audit's original repros re-run against the final binary — all confirmed fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)