### PR TITLE
fix(tui): remove dead View-mode scaffolding, gate tab dispatch to Diff mode, honest shortcuts overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,8 @@ sbom-tools timeline v1.json v2.json v3.json
 sbom-tools matrix sbom1.json sbom2.json sbom3.json
 ```
 
+Each command opens a full-screen dashboard: press `p`/`Tab` to switch panels, `v` for the variable-components drill-down (multi-diff), `Enter` for a pair diff (matrix), and `d` to compare adjacent versions (timeline).
+
 ### Shell completions
 
 ```sh
@@ -613,7 +615,7 @@ Both `diff` and `view` commands launch an interactive terminal UI by default whe
 
 ### Diff Mode
 
-Compare two SBOMs with semantic change detection across 10 tabs.
+Compare two SBOMs with semantic change detection across 10 tabs (the Graph tab appears when dependency-graph changes are detected).
 
 **Summary** — Overall change score with component, vulnerability, and compliance breakdowns at a glance.
 
@@ -669,7 +671,7 @@ Explore a single SBOM, CBOM, or AI-BOM interactively. SBOM mode shows 8 tabs (Ov
 
 | Key | Action |
 |-----|--------|
-| `1`–`0` / `Tab` | Switch tabs |
+| `1`–`0` / `Tab` | Switch tabs (diff/view modes) |
 | `↑↓` / `jk` | Navigate items |
 | `Enter` / `Space` | Expand / collapse |
 | `/` | Search |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -109,7 +109,7 @@ responsible for calling it at the right time.
 
 The TUI has two independent app types:
 
-- **DiffApp** (`src/tui/app.rs`, `src/tui/views/`): Handles diff mode with `App` struct holding all state. Supports diff, multi-diff, timeline, and matrix modes across 12 tabs. Uses `ViewState` trait with per-tab state structs for all tabs.
+- **DiffApp** (`src/tui/app.rs`, `src/tui/views/`): Handles diff mode with `App` struct holding all state — 10 tabs (Summary, Components, Dependencies, Licenses, Vulnerabilities, Quality, Compliance, Side-by-Side, Graph, Source; Graph appears only when the diff contains graph changes). Multi-diff, timeline, and matrix modes reuse the same `App` but render full-screen dashboards with panel navigation instead of tabs. Uses `ViewState` trait with per-tab state structs for all tabs.
 
 - **ViewApp** (`src/tui/view/app.rs`, `src/tui/view/views/`): Handles single-SBOM/CBOM/AI-BOM view mode. Profile-driven tab system via `ViewTab::tabs_for_profile(BomProfile)` — SBOM mode shows 8 tabs, CBOM mode shows 8 crypto-specific tabs, AI-BOM mode shows 6 tabs (Overview, Models, Datasets, AI Readiness, Compliance, Source). Quality scoring uses `ScoringProfile::Cbom` when CBOM is detected. Runtime toggle via `P` key re-scores with the selected profile.
 

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -251,11 +251,11 @@ impl App {
     /// primaries and the ?/K overlay's This-Tab section. `None` in the multi
     /// modes (their `active_tab` is a stale preference restore).
     pub(crate) fn active_view_state(&self) -> Option<&dyn crate::tui::traits::ViewState> {
-        if !matches!(self.mode, AppMode::Diff | AppMode::View) {
+        if self.mode != AppMode::Diff {
             return None;
         }
         Some(match self.active_tab {
-            TabKind::Summary | TabKind::Overview | TabKind::Tree => &self.summary_view,
+            TabKind::Summary => &self.summary_view,
             TabKind::Components => &self.components_view,
             TabKind::Dependencies => &self.dependencies_view,
             TabKind::Licenses => &self.licenses_view,
@@ -430,9 +430,7 @@ impl App {
     /// The export is scoped to the active tab: e.g. if the user is on the
     /// Vulnerabilities tab only vulnerability data is included.
     pub fn export(&mut self, format: super::export::ExportFormat) {
-        use super::export::{
-            export_diff, export_view, tab_to_report_type, view_tab_to_report_type,
-        };
+        use super::export::{export_diff, tab_to_report_type};
         use crate::reports::ReportConfig;
 
         let result = match self.mode {
@@ -462,29 +460,6 @@ impl App {
                     )
                 } else {
                     self.set_status_message("No diff data to export");
-                    return;
-                }
-            }
-            AppMode::View => {
-                // Map diff TabKind to ViewTab for report type mapping
-                let report_type = match self.active_tab {
-                    super::TabKind::Tree => view_tab_to_report_type(crate::tui::ViewTab::Tree),
-                    super::TabKind::Vulnerabilities => {
-                        view_tab_to_report_type(crate::tui::ViewTab::Vulnerabilities)
-                    }
-                    super::TabKind::Licenses => {
-                        view_tab_to_report_type(crate::tui::ViewTab::Licenses)
-                    }
-                    super::TabKind::Dependencies => {
-                        view_tab_to_report_type(crate::tui::ViewTab::Dependencies)
-                    }
-                    _ => view_tab_to_report_type(crate::tui::ViewTab::Overview),
-                };
-                let config = ReportConfig::with_types(vec![report_type]);
-                if let Some(ref sbom) = self.data.sbom {
-                    export_view(format, sbom, None, &config, self.export_template.as_deref())
-                } else {
-                    self.set_status_message("No SBOM data available for export");
                     return;
                 }
             }
@@ -813,7 +788,6 @@ impl App {
                     AppMode::Timeline => ShortcutsContext::Timeline,
                     AppMode::Matrix => ShortcutsContext::Matrix,
                     AppMode::Diff => ShortcutsContext::Diff,
-                    AppMode::View => ShortcutsContext::View,
                 };
                 self.overlays.shortcuts.show(context);
             }
@@ -923,14 +897,14 @@ impl App {
         self.ensure_compliance_results();
 
         // 3. Vulnerability cache (was inline in render_vulnerabilities)
-        if matches!(self.mode, AppMode::Diff | AppMode::View) {
+        if self.mode == AppMode::Diff {
             self.ensure_vulnerability_cache();
         }
 
         // 4. Component totals (was inline in render_components)
         let comp_filter = self.components_state().filter;
         let comp_total = match self.mode {
-            AppMode::Diff | AppMode::View => self.diff_component_count(comp_filter),
+            AppMode::Diff => self.diff_component_count(comp_filter),
             AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => 0,
         };
         self.components_state_mut().total = comp_total;
@@ -965,7 +939,7 @@ impl App {
         // Build the aligned-rows / unified-entries lists and grouped panel counts
         // into owned locals BEFORE taking a &mut on the side-by-side state, so the
         // immutable `self.data.diff_result` borrow does not overlap the &mut borrow.
-        if matches!(self.mode, AppMode::Diff | AppMode::View) {
+        if self.mode == AppMode::Diff {
             let filter = self.side_by_side_state().filter.clone();
             let (aligned, unified, grouped_left, grouped_right) =
                 self.data.diff_result.as_ref().map_or_else(
@@ -1003,7 +977,7 @@ impl App {
     /// Pre-compute license totals for rendering.
     fn prepare_license_totals(&mut self) {
         match self.mode {
-            AppMode::Diff | AppMode::View => {
+            AppMode::Diff => {
                 if let Some(ref result) = self.data.diff_result {
                     let focus_left = self.licenses_state().focus_left;
                     let risk_filter = self.licenses_state().risk_filter;
@@ -1047,7 +1021,7 @@ impl App {
     /// Pre-compute vulnerability totals for rendering.
     fn prepare_vulnerability_totals(&mut self) {
         let vuln_total = match self.mode {
-            AppMode::Diff | AppMode::View => self.diff_vulnerability_count(),
+            AppMode::Diff => self.diff_vulnerability_count(),
             AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => 0,
         };
         self.vulnerabilities_state_mut().total = vuln_total;
@@ -1067,8 +1041,6 @@ impl App {
 pub enum AppMode {
     /// Comparing two SBOMs
     Diff,
-    /// Exploring a single SBOM
-    View,
     /// 1:N multi-diff comparison
     MultiDiff,
     /// Timeline analysis
@@ -1081,10 +1053,6 @@ pub enum AppMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TabKind {
     Summary,
-    /// Single SBOM overview (View mode)
-    Overview,
-    /// Hierarchical component browser (View mode)
-    Tree,
     Components,
     Dependencies,
     Licenses,
@@ -1101,8 +1069,6 @@ impl TabKind {
     pub const fn title(&self) -> &'static str {
         match self {
             Self::Summary => "Summary",
-            Self::Overview => "Overview",
-            Self::Tree => "Tree",
             Self::Components => "Components",
             Self::Dependencies => "Dependencies",
             Self::Licenses => "Licenses",
@@ -1120,8 +1086,6 @@ impl TabKind {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Summary => "summary",
-            Self::Overview => "overview",
-            Self::Tree => "tree",
             Self::Components => "components",
             Self::Dependencies => "dependencies",
             Self::Licenses => "licenses",
@@ -1139,8 +1103,6 @@ impl TabKind {
     pub fn from_str_opt(s: &str) -> Option<Self> {
         match s {
             "summary" => Some(Self::Summary),
-            "overview" => Some(Self::Overview),
-            "tree" => Some(Self::Tree),
             "components" => Some(Self::Components),
             "dependencies" => Some(Self::Dependencies),
             "licenses" => Some(Self::Licenses),
@@ -1151,37 +1113,6 @@ impl TabKind {
             "graph" => Some(Self::GraphChanges),
             "source" => Some(Self::Source),
             _ => None,
-        }
-    }
-
-    /// Returns the tabs visible in a given mode.
-    #[must_use]
-    pub const fn tabs_for_mode(mode: AppMode) -> &'static [TabKind] {
-        match mode {
-            AppMode::View => &[
-                TabKind::Overview,
-                TabKind::Tree,
-                TabKind::Vulnerabilities,
-                TabKind::Licenses,
-                TabKind::Dependencies,
-                TabKind::Quality,
-                TabKind::Compliance,
-                TabKind::Source,
-            ],
-            AppMode::Diff => &[
-                TabKind::Summary,
-                TabKind::Components,
-                TabKind::Dependencies,
-                TabKind::Licenses,
-                TabKind::Vulnerabilities,
-                TabKind::Quality,
-                TabKind::Compliance,
-                TabKind::SideBySide,
-                TabKind::GraphChanges,
-                TabKind::Source,
-            ],
-            // MultiDiff/Timeline/Matrix use full-screen renders, not tabs
-            AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => &[],
         }
     }
 }

--- a/src/tui/app_impl_constructors.rs
+++ b/src/tui/app_impl_constructors.rs
@@ -195,39 +195,6 @@ impl App {
         }
     }
 
-    /// Create a new app for single-SBOM view mode.
-    ///
-    /// Sets up quality scoring, compliance checking, and source viewing
-    /// for exploring a single SBOM interactively.
-    #[must_use]
-    pub fn new_view(sbom: NormalizedSbom, raw_content: &str) -> Self {
-        // Quality scoring — profile-aware so AI-BOMs / CBOMs score correctly.
-        let profile = crate::tui::scoring_profile_for(crate::model::BomProfile::detect(&sbom));
-        let scorer = QualityScorer::new(profile);
-        let quality_report = Some(scorer.score(&sbom));
-
-        // Build index for O(1) lookups
-        let sbom_index = Some(sbom.build_index());
-
-        // Source viewer (single SBOM, no diff annotations)
-        let source = SourceDiffState::new("", raw_content);
-
-        let mut app = Self::base(AppMode::View);
-
-        // Restore last view tab preference
-        app.active_tab = crate::config::TuiPreferences::load()
-            .last_view_tab
-            .as_deref()
-            .and_then(TabKind::from_str_opt)
-            .unwrap_or(TabKind::Overview);
-
-        app.source_view = crate::tui::view_states::SourceView::with_state(source);
-        app.data.sbom = Some(sbom);
-        app.data.sbom_index = sbom_index;
-        app.data.quality_report = quality_report;
-        app
-    }
-
     /// Create a new app for multi-diff mode
     #[must_use]
     pub fn new_multi_diff(result: MultiDiffResult) -> Self {

--- a/src/tui/app_impl_nav.rs
+++ b/src/tui/app_impl_nav.rs
@@ -15,14 +15,12 @@ impl App {
 
         self.active_tab = match self.active_tab {
             TabKind::Summary => TabKind::Components,
-            TabKind::Overview => TabKind::Tree,
-            TabKind::Tree => TabKind::Components,
             TabKind::Components => TabKind::Dependencies,
             TabKind::Dependencies => TabKind::Licenses,
             TabKind::Licenses => TabKind::Vulnerabilities,
             TabKind::Vulnerabilities => TabKind::Quality,
             TabKind::Quality => {
-                if matches!(self.mode, AppMode::Diff | AppMode::View) {
+                if self.mode == AppMode::Diff {
                     TabKind::Compliance
                 } else {
                     TabKind::Summary
@@ -51,14 +49,12 @@ impl App {
 
         self.active_tab = match self.active_tab {
             TabKind::Summary => {
-                if matches!(self.mode, AppMode::Diff | AppMode::View) {
+                if self.mode == AppMode::Diff {
                     TabKind::Source
                 } else {
                     TabKind::Quality
                 }
             }
-            TabKind::Overview => TabKind::Summary,
-            TabKind::Tree => TabKind::Overview,
             TabKind::Components => TabKind::Summary,
             TabKind::Dependencies => TabKind::Components,
             TabKind::Licenses => TabKind::Dependencies,
@@ -286,8 +282,6 @@ impl App {
 
         match target {
             TabTarget::Summary => self.active_tab = TabKind::Summary,
-            TabTarget::Overview => self.active_tab = TabKind::Overview,
-            TabTarget::Tree => self.active_tab = TabKind::Tree,
             TabTarget::Components => self.active_tab = TabKind::Components,
             TabTarget::Dependencies => self.active_tab = TabKind::Dependencies,
             TabTarget::Licenses => self.active_tab = TabKind::Licenses,

--- a/src/tui/events/helpers.rs
+++ b/src/tui/events/helpers.rs
@@ -40,7 +40,7 @@ pub(super) fn get_selected_component_name(app: &App) -> Option<String> {
             }
             None
         }
-        AppMode::Diff | AppMode::View => {
+        AppMode::Diff => {
             // Resolve through the same filtered + sorted list the Components
             // table renders (the raw added->removed->modified concatenation
             // opened the wrong component's deep dive under any sort/filter).

--- a/src/tui/events/mod.rs
+++ b/src/tui/events/mod.rs
@@ -260,10 +260,15 @@ pub fn handle_key_event(app: &mut super::App, key: KeyEvent) {
 /// Dispatch a key to the active tab's handler.
 ///
 /// Returns `true` if the tab consumed the key, meaning it must not fall through
-/// to [`handle_global_fallback`]. Tabs without a dedicated handler
-/// (Summary/Overview/Tree) never consume, so global bindings and list
-/// navigation still apply on them.
+/// to [`handle_global_fallback`]. Tabs without a dedicated handler (Summary)
+/// never consume, so global bindings and list navigation still apply on them.
 fn dispatch_tab_key(app: &mut super::App, key: KeyEvent) -> bool {
+    // Gated to Diff mode: the multi modes have no visible tabs — their
+    // `active_tab` is a stale preference restore (see `App::base`) — so no
+    // key may leak into an invisible tab handler.
+    if app.mode != super::AppMode::Diff {
+        return false;
+    }
     match app.active_tab {
         super::TabKind::Components => components::handle_components_keys(app, key),
         super::TabKind::Dependencies => dependencies::handle_dependencies_keys(app, key),
@@ -274,20 +279,20 @@ fn dispatch_tab_key(app: &mut super::App, key: KeyEvent) -> bool {
         super::TabKind::GraphChanges => graph_changes::handle_graph_changes_keys(app, key),
         super::TabKind::SideBySide => sidebyside::handle_sidebyside_keys(app, key),
         super::TabKind::Source => source::handle_source_keys(app, key),
-        super::TabKind::Summary | super::TabKind::Overview | super::TabKind::Tree => false,
+        super::TabKind::Summary => false,
     }
 }
 
 /// Dispatch a key to the active multi-comparison mode handler.
 ///
-/// Returns `true` if the mode consumed the key. Single-pair modes (Diff/View)
-/// have no mode handler and never consume here.
+/// Returns `true` if the mode consumed the key. The single-pair Diff mode
+/// has no mode handler and never consumes here.
 fn dispatch_mode_key(app: &mut super::App, key: KeyEvent) -> bool {
     match app.mode {
         super::AppMode::MultiDiff => multi_diff::handle_multi_diff_keys(app, key),
         super::AppMode::Timeline => timeline::handle_timeline_keys(app, key),
         super::AppMode::Matrix => matrix::handle_matrix_keys(app, key),
-        super::AppMode::Diff | super::AppMode::View => false,
+        super::AppMode::Diff => false,
     }
 }
 
@@ -370,19 +375,25 @@ fn handle_global_fallback(app: &mut super::App, key: KeyEvent) {
             }
         }
         // Real terminals report Shift+Tab as BackTab (never Tab+SHIFT), so
-        // the modifier check above only serves synthetic events. Gated to the
-        // tabbed modes: the multi-mode handlers consume Tab as a panel toggle
+        // the modifier check above only serves synthetic events. Gated to
+        // Diff mode: the multi-mode handlers consume Tab as a panel toggle
         // and BackTab must not mutate their hidden diff active_tab.
-        KeyCode::BackTab if matches!(app.mode, super::AppMode::Diff | super::AppMode::View) => {
+        KeyCode::BackTab if app.mode == super::AppMode::Diff => {
             app.prev_tab();
         }
         KeyCode::Char('/') => app.start_search(),
-        KeyCode::Char('1') => app.select_tab(super::TabKind::Summary),
-        KeyCode::Char('2') => app.select_tab(super::TabKind::Components),
-        KeyCode::Char('3') => app.select_tab(super::TabKind::Dependencies),
-        KeyCode::Char('4') => app.select_tab(super::TabKind::Licenses),
-        KeyCode::Char('5') => app.select_tab(super::TabKind::Vulnerabilities),
-        KeyCode::Char('6') => app.select_tab(super::TabKind::Quality),
+        // Digit tab-select only in Diff mode: the multi modes have no visible
+        // tabs, so a digit must never mutate their hidden active_tab.
+        KeyCode::Char(c @ '1'..='6') if app.mode == super::AppMode::Diff => {
+            app.select_tab(match c {
+                '1' => super::TabKind::Summary,
+                '2' => super::TabKind::Components,
+                '3' => super::TabKind::Dependencies,
+                '4' => super::TabKind::Licenses,
+                '5' => super::TabKind::Vulnerabilities,
+                _ => super::TabKind::Quality,
+            });
+        }
         KeyCode::Char('7') => {
             // Compliance only in diff mode
             if app.mode == super::AppMode::Diff {
@@ -396,16 +407,20 @@ fn handle_global_fallback(app: &mut super::App, key: KeyEvent) {
             }
         }
         KeyCode::Char('9') => {
-            // Graph changes tab when graph diff data is available, otherwise Source
+            // Graph changes tab when graph diff data is available, otherwise
+            // Source. Diff mode only (belt-and-braces: multi modes never have
+            // diff_result, but they must not reach a tab select either way).
             let has_graph = app
                 .data
                 .diff_result
                 .as_ref()
                 .is_some_and(|r| !r.graph_changes.is_empty());
-            if has_graph {
-                app.select_tab(super::TabKind::GraphChanges);
-            } else if app.mode == super::AppMode::Diff {
-                app.select_tab(super::TabKind::Source);
+            if app.mode == super::AppMode::Diff {
+                if has_graph {
+                    app.select_tab(super::TabKind::GraphChanges);
+                } else {
+                    app.select_tab(super::TabKind::Source);
+                }
             }
         }
         KeyCode::Char('0') => {
@@ -575,7 +590,6 @@ fn open_shortcuts_overlay(app: &mut super::App) {
         super::AppMode::Timeline => super::app::ShortcutsContext::Timeline,
         super::AppMode::Matrix => super::app::ShortcutsContext::Matrix,
         super::AppMode::Diff => super::app::ShortcutsContext::Diff,
-        super::AppMode::View => super::app::ShortcutsContext::View,
     };
     let tab = app.active_view_state().map(|v| {
         (
@@ -772,5 +786,57 @@ mod dispatch_precedence_tests {
             TabKind::Components,
             "Tab must switch tabs from Components, not toggle panel focus"
         );
+    }
+
+    /// The three multi-mode dashboards, built from the real fixtures. The
+    /// active tab is forced post-construction (the same prefs-isolation
+    /// convention as [`diff_app`]) — in production it is a stale preference
+    /// restore from `App::base`.
+    fn multi_apps() -> Vec<App> {
+        use crate::tui::test_support::{demo_matrix, demo_multi_diff, demo_timeline};
+        pin_theme();
+        vec![
+            App::new_multi_diff(demo_multi_diff()),
+            App::new_timeline(demo_timeline()),
+            App::new_matrix(demo_matrix()),
+        ]
+    }
+
+    /// The multi modes have no visible tabs; their `active_tab` is a stale
+    /// preference restore. `dispatch_tab_key` must never route a key into an
+    /// invisible tab handler there — neither a tab-local binding ('f' filter,
+    /// '/' search) nor a digit the hidden tab would swallow.
+    #[test]
+    fn multi_modes_never_dispatch_to_hidden_tab_handlers() {
+        for mut app in multi_apps() {
+            for hidden_tab in [TabKind::Components, TabKind::SideBySide] {
+                app.active_tab = hidden_tab;
+                for key in ['f', '1', '/'] {
+                    assert!(
+                        !dispatch_tab_key(&mut app, k(KeyCode::Char(key))),
+                        "{:?} with hidden {hidden_tab:?} must not consume '{key}' in an invisible tab handler",
+                        app.mode
+                    );
+                }
+            }
+        }
+    }
+
+    /// End-to-end through the real dispatcher: the global digit tab-select is
+    /// gated to Diff mode, so a digit pressed in a multi-mode dashboard leaves
+    /// the hidden `active_tab` untouched.
+    #[test]
+    fn digit_tab_select_is_inert_in_multi_modes() {
+        for mut app in multi_apps() {
+            for hidden_tab in [TabKind::Components, TabKind::SideBySide] {
+                app.active_tab = hidden_tab;
+                handle_key_event(&mut app, k(KeyCode::Char('2')));
+                assert_eq!(
+                    app.active_tab, hidden_tab,
+                    "'2' in {:?} must not mutate the hidden active_tab",
+                    app.mode
+                );
+            }
+        }
     }
 }

--- a/src/tui/events/mouse.rs
+++ b/src/tui/events/mouse.rs
@@ -8,7 +8,7 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent) {
     app.clear_status_message();
 
     // The multi-comparison modes have their own layouts; the tabbed logic
-    // below assumes the Diff/View chrome and mis-routed y<=2 clicks into
+    // below assumes the Diff chrome and mis-routed y<=2 clicks into
     // select_tab.
     match app.mode {
         AppMode::MultiDiff => {
@@ -23,7 +23,7 @@ pub fn handle_mouse_event(app: &mut App, mouse: MouseEvent) {
             handle_matrix_mouse(app, mouse);
             return;
         }
-        AppMode::Diff | AppMode::View => {}
+        AppMode::Diff => {}
     }
 
     match mouse.kind {

--- a/src/tui/export.rs
+++ b/src/tui/export.rs
@@ -65,8 +65,6 @@ pub const fn tab_to_report_type(tab: TabKind) -> ReportType {
         TabKind::Licenses => ReportType::Licenses,
         TabKind::Vulnerabilities => ReportType::Vulnerabilities,
         TabKind::Summary
-        | TabKind::Overview
-        | TabKind::Tree
         | TabKind::Quality
         | TabKind::Compliance
         | TabKind::SideBySide

--- a/src/tui/traits.rs
+++ b/src/tui/traits.rs
@@ -87,8 +87,6 @@ impl EventResult {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TabTarget {
     Summary,
-    Overview,
-    Tree,
     Components,
     Dependencies,
     Licenses,
@@ -112,8 +110,6 @@ impl TabTarget {
     pub const fn to_tab_kind(&self) -> Option<super::app::TabKind> {
         match self {
             Self::Summary => Some(super::app::TabKind::Summary),
-            Self::Overview => Some(super::app::TabKind::Overview),
-            Self::Tree => Some(super::app::TabKind::Tree),
             Self::Components | Self::ComponentByName(_) | Self::ComponentByLicense(_) => {
                 Some(super::app::TabKind::Components)
             }
@@ -135,8 +131,6 @@ impl TabTarget {
     pub const fn from_tab_kind(kind: super::app::TabKind) -> Self {
         match kind {
             super::app::TabKind::Summary => Self::Summary,
-            super::app::TabKind::Overview => Self::Overview,
-            super::app::TabKind::Tree => Self::Tree,
             super::app::TabKind::Components => Self::Components,
             super::app::TabKind::Dependencies => Self::Dependencies,
             super::app::TabKind::Licenses => Self::Licenses,
@@ -240,7 +234,6 @@ impl ViewMode {
     pub const fn from_app_mode(mode: super::app::AppMode) -> Self {
         match mode {
             super::app::AppMode::Diff => Self::Diff,
-            super::app::AppMode::View => Self::View,
             super::app::AppMode::MultiDiff => Self::MultiDiff,
             super::app::AppMode::Timeline => Self::Timeline,
             super::app::AppMode::Matrix => Self::Matrix,

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -120,8 +120,8 @@ fn render(frame: &mut Frame, app: &mut App) {
             render_cross_view_overlays(frame, app);
             return;
         }
-        // Diff and View modes use the tabbed layout below
-        AppMode::Diff | AppMode::View => {}
+        // Diff mode uses the tabbed layout below
+        AppMode::Diff => {}
     }
 
     // Main layout: header, tabs, content, status bar, footer
@@ -155,8 +155,6 @@ fn render(frame: &mut Frame, app: &mut App) {
     match app.active_tab {
         // --- Migrated to RenderContext ---
         TabKind::Summary
-        | TabKind::Overview
-        | TabKind::Tree
         | TabKind::Quality
         | TabKind::GraphChanges
         | TabKind::Compliance
@@ -167,9 +165,7 @@ fn render(frame: &mut Frame, app: &mut App) {
         | TabKind::Vulnerabilities => {
             let ctx = super::render_context::RenderContext::from_app(app);
             match app.active_tab {
-                TabKind::Summary | TabKind::Overview | TabKind::Tree => {
-                    views::render_summary(frame, chunks[2], &ctx);
-                }
+                TabKind::Summary => views::render_summary(frame, chunks[2], &ctx),
                 TabKind::Quality => views::render_quality(frame, chunks[2], &ctx),
                 TabKind::GraphChanges => views::render_graph_changes(frame, chunks[2], &ctx),
                 TabKind::Compliance => views::render_diff_compliance(frame, chunks[2], &ctx),
@@ -261,10 +257,6 @@ fn render_header(frame: &mut Frame, area: Rect, app: &App) {
             let new_label = sbom_label(app.data.new_sbom.as_ref());
             ("diff", format!("{old_label} \u{27f7} {new_label}"))
         }
-        AppMode::View => {
-            let label = sbom_label(app.data.sbom.as_ref());
-            ("view", label)
-        }
         AppMode::MultiDiff => ("multi-diff", "Multi-Diff Comparison".to_string()),
         AppMode::Timeline => ("timeline", "Timeline Analysis".to_string()),
         AppMode::Matrix => ("matrix", "Matrix Comparison".to_string()),
@@ -328,8 +320,8 @@ pub(crate) fn diff_tab_entries(app: &App) -> Vec<(TabKind, &'static str, &'stati
         (TabKind::Quality, "6", "Quality"),
     ];
 
-    // Compliance and side-by-side tabs only in diff/view mode
-    if matches!(app.mode, AppMode::Diff | AppMode::View) {
+    // Compliance and side-by-side tabs only in diff mode
+    if app.mode == AppMode::Diff {
         tabs_data.push((TabKind::Compliance, "7", "Compliance"));
         tabs_data.push((TabKind::SideBySide, "8", "Diff"));
     }
@@ -344,9 +336,9 @@ pub(crate) fn diff_tab_entries(app: &App) -> Vec<(TabKind, &'static str, &'stati
         tabs_data.push((TabKind::GraphChanges, "9", "Graph"));
     }
 
-    // Source tab always available in diff/view mode.
+    // Source tab always available in diff mode.
     // Uses [9] when it's the 9th tab (no graph changes), [0] when it's the 10th.
-    if matches!(app.mode, AppMode::Diff | AppMode::View) {
+    if app.mode == AppMode::Diff {
         let source_key = if has_graph_changes { "0" } else { "9" };
         tabs_data.push((TabKind::Source, source_key, "Source"));
     }
@@ -434,10 +426,6 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
             let score = result.map_or(0.0, |r| r.semantic_score);
             (comp, vuln, Some(score))
         }
-        AppMode::View => {
-            let comp = app.data.sbom.as_ref().map_or(0, |s| s.components.len());
-            (comp, 0, None)
-        }
         // Multi-comparison modes use their own status bars
         AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => (0, 0, None),
     };
@@ -450,7 +438,7 @@ fn render_status_bar(frame: &mut Frame, area: Rect, app: &App) {
                 .filter(|v| v.severity == "Critical")
                 .count()
         }),
-        AppMode::View | AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => 0,
+        AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => 0,
     };
 
     let mut spans = vec![

--- a/src/tui/views/components.rs
+++ b/src/tui/views/components.rs
@@ -72,13 +72,13 @@ pub fn render_components(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
     // Totals and clamp_selection are done in prepare_render().
     // Compute total_unfiltered for empty-state display only.
     let total_unfiltered = match ctx.mode {
-        AppMode::Diff | AppMode::View => ctx.diff_result.map_or(0, |r| r.components.total()),
+        AppMode::Diff => ctx.diff_result.map_or(0, |r| r.components.total()),
         AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => 0,
     };
 
     // Build the list data once for rendering
     let component_data = match ctx.mode {
-        AppMode::Diff | AppMode::View => ComponentListData::Diff(ctx.diff_component_items()),
+        AppMode::Diff => ComponentListData::Diff(ctx.diff_component_items()),
         AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => ComponentListData::Empty,
     };
 

--- a/src/tui/views/dependencies.rs
+++ b/src/tui/views/dependencies.rs
@@ -27,7 +27,7 @@ fn compute_graph_hash(edges: &[(String, String)]) -> u64 {
 /// Takes `&mut DependenciesState` and `&DataContext` separately to avoid
 /// borrow conflicts when accessing both data and state on `App`.
 pub fn update_graph_cache(deps: &mut DependenciesState, data: &DataContext, mode: AppMode) {
-    if matches!(mode, AppMode::Diff | AppMode::View) {
+    if mode == AppMode::Diff {
         update_diff_mode_cache(deps, data);
     }
 }
@@ -539,7 +539,7 @@ fn render_dependency_tree(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
     let vuln_components = &ctx.dependencies.cached_vuln_components;
 
     match ctx.mode {
-        AppMode::Diff | AppMode::View => {
+        AppMode::Diff => {
             render_diff_tree_cached(
                 &mut lines,
                 &mut visible_nodes,

--- a/src/tui/views/licenses.rs
+++ b/src/tui/views/licenses.rs
@@ -28,7 +28,7 @@ pub fn render_licenses(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
 
     // License content
     match ctx.mode {
-        AppMode::Diff | AppMode::View => render_diff_licenses(frame, chunks[1], ctx),
+        AppMode::Diff => render_diff_licenses(frame, chunks[1], ctx),
         // Multi-comparison modes have their own views
         AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => {}
     }

--- a/src/tui/views/overlays.rs
+++ b/src/tui/views/overlays.rs
@@ -522,20 +522,44 @@ fn get_shortcuts_for_context(
     context: ShortcutsContext,
     profile: Option<crate::model::BomProfile>,
 ) -> Vec<ShortcutSection> {
-    // When the active profile is known (view mode), the number keys map
-    // positionally to that profile's tab set, so derive the "Jump to tab"
-    // range from the real tab count instead of a hard-coded "1-8".
-    let jump_hint = profile.map_or_else(
-        || "1-8".to_string(),
-        |p| {
-            let n = crate::tui::view::ViewTab::tabs_for_profile(p).len();
-            if n <= 1 {
-                "1".to_string()
-            } else {
-                format!("1-{n}")
-            }
-        },
-    );
+    let mut nav_items = vec![
+        item("j/k", "Up/Down"),
+        item("h/l", "Left/Right"),
+        item("g/G", "First/Last"),
+        item("PgUp/PgDn", "Page up/down"),
+        item("Home/End", "Jump to start/end"),
+    ];
+    // Tab-switching rows only exist in the tabbed modes; the multi modes bind
+    // Tab to panel switching (documented in their own sections) and digits are
+    // gated off there.
+    if !matches!(
+        context,
+        ShortcutsContext::MultiDiff | ShortcutsContext::Timeline | ShortcutsContext::Matrix
+    ) {
+        // When the active profile is known (view mode), the number keys map
+        // positionally to that profile's tab set, so derive the "Jump to tab"
+        // range from the real tab count. The Diff tab bar binds 1-9 plus 0
+        // (Source shifts to 0 when the Graph tab appears).
+        let jump_hint = profile.map_or_else(
+            || {
+                if context == ShortcutsContext::Diff {
+                    "1-9/0".to_string()
+                } else {
+                    "1-8".to_string()
+                }
+            },
+            |p| {
+                let n = crate::tui::view::ViewTab::tabs_for_profile(p).len();
+                if n <= 1 {
+                    "1".to_string()
+                } else {
+                    format!("1-{n}")
+                }
+            },
+        );
+        nav_items.push(item("Tab", "Next tab"));
+        nav_items.push((jump_hint, "Jump to tab".to_string()));
+    }
 
     let mut sections = vec![
         ShortcutSection {
@@ -557,15 +581,7 @@ fn get_shortcuts_for_context(
         },
         ShortcutSection {
             title: "Navigation",
-            items: vec![
-                item("j/k", "Up/Down"),
-                item("h/l", "Left/Right"),
-                item("g/G", "First/Last"),
-                item("PgUp/PgDn", "Page up/down"),
-                item("Home/End", "Jump to start/end"),
-                item("Tab", "Next tab"),
-                (jump_hint, "Jump to tab".to_string()),
-            ],
+            items: nav_items,
         },
     ];
 
@@ -1002,7 +1018,8 @@ mod tests {
 
     #[test]
     fn no_profile_falls_back_to_generic_hint_without_tab_section() {
-        // Diff-mode passes None: keep the existing generic "1-8" hint and no
+        // Diff-mode passes None: the hint documents the real diff digit
+        // targets (1-9 plus 0 when the Graph tab appears) and there is no
         // profile-specific tab listing.
         let sections = get_shortcuts_for_context(ShortcutsContext::Diff, None);
         assert!(
@@ -1010,7 +1027,29 @@ mod tests {
             "no profile -> no profile-tab section"
         );
         let items: Vec<_> = sections.into_iter().flat_map(|s| s.items).collect();
-        assert_eq!(jump_range(&items), "1-8");
+        assert_eq!(jump_range(&items), "1-9/0");
+    }
+
+    /// The multi modes have no visible tabs — Tab switches panels there — so
+    /// the Navigation section must not advertise tab switching or digit
+    /// jumping in those contexts.
+    #[test]
+    fn multi_contexts_do_not_advertise_tab_switching() {
+        for ctx in [
+            ShortcutsContext::MultiDiff,
+            ShortcutsContext::Timeline,
+            ShortcutsContext::Matrix,
+        ] {
+            let items = flatten(ctx, None);
+            assert!(
+                !items.iter().any(|(_, d)| d == "Next tab"),
+                "{ctx:?} must not advertise a Next tab row"
+            );
+            assert!(
+                !items.iter().any(|(_, d)| d == "Jump to tab"),
+                "{ctx:?} must not advertise a Jump to tab row"
+            );
+        }
     }
 
     /// The MultiDiff/Timeline/Matrix sections must document the phase-6

--- a/src/tui/views/quality.rs
+++ b/src/tui/views/quality.rs
@@ -17,7 +17,7 @@ use ratatui::{
 
 pub fn render_quality(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
     match ctx.mode {
-        AppMode::Diff | AppMode::View => render_diff_quality(frame, area, ctx),
+        AppMode::Diff => render_diff_quality(frame, area, ctx),
         AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => {}
     }
 }

--- a/src/tui/views/sidebyside.rs
+++ b/src/tui/views/sidebyside.rs
@@ -42,7 +42,7 @@ enum SemverBump {
 /// Render side-by-side diff view
 pub fn render_sidebyside(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
     match ctx.mode {
-        AppMode::Diff | AppMode::View => render_diff_sidebyside(frame, area, ctx),
+        AppMode::Diff => render_diff_sidebyside(frame, area, ctx),
         // Multi-comparison modes have their own views
         AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => {
             crate::tui::widgets::render_empty_state_enhanced(

--- a/src/tui/views/summary.rs
+++ b/src/tui/views/summary.rs
@@ -10,7 +10,7 @@ use ratatui::{
 
 pub fn render_summary(frame: &mut Frame, area: Rect, ctx: &RenderContext) {
     match ctx.mode {
-        AppMode::Diff | AppMode::View => render_diff_summary(frame, area, ctx),
+        AppMode::Diff => render_diff_summary(frame, area, ctx),
         // Multi-comparison modes have their own views
         AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => {}
     }

--- a/src/tui/views/vulnerabilities.rs
+++ b/src/tui/views/vulnerabilities.rs
@@ -85,7 +85,7 @@ pub fn render_vulnerabilities(frame: &mut Frame, area: Rect, ctx: &RenderContext
 
     // Compute total unfiltered count (totals/clamping already done in prepare_render)
     let total_unfiltered = match ctx.mode {
-        AppMode::Diff | AppMode::View => ctx.diff_result.map_or(0, |r| {
+        AppMode::Diff => ctx.diff_result.map_or(0, |r| {
             r.vulnerabilities.introduced.len()
                 + r.vulnerabilities.resolved.len()
                 + r.vulnerabilities.persistent.len()
@@ -95,9 +95,7 @@ pub fn render_vulnerabilities(frame: &mut Frame, area: Rect, ctx: &RenderContext
 
     // Build the list data once for rendering (cache already warmed in prepare_render)
     let vuln_data = match ctx.mode {
-        AppMode::Diff | AppMode::View => {
-            VulnListData::Diff(ctx.diff_vulnerability_items_from_cache())
-        }
+        AppMode::Diff => VulnListData::Diff(ctx.diff_vulnerability_items_from_cache()),
         AppMode::MultiDiff | AppMode::Timeline | AppMode::Matrix => VulnListData::Empty,
     };
 


### PR DESCRIPTION
## Summary

Precursor PR for the upcoming multi-mode pair drill-down feature; independently valuable cleanup of the DiffApp TUI's tab machinery.

- **Dead code removed**: `AppMode::View`, `TabKind::{Overview,Tree}`, `TabTarget::{Overview,Tree}`, `TabKind::tabs_for_mode()`, `App::new_view()` — all unreachable from any CLI path (the `view` command uses the separate `ViewApp`). ~45 dead match arms deleted; the `Diff | View` patterns collapse to `Diff`. No prefs migration needed: stale `"overview"`/`"tree"` `last_tab` values already fall back to Summary.
- **Dispatch gating**: `dispatch_tab_key` and the digit tab-select fallback (`1`–`6`, plus belt-and-braces on `9`) are now gated to Diff mode. Previously, a stale `last_tab` preference restored into a multi-mode dashboard let keys leak into invisible tab handlers (e.g. `f` toggling a hidden Components security filter while also cycling the MultiDiff filter preset, hidden handlers swallowing `/` and digits). This closes the class, mirroring the existing BackTab gate.
- **Shortcuts overlay honesty**: the Navigation section no longer advertises "Tab: Next tab" / "Jump to tab" in MultiDiff/Timeline/Matrix contexts (Tab toggles panels there, digits are now inert); the Diff-context jump hint is corrected from "1-8" to "1-9/0".
- **Docs**: ARCHITECTURE.md no longer claims "12 tabs" across all modes (10 diff tabs; multi modes are full-screen dashboards with panel navigation); README fleet section documents dashboard navigation keys.

## Tests

- New: multi-mode dispatch negatives (all 3 dashboards × hidden Components/SideBySide × `f`/`1`/`/` never reach tab handlers; end-to-end `2` leaves `active_tab` unchanged), overlay multi-context negatives.
- Updated: one overlay test that pinned the old "1-8" hint.
- `cargo test`: 2200 passed / 0 failed; `cargo fmt --check` and both CI clippy gates clean; **zero snapshot changes** (verified prediction: the changed rows render below the fold in all committed snapshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)