### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ them is listed under **Upgrade notes** for its release.
 
 ---
 
-## v0.2.0 — unreleased
+## v0.2.0 — 2026-08-01
 
 ### Highlights
 
@@ -119,12 +119,6 @@ These behaviors changed in this release:
 - **The compliance verdict is tri-state** — compliant / non-compliant / not-applicable, the last surfaced as `"compliant": null` — with one honest compliance score shared across the TUI, reports and exports; N/A findings are surfaced rather than counted as passes. (#320)
 - **The TUI keymap changed.** Digits always jump tabs in diff mode; Components' quick filters moved to a `Q` picker, Side-by-Side filters to `A`/`r`/`m`/`x`, the KEV filter from `k` to `K`, vulnerability group jump to `}`/`{`, Dependencies fold to `x`/`X`, the cycles toggle to `C`, and the threshold overlay to `t`. `e` is export on every tab. `docs/TUI_SHORTCUTS.md` is the full reference; `?` in the app is context-aware. Recorded demos, scripts and third-party docs referencing the old keys are stale. (#333, #334)
 
-### Known gaps
-
-- Attestation-satisfied compliance checks are not surfaced positively in `validate` output; the effect is visible only by comparing against a declarations-stripped document.
-- CDXA ingestion reads CycloneDX **JSON** only — the XML path does not parse `declarations`, and `convert` does not round-trip them.
-- Attestation phase 2 (external in-toto / DSSE bundles) is not implemented.
-
 ---
 
 ## v0.1.22 — 2026-06-15
@@ -153,5 +147,5 @@ enrichment with an offline/air-gapped mode, and broad CLI/TUI alignment.
 Earlier releases: [`RELEASE_NOTES_v0.1.21.md`](RELEASE_NOTES_v0.1.21.md) and the
 [GitHub Releases page](https://github.com/sbom-tool/sbom-tools/releases).
 
-[Unreleased]: https://github.com/sbom-tool/sbom-tools/compare/v0.1.22...HEAD
+[0.2.0]: https://github.com/sbom-tool/sbom-tools/releases/tag/v0.2.0
 [0.1.22]: https://github.com/sbom-tool/sbom-tools/releases/tag/v0.1.22

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2770,7 +2770,7 @@ dependencies = [
 
 [[package]]
 name = "sbom-tools"
-version = "0.1.22"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "sbom-tools-ffi"
-version = "0.1.22"
+version = "0.2.0"
 dependencies = [
  "sbom-tools",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ exclude = ["dagger/rust-sdk"]
 
 [package]
 name = "sbom-tools"
-version = "0.1.22"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88"
 description = "Semantic SBOM diff and analysis tool"

--- a/RELEASE_NOTES_v0.2.0.md
+++ b/RELEASE_NOTES_v0.2.0.md
@@ -72,12 +72,6 @@ These behaviors changed in this release. `CHANGELOG.md` carries the full list wi
 - **Exit codes fail closed.** Operational errors exit `3`, command-line parse errors exit `2`, and a nonzero exit is a gate verdict only when the expected report was produced.
 - **The TUI keymap changed.** Digits always jump tabs; Components' quick filters moved to a `Q` picker, Side-by-Side filters to `A`/`r`/`m`/`x`, the KEV filter to `K`, vulnerability group jump to `}`/`{`, Dependencies fold to `x`/`X`, the cycles toggle to `C`, and the threshold overlay — previously unreachable — to `t`. `docs/TUI_SHORTCUTS.md` is the full reference; `?` in the app is context-aware.
 
-## Known gaps
-
-- Attestation-satisfied compliance checks are not surfaced positively in `validate` output; the effect is visible only by comparing against a declarations-stripped document.
-- CDXA ingestion reads CycloneDX **JSON** only — the XML path does not yet parse `declarations`, and `convert` does not round-trip them.
-- Attestation phase 2 (external in-toto / DSSE bundles) is not implemented.
-
 ---
 
 Install: `cargo install sbom-tools`

--- a/crates/sbom-tools-ffi/Cargo.toml
+++ b/crates/sbom-tools-ffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sbom-tools-ffi"
-version = "0.1.22"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88"
 description = "C ABI bindings for sbom-tools (Go, Swift, Python consumers)"
@@ -17,4 +17,4 @@ crate-type = ["cdylib", "staticlib"]
 #
 # `version` is required for `cargo publish` (crates.io rejects path deps without
 # one) and is kept in lockstep with the root crate by scripts/release.sh.
-sbom-tools = { path = "../..", version = "=0.1.22", default-features = false, features = ["ffi"] }
+sbom-tools = { path = "../..", version = "=0.2.0", default-features = false, features = ["ffi"] }


### PR DESCRIPTION
Release preparation for **v0.2.0**.

- Workspace bumped `0.1.22` → `0.2.0` (root crate, `sbom-tools-ffi`, and the pinned inter-crate dependency), plus `Cargo.lock`.
- `CHANGELOG.md` entry dated.
- **Known gaps** section removed from both the changelog and `RELEASE_NOTES_v0.2.0.md`, as requested — those items stay recorded in the docs rather than in the release announcement.

A minor bump rather than a patch: this release changes machine-readable output (`diff-multi` deviation scale, logical purl identity, additive JSON fields), the Rust API (`Option<f32>` readiness scores, `run_tui` signature), several compliance verdicts (`ntia`/`fda` engine-backed and stricter, CRA phase dates re-anchored), and the TUI keymap. All are listed under Upgrade notes.

Verified: full suite green, both clippy gates and `cargo fmt --check` clean, `cargo publish --dry-run --locked` passes, and the built binary reports `sbom-tools 0.2.0`.

Merging this and pushing the `v0.2.0` tag triggers `publish-crates.yml`: crates.io publish, SLSA provenance, cross-platform binaries, the GitHub release, and the Homebrew tap update. The workflow creates the release with `--generate-notes`, so the curated notes are applied afterwards with `gh release edit --notes-file`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)