### PR TITLE
docs: sync README and docs/ with post-audit reality (PRs #320–#322)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ language bindings provide application access to the JSON-oriented C ABI.
 - **Fleet Comparison** — 1:N baseline comparison, timeline analysis across versions, and NxN matrix analysis, all with enrichment support
 - **Incremental Diff** — Section-selective recomputation for partial changes with cached matching results
 - **VEX Tracking** — Detect VEX state transitions (NotAffected → Affected) across SBOM versions, with `--fail-on-vex-gap` CI gate
-- **Multiple Output Formats** — JSON, SARIF, HTML, Markdown, CSV, table, side-by-side, summary, and an interactive TUI
+- **Multiple Output Formats** — JSON, SARIF, OSCAL assessment results (`validate`), HTML, Markdown, CSV, table, side-by-side, summary, and an interactive TUI
 - **Ecosystem-Aware** — Configurable per-ecosystem normalization rules, typosquat detection, pre-release version handling, and cross-ecosystem package correlation
 
 ## Installation
@@ -405,6 +405,7 @@ Compares two SBOMs and reports added, removed, and modified components with vers
 | `--fail-on-change` | Exit with code 1 if changes are detected |
 | `--fail-on-vuln` | Exit with code 2 if new vulnerabilities are introduced |
 | `--fail-on-vex-gap` | Exit with code 4 if introduced vulnerabilities lack VEX statements |
+| `--fail-on-kev` | Exit with code 6 if an introduced vulnerability is in CISA's KEV catalog (implies `--kev` enrichment) |
 | `--fail-on-ml-regression` | Exit with code 7 if a supported numeric ML metric regresses |
 | `--graph-diff` | Enable dependency graph structure diffing |
 | `--ecosystem-rules <path>` | Load custom per-ecosystem normalization rules |
@@ -467,7 +468,7 @@ Launches an interactive TUI with component tree, vulnerability details, license 
 | `--ecosystem <name>` | Filter components by ecosystem (e.g., `npm`, `cargo`, `pypi`) |
 | `--enrich-eol` | Detect end-of-life status via endoflife.date API |
 | `--validate-ntia` | Validate against NTIA minimum elements |
-| `--bom-type <type>` | BOM type override (`sbom`, `cbom`). Auto-detected from content if omitted |
+| `--bom-type <type>` | BOM type override (`sbom`, `cbom`, `aibom`). Auto-detected from content if omitted |
 
 </details>
 
@@ -505,6 +506,7 @@ Scores an SBOM from 0–100 using a weighted profile. Use `--min-score` to fail 
 |------|-------------|
 | `--profile <name>` | Scoring profile: `minimal`, `standard` (default), `security`, `license-compliance`, `cra`, `bsi`, `comprehensive`, `cbom`, `ai-readiness` |
 | `--min-score <n>` | Fail if quality score is below threshold (0–100) |
+| `--fail-on-noncompliant` | Exit with code 1 if the profile's embedded compliance check reports the SBOM as non-compliant |
 | `--recommendations` | Show detailed improvement recommendations |
 | `--metrics` | Show detailed scoring metrics |
 
@@ -599,10 +601,11 @@ sbom-tools completions fish > ~/.config/fish/completions/sbom-tools.fish
 
 | Flag | Description |
 |------|-------------|
-| `-o, --output <fmt>` | Output format (see [Output Formats](#output-formats)) |
+| `-o, --output <fmt>` | Output format, accepted per command (see [Output Formats](#output-formats)) |
 | `-v, --verbose` | Enable debug output |
 | `-q, --quiet` | Suppress non-essential output |
 | `--no-color` | Disable colored output (also respects `NO_COLOR`) |
+| `--offline` | Never make network calls; serve enrichment purely from cache (also settable via `SBOM_TOOLS_OFFLINE`) |
 
 ## Interactive TUI
 
@@ -610,7 +613,7 @@ Both `diff` and `view` commands launch an interactive terminal UI by default whe
 
 ### Diff Mode
 
-Compare two SBOMs with semantic change detection across 9 tabs.
+Compare two SBOMs with semantic change detection across 10 tabs.
 
 **Summary** — Overall change score with component, vulnerability, and compliance breakdowns at a glance.
 
@@ -639,7 +642,7 @@ Compare two SBOMs with semantic change detection across 9 tabs.
 
 ### View Mode
 
-Explore a single SBOM or CBOM interactively. SBOM mode shows 8 tabs (Overview, Tree, Vulnerabilities, Licenses, Dependencies, Quality, Compliance, Source). CBOM mode auto-detects and shows crypto-specific tabs (Overview, Algorithms, Certificates, Keys, Protocols, Quality, PQC Compliance, Source). Press `P` to toggle between modes.
+Explore a single SBOM, CBOM, or AI-BOM interactively. SBOM mode shows 8 tabs (Overview, Tree, Vulnerabilities, Licenses, Dependencies, Quality, Compliance, Source). CBOM mode auto-detects and shows crypto-specific tabs (Overview, Algorithms, Certificates, Keys, Protocols, Quality, PQC Compliance, Source). AI-BOM mode shows model-centric tabs (Overview, Models, Datasets, AI-Readiness, Compliance, Source). Press `P` to cycle between modes.
 
 **Overview** — SBOM metadata, component statistics, and vulnerability summary.
 
@@ -673,7 +676,7 @@ Explore a single SBOM or CBOM interactively. SBOM mode shows 8 tabs (Overview, T
 | `f` | Filter panel |
 | `s` | Sync panels (Source) / sort (Algorithms, Vulnerabilities) |
 | `w` | Switch focus (Source, Side-by-Side) |
-| `P` | Toggle SBOM/CBOM profile |
+| `P` | Cycle SBOM/CBOM/AI-BOM profile |
 | `v` | Tree / raw toggle (Source) |
 | `e` | Export |
 | `T` | Cycle theme |
@@ -725,7 +728,7 @@ sbom-tools validate sbom.json --standard cra -o sarif -O compliance.sarif
 sbom-tools validate sbom.json --standard ntia \
   -o oscal-json -O validation-results.oscal.json
 
-# Check for vulnerable Log4j versions across all SBOMs (exits 1 if found)
+# Find vulnerable Log4j versions across all SBOMs (exits 1 if nothing matches)
 sbom-tools query "log4j" --version "<2.17.0" fleet/*.json -o json
 
 # Check license compliance with strict policy
@@ -845,20 +848,21 @@ jobs:
 | Code | Meaning |
 |------|---------|
 | `0` | Success (no changes detected, or run without `--fail-on-change`) |
-| `1` | Changes detected (`--fail-on-change`) / no query matches |
-| `2` | New vulnerabilities introduced (`--fail-on-vuln`) |
-| `3` | Error |
+| `1` | Changes detected (`--fail-on-change`) / compliance errors (`validate`) / quality score below `--min-score` or non-compliant with `--fail-on-noncompliant` (`quality`) / no query matches |
+| `2` | New vulnerabilities introduced (`--fail-on-vuln`) / compliance warnings (`validate --fail-on-warning`); also command-line parse errors |
+| `3` | Operational error (I/O, parse, config, invalid flag values) |
 | `4` | VEX coverage gaps found (`--fail-on-vex-gap`) |
 | `5` | License policy violations found (`license-check`) |
 | `6` | Actively exploited (KEV) vulnerability introduced (`--fail-on-kev`) |
 | `7` | Supported ML performance metric regressed (`--fail-on-ml-regression`) |
 
 Gate codes only apply to runs that completed successfully and produced their
-report. Usage and configuration errors (an unsupported `-o` format for the
-command, an invalid `--as-of`/`--cra-product-class` value, a broken explicit
-`--cra-sidecar`, or an invalid config file) exit `1`, and command-line parse
-errors exit `2` — CI pipelines should therefore only interpret a nonzero exit
-as a gate verdict when the expected report output was produced.
+report. Every operational error — I/O, parse failures, an unsupported `-o`
+format for the command, an invalid `--as-of`/`--cra-product-class` value, a
+broken explicit `--cra-sidecar`, or an invalid config file — exits `3`, and
+command-line parse errors exit `2` — CI pipelines should therefore only
+interpret a nonzero exit as a gate verdict when the expected report output was
+produced.
 
 ML regression directions are explicit. Higher is better for `accuracy`, `f1`,
 `f1_score`, `precision`, `recall`, `auc`, `roc_auc`, `bleu`, and `rouge`.
@@ -897,7 +901,7 @@ src/
 ├── matching/     Multi-tier fuzzy matching (PURL, alias, ecosystem, adaptive, LSH)
 ├── diff/         Semantic diffing engine with graph support + incremental section-selective diff
 ├── enrichment/   OSV/KEV vulnerability data + EOL detection + VEX (feature-gated)
-├── quality/      8-category scoring engine + CBOM crypto scoring profile + 11 compliance standards (NTIA/FDA/CRA/SSDF/EO 14028/CNSA 2.0/NIST PQC)
+├── quality/      8-category scoring engine + CBOM crypto scoring profile + 13 compliance standards (NTIA/FDA/CRA/SSDF/EO 14028/CNSA 2.0/NIST PQC/BSI TR-03183-2/OSS-steward/EUCC/EU AI Act/BSI SBOM-for-AI)
 ├── pipeline/     parse → enrich → diff → report orchestration + shared enrichment pipeline
 ├── reports/      9 output format generators + streaming reporter
 ├── verification/ File hash verification + component hash auditing

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,21 +5,21 @@ sbom-tools follows a linear pipeline that normalizes inputs, performs semantic
 diffing and scoring, and renders the result through reports or the TUI.
 
 ```
-SBOM/CBOM files
-  -> parsers (CycloneDX/SPDX, streaming for large files)
+SBOM/CBOM/AI-BOM files
+  -> parsers (CycloneDX 1.4-1.7, SPDX 2.2/2.3, SPDX 3.0 JSON-LD; streaming for large files)
   -> NormalizedSbom (canonical model, incl. CryptoProperties)
-  -> BomProfile detection (SBOM vs CBOM auto-detect)
+  -> BomProfile detection (SBOM / CBOM / AI-BOM auto-detect)
   -> matching (PURL, alias, ecosystem, adaptive fuzzy, LSH index)
   -> diff engine (semantic + graph)
-  -> DiffResult / QualityReport (profile-aware: Standard or CBOM scoring)
-  -> reports (json/sarif/html/markdown/csv/summary/table/side-by-side) or TUI
+  -> DiffResult / QualityReport (profile-aware: Standard, CBOM, or AI-readiness scoring)
+  -> reports (json/ndjson/sarif/oscal-json/html/markdown/csv/summary/table/side-by-side) or TUI
 ```
 
 ## Core Modules
 
-- **cli** (`src/cli/`): Clap command handlers for diff, view, validate, quality, query, diff-multi, timeline, matrix, watch, enrich, tailor, merge, license-check, verify, vex, completions, and config-schema.
+- **cli** (`src/cli/`): Clap command handlers for diff, view, validate, quality, query, diff-multi, timeline, matrix, watch, enrich, tailor, merge, convert, license-check, verify, vex, cache, cra-docs, cra-standards-watch, config, completions, config-schema, and man.
 - **config** (`src/config/`): Typed configuration with YAML/JSON support, presets, validation, and schema generation.
-- **parsers** (`src/parsers/`): CycloneDX/SPDX format detection and parsing into NormalizedSbom. Includes a streaming parser for large files (>512MB) with progress callbacks.
+- **parsers** (`src/parsers/`): CycloneDX (1.4–1.7, JSON/XML) and SPDX (2.2/2.3 plus SPDX 3.0 JSON-LD via a separate `spdx3.rs` parser) format detection and parsing into NormalizedSbom. Includes a streaming parser for memory-efficient parsing of large files with progress callbacks; inputs are capped at 512 MB.
 - **model** (`src/model/`): Canonical data model — NormalizedSbom, Component, CanonicalId, DocumentMetadata, Vulnerability, DependencyEdge, License, CryptoProperties, BomProfile. Includes CycloneDX 1.6/1.7 crypto types (CryptoAssetType, AlgorithmProperties, CertificateProperties, RelatedCryptoMaterialProperties, ProtocolProperties).
 - **matching** (`src/matching/`): Multi-tier fuzzy matching for component alignment.
   - Exact PURL match, alias lookup, ecosystem-specific normalization, string similarity (Jaro-Winkler, Levenshtein).
@@ -27,14 +27,14 @@ SBOM/CBOM files
   - LSH (locality-sensitive hashing) index for fast candidate lookup.
   - Custom rule engine for user-defined matching rules.
 - **diff** (`src/diff/`): Semantic diff engine with graph-aware dependency diffing, incremental diff tracking, and cost-model scoring.
-- **enrichment** (`src/enrichment/`): OSV and KEV vulnerability database integration plus EOL detection via endoflife.date API (feature-gated behind `enrichment`). Includes file-based caching with TTL and staleness tracking.
-- **quality** (`src/quality/`): 8-category quality scoring engine with profile-aware weights (Standard, Security, CRA, CBOM, etc.). CBOM profile scores algorithm strength, PQC readiness, OID coverage, crypto completeness, key/cert lifecycle, and cross-reference resolution with hard caps for broken cryptography. Compliance checks against 11 standards: NTIA, FDA, CRA Phase 1/2, NIST SSDF, EO 14028, CNSA 2.0, and NIST PQC (IR 8547).
+- **enrichment** (`src/enrichment/`): OSV and KEV vulnerability database integration, EPSS exploit-probability scores, EOL detection via endoflife.date API, package-registry staleness detection, Hugging Face model-registry metadata, and VEX ingestion (feature-gated behind `enrichment`). Includes file-based caching with TTL and staleness tracking, plus an offline mode served purely from cache.
+- **quality** (`src/quality/`): 8-category quality scoring engine with profile-aware weights (Standard, Security, CRA, BSI, CBOM, AI-readiness, etc.). CBOM profile scores algorithm strength, PQC readiness, OID coverage, crypto completeness, key/cert lifecycle, and cross-reference resolution with hard caps for broken cryptography. Compliance checks against 13 selectable standards: NTIA, FDA, CRA Phase 1/2, CRA Art. 24 (OSS steward), BSI TR-03183-2 v2.1.0, NIST SSDF, EO 14028, CNSA 2.0, NIST PQC (IR 8547), EUCC, EU AI Act, and BSI/G7 SBOM-for-AI.
 - **pipeline** (`src/pipeline/`): Orchestrates the parse → enrich → diff → report workflow. Handles stage sequencing and output routing.
-- **reports** (`src/reports/`): Report generators for JSON, SARIF, HTML, Markdown, CSV, summary, table, and side-by-side formats. Includes a streaming reporter for large outputs.
+- **reports** (`src/reports/`): Report generators for JSON, NDJSON, SARIF, OSCAL 1.1.2 assessment-results (validate), HTML, Markdown, CSV, summary, table, and side-by-side formats. Includes a streaming reporter for large outputs.
 - **tui** (`src/tui/`): Interactive ratatui-based UI for exploring diffs and single SBOMs/CBOMs. Supports diff mode, view mode (with SBOM/CBOM profile-driven tabs), fleet comparison, and timeline views. CBOM mode provides dedicated Algorithms, Certificates, Keys, Protocols, and PQC Compliance tabs with sorting and crypto inventory panels.
 - **verification** (`src/verification/`): File hash verification (SHA-256/512) and component hash auditing.
 - **license** (`src/license/`): License policy engine (allow/deny/review lists) with dependency propagation analysis.
-- **serialization** (`src/serialization/`): Raw JSON enrichment, SBOM tailoring (filter), and merging with deduplication.
+- **serialization** (`src/serialization/`): Raw JSON enrichment, SBOM tailoring (filter), merging with deduplication, and format emit/conversion (backing the `convert` command).
 - **watch** (`src/watch/`): Continuous SBOM monitoring with file watcher, vulnerability alerts, and debounced change detection.
 
 ## Data Flow
@@ -51,23 +51,21 @@ The `diff` command uses the full pipeline:
 
 ### Multi-SBOM Commands (`diff-multi`, `timeline`, `matrix`)
 
-Multi-SBOM commands bypass the pipeline and use `MultiDiffEngine` directly:
+Multi-SBOM commands reuse the pipeline for parsing and enrichment, then use `MultiDiffEngine` directly:
 
 ```
 cli/multi.rs
-  -> parse_sbom() (direct, not pipeline)
-  -> FuzzyMatchConfig::from_preset()
+  -> pipeline::parse_sbom_with_context() per path (+ optional enrichment)
+  -> FuzzyMatchConfig + optional matching rules (load_multi_rules)
   -> MultiDiffEngine::new()
   -> .diff_multi() / .timeline() / .matrix()
   -> JSON or TUI output only
 ```
 
 Key differences from single-diff:
-- No `DiffConfig` — uses scattered function parameters instead
-- No enrichment — vulnerability data not available in multi-SBOM views
+- Typed `MultiDiffConfig` (baseline/targets, enrichment, filtering, graph-diff, output sections)
 - No report format variety — JSON or TUI only (no SARIF/CSV/HTML/Markdown)
 - No streaming support
-- No matching rules
 
 ### Query Command (`query`)
 
@@ -113,7 +111,7 @@ The TUI has two independent app types:
 
 - **DiffApp** (`src/tui/app.rs`, `src/tui/views/`): Handles diff mode with `App` struct holding all state. Supports diff, multi-diff, timeline, and matrix modes across 12 tabs. Uses `ViewState` trait with per-tab state structs for all tabs.
 
-- **ViewApp** (`src/tui/view/app.rs`, `src/tui/view/views/`): Handles single-SBOM/CBOM view mode. Profile-driven tab system via `ViewTab::tabs_for_profile(BomProfile)` — SBOM mode shows 8 tabs, CBOM mode shows 8 crypto-specific tabs. Quality scoring uses `ScoringProfile::Cbom` when CBOM is detected. Runtime toggle via `P` key re-scores with the selected profile.
+- **ViewApp** (`src/tui/view/app.rs`, `src/tui/view/views/`): Handles single-SBOM/CBOM/AI-BOM view mode. Profile-driven tab system via `ViewTab::tabs_for_profile(BomProfile)` — SBOM mode shows 8 tabs, CBOM mode shows 8 crypto-specific tabs, AI-BOM mode shows 6 tabs (Overview, Models, Datasets, AI Readiness, Compliance, Source). Quality scoring uses `ScoringProfile::Cbom` when CBOM is detected. Runtime toggle via `P` key re-scores with the selected profile.
 
 Both app types share rendering utilities in `src/tui/shared/` (quality charts, component info, theme) and use `RenderContext` for read-only frame preparation.
 
@@ -132,14 +130,14 @@ Both app types share rendering utilities in `src/tui/shared/` (quality charts, c
 - **Matching rules**: Configurable matching behavior via YAML configs and custom rule engine.
 - **Enrichment**: OSV/KEV integration for vulnerability data and EOL detection via endoflife.date API (feature-gated).
 - **Reports**: Add new generators by implementing ReportGenerator.
-- **Compliance**: Add new standards by extending the quality scorer (currently: NTIA, FDA, CRA Phase 1/2, NIST SSDF, EO 14028, CNSA 2.0, NIST PQC).
+- **Compliance**: Add new standards by extending the compliance engine (`src/quality/compliance/`) and its `StandardSelector`/`rule_meta()` registry (currently: NTIA, FDA, CRA Phase 1/2, CRA Art. 24, BSI TR-03183-2, NIST SSDF, EO 14028, CNSA 2.0, NIST PQC, EUCC, EU AI Act, BSI/G7 SBOM-for-AI).
 - **CBOM Scoring**: Add new crypto quality categories by extending `CryptographyMetrics` and adding scoring methods. New `ScoringProfile` variants can define custom weight distributions.
-- **BOM Profiles**: Add new profile types beyond SBOM/CBOM by extending `BomProfile` enum and `tabs_for_profile()`.
+- **BOM Profiles**: Add new profile types beyond SBOM/CBOM/AI-BOM by extending `BomProfile` enum and `tabs_for_profile()`.
 
 ## Known Technical Debt
 
-- Multi-SBOM fleet commands (diff-multi, timeline, matrix) bypass the pipeline (no enrichment, limited output formats). The `query` command supports enrichment.
+- Multi-SBOM fleet commands (diff-multi, timeline, matrix) support enrichment but remain limited to JSON/TUI output.
 - Enrichment is orchestrated by CLI, not the pipeline module.
 - TUI has two parallel app types (DiffApp for diff modes, ViewApp for view mode) — intentionally separate but share rendering utilities.
 - SPDX 3.0 parser does not extract crypto properties (CycloneDX-only for CBOM).
-- ~996 tests across 19 test suites (708 unit + 288 integration/doc).
+- ~2,200 tests (~1,580 unit + ~630 integration) across 51 integration test suites.

--- a/docs/PROJECT_BRIEF.md
+++ b/docs/PROJECT_BRIEF.md
@@ -45,7 +45,8 @@ behavior rather than implement independent parsing or analysis rules.
 - Semantic and graph-aware diffing.
 - Quality profiles, standards validation, and documented CI exit gates.
 - Optional vulnerability, lifecycle, and model-registry enrichment.
-- TUI and JSON, SARIF, HTML, Markdown, CSV, table, summary, and NDJSON output.
+- TUI and JSON, NDJSON, SARIF, OSCAL (validate), HTML, Markdown, CSV, table,
+  summary, and side-by-side output.
 - C ABI with Go, Swift, Python, and Node.js bindings.
 
 ## Interface contract
@@ -81,8 +82,10 @@ this repository.
 ## Current contribution sequence
 
 1. Installation packaging for the Python and Node.js bindings, proposed separately.
-2. BOM-visible ML-regression CI gate.
-3. OSCAL assessment-results export for existing validation findings.
+
+Previously sequenced items now implemented: the BOM-visible ML-regression CI
+gate (`diff --fail-on-ml-regression`, exit code 7) and OSCAL 1.1.2
+assessment-results export for validation findings (`validate -o oscal-json`).
 
 The sequence is a roadmap, not a claim that unmerged or proposed work is
 available in a release.

--- a/docs/USER_JOURNEYS.md
+++ b/docs/USER_JOURNEYS.md
@@ -52,7 +52,7 @@ cargo run --release -- diff \
   /tmp/model-v2.cdx.json \
   -o json > /tmp/model-diff.json
 
-jq '.components.modified' /tmp/model-diff.json
+jq '.reports.components.modified' /tmp/model-diff.json
 ```
 
 The diff reports only changes represented in the two BOMs. It does not infer
@@ -157,9 +157,10 @@ cargo run --release -- validate \
 ```
 
 With the repository's deliberately minimal fixture, the quality command exits
-with code 1 because its score is below 70, and strict validation exits with code
-2 because warnings are present. Those non-zero results demonstrate the gates;
-they are not command failures.
+with code 1 because its score is below 70, and validation exits with code 1
+because the engine-backed NTIA check reports compliance errors (code 2 is
+reserved for warnings-only results under `--fail-on-warning`). Those non-zero
+results demonstrate the gates; they are not command failures.
 
 Exit codes are part of the CLI contract. A pipeline should gate on the selected
 flag and exit code, then retain the JSON or SARIF output for diagnosis. See

--- a/docs/cyclonedx-tool-center-submission.md
+++ b/docs/cyclonedx-tool-center-submission.md
@@ -116,7 +116,7 @@ Save as `tools/semantic_sbom_diff.json`:
 | `availability` | `OPEN_SOURCE`, `OSI_APPROVED` | MIT-licensed (MIT is OSI-approved). |
 | `functions` | `ANALYSIS`, `TRANSFORM` | Analyzes CycloneDX/SPDX BOMs; `merge`/`tailor`/`enrich` transform them. |
 | `analysis` | license / outdated / policy / vuln | `license-check`, EOL detection, license+quality policy engine, OSV/KEV enrichment. |
-| `transform` | `BOM_SERIALIZATION_FORMAT` | Reads/writes BOMs across JSON/XML during merge/tailor. Drop this entry if you consider it out of scope. |
+| `transform` | `BOM_SERIALIZATION_FORMAT` | The `convert` command converts between formats (SPDX ↔ CycloneDX); `merge`/`tailor` read/write BOMs across JSON/XML. |
 | `packaging` | `COMMAND_LINE_UTILITY` | Shipped as a CLI (also crates.io / Homebrew / prebuilt binaries). |
 | `library` | `RUST` | Implementation language. |
 | `platform` | Linux/Mac/Windows | Release ships binaries for all three. |

--- a/docs/pipeline-diagrams.md
+++ b/docs/pipeline-diagrams.md
@@ -64,10 +64,12 @@ flowchart TD
     B -->|Table| D[TableReporter - color-aware]
     B -->|Json| E[JsonReporter]
     B -->|Sarif| F[SarifReporter]
+    B -->|OscalJson| E
     B -->|Markdown| G[MarkdownReporter]
     B -->|Html| H[HtmlReporter]
     B -->|SideBySide| I[SideBySideReporter]
     B -->|Csv| L[CsvReporter]
+    B -->|Ndjson| N[NdjsonReportGenerator]
     B -->|Tui| E
 
     C --> J[generate_diff_report / generate_view_report]
@@ -78,6 +80,7 @@ flowchart TD
     H --> J
     I --> J
     L --> J
+    N --> J
     J --> K[String output]
     K --> M[write to file/stdout]
 ```
@@ -85,12 +88,12 @@ flowchart TD
 ## Multi-SBOM Pipeline (diff-multi / timeline / matrix)
 Source: `src/cli/multi.rs`, `src/diff/multi.rs`
 
-Multi-SBOM commands bypass the standard pipeline and use `MultiDiffEngine` directly.
+Multi-SBOM commands reuse the pipeline for parsing and optional enrichment, then use `MultiDiffEngine` directly.
 
 ```mermaid
 flowchart TD
-    A[SBOM paths] --> B[parse_sbom per path]
-    B --> C[FuzzyMatchConfig::from_preset]
+    A[SBOM paths] --> B[pipeline::parse_sbom_with_context per path + optional enrichment]
+    B --> C[FuzzyMatchConfig + optional matching rules]
     C --> D[MultiDiffEngine::new]
 
     D --> E{Command}
@@ -110,7 +113,7 @@ flowchart TD
     N --> O[write to file/stdout]
 ```
 
-Note: No enrichment, no DiffConfig, no streaming, no report format variety.
+Note: Typed `MultiDiffConfig`; enrichment supported; no streaming; output limited to JSON or TUI.
 
 ## Vulnerability Enrichment Flow (feature-gated)
 Source: `src/pipeline/parse.rs`, `src/cli/diff.rs`

--- a/docs/standards-support-plan.md
+++ b/docs/standards-support-plan.md
@@ -1,5 +1,12 @@
 # Standards Support Improvement Plan: CycloneDX 1.7 + SPDX 3.0
 
+> **Status: implemented.** CycloneDX 1.7 and SPDX 3.0 (JSON-LD) support has
+> since shipped — the parser today handles CycloneDX 1.4–1.7 (JSON/XML) and
+> SPDX 2.2/2.3 (JSON, tag-value, RDF/XML) plus SPDX 3.0 via a separate
+> `src/parsers/spdx3.rs`. This document is retained as the historical plan;
+> statements below about "current" parser capabilities describe the state
+> before implementation.
+
 ## Executive Summary
 
 This plan covers adding CycloneDX 1.7 and SPDX 3.0 support to sbom-tools. These are


### PR DESCRIPTION
## Summary

The three recent audit PRs (#320 compliance engine overhaul, #321 e2e fixes, #322 CLI audit) intentionally changed CLI behavior but the README and docs/ were never updated. This PR syncs all user-facing documentation with the actual code, verified claim-by-claim against source (and empirically against a freshly built binary for the exit codes and JSON shapes).

## README
- **Exit-code contract corrected** (the big one): operational/config errors exit `3` (not `1` as documented), clap parse errors exit `2`; gate-code table expanded with per-command meanings (validate compliance errors, `--min-score`/`--fail-on-noncompliant`, `--fail-on-warning`)
- `query` CI example comment was inverted — it exits 1 when *nothing* matches
- Added missing flags: `diff --fail-on-kev`, `quality --fail-on-noncompliant`, global `--offline`
- Diff TUI has 10 tabs (not 9); view mode cycles SBOM → CBOM → AI-BOM (`--bom-type aibom`, `P` key)
- 13 selectable compliance standards (not 11); OSCAL added to output formats

## docs/
- **ARCHITECTURE.md** (most stale): full command list (convert, cra-docs, cra-standards-watch, cache, config, man), 13 standards, real enrichment sources (EPSS, staleness, Hugging Face, VEX, offline), multi-SBOM commands now pipeline-backed with enrichment and typed `MultiDiffConfig`, NDJSON/OSCAL reporters, >512 MB inputs are rejected (not streamed), real test counts (~2,200 across 51 suites)
- **USER_JOURNEYS.md**: diff JSON path is `.reports.components.modified`; engine-backed NTIA validation now exits 1 (errors) on the demo fixture, 2 is reserved for warnings-only
- **PROJECT_BRIEF.md**: ML-regression gate and OSCAL export moved from roadmap to implemented
- **pipeline-diagrams.md**: OscalJson/Ndjson reporter branches; multi-SBOM diagram matches current code
- **cyclonedx-tool-center-submission.md**: `transform` entry now cites the real `convert` command
- **standards-support-plan.md**: marked as historical — CDX 1.7 + SPDX 3.0 have shipped

Verified accurate and untouched: docs/CRA_COMPLIANCE.md (all re-anchored citations, calibration tables, and cheat-sheet commands check out), docs/STANDARDS_VERSIONS.md, docs/PROJECT_OVERVIEW.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)