### PR TITLE
parsers: spdx3: add string deserializer for supplied_by

### DIFF
--- a/src/parsers/spdx3.rs
+++ b/src/parsers/spdx3.rs
@@ -1852,11 +1852,7 @@ struct Spdx3Package {
     #[serde(alias = "software_copyrightText")]
     copyright_text: Option<String>,
     description: Option<String>,
-    #[serde(
-        default,
-        deserialize_with = "de_string_or_seq_opt",
-        skip_serializing_if = "Option::is_none"
-    )]
+    #[serde(default, deserialize_with = "de_string_or_seq_opt")]
     supplied_by: Option<Vec<String>>,
     originated_by: Option<Vec<String>>,
     verified_using: Option<Vec<Spdx3IntegrityMethod>>,
@@ -2461,6 +2457,43 @@ mod tests {
             ds.sensitivity_classifications
                 .contains(&"amber".to_string())
         );
+    }
+
+    #[test]
+    fn test_spdx3_supplied_by_accepts_bare_string() {
+        // Real-world producers (e.g. Yocto) emit suppliedBy as a single
+        // string even though the type is nominally Vec<String>; suppliedBy's
+        // spec cardinality is 0..1, so a bare string must parse the same as
+        // a one-element array instead of failing with a "expected a sequence"
+        // JSON error (see issue #348).
+        let pkg: Spdx3Package = serde_json::from_str(
+            r#"{"type": "software_Package", "spdxId": "urn:x:p", "name": "p",
+                "suppliedBy": "urn:spdx:agent:Test_Supplier"}"#,
+        )
+        .expect("bare-string suppliedBy should deserialize");
+        assert_eq!(
+            pkg.supplied_by,
+            Some(vec!["urn:spdx:agent:Test_Supplier".to_string()])
+        );
+
+        let pkg_array: Spdx3Package = serde_json::from_str(
+            r#"{"type": "software_Package", "spdxId": "urn:x:p", "name": "p",
+                "suppliedBy": ["urn:spdx:agent:a", "urn:spdx:agent:b"]}"#,
+        )
+        .expect("array suppliedBy should still deserialize");
+        assert_eq!(
+            pkg_array.supplied_by,
+            Some(vec![
+                "urn:spdx:agent:a".to_string(),
+                "urn:spdx:agent:b".to_string()
+            ])
+        );
+
+        let pkg_absent: Spdx3Package = serde_json::from_str(
+            r#"{"type": "software_Package", "spdxId": "urn:x:p", "name": "p"}"#,
+        )
+        .expect("missing suppliedBy should deserialize");
+        assert_eq!(pkg_absent.supplied_by, None);
     }
 
     fn spdx3_lib(elements: &str) -> NormalizedSbom {

--- a/src/parsers/spdx3.rs
+++ b/src/parsers/spdx3.rs
@@ -1852,6 +1852,11 @@ struct Spdx3Package {
     #[serde(alias = "software_copyrightText")]
     copyright_text: Option<String>,
     description: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "de_string_or_seq_opt",
+        skip_serializing_if = "Option::is_none"
+    )]
     supplied_by: Option<Vec<String>>,
     originated_by: Option<Vec<String>>,
     verified_using: Option<Vec<Spdx3IntegrityMethod>>,
@@ -2026,6 +2031,26 @@ where
         }
         _ => None,
     }))
+}
+
+/// Deserialize an optional `Vec<String>` field that may be supplied as
+/// either a single string (cardinality 0..1) or a JSON array of strings.
+fn de_string_or_seq_opt<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+
+    Ok(match Option::<OneOrMany>::deserialize(deserializer)? {
+        None => None,
+        Some(OneOrMany::One(s)) => Some(vec![s]),
+        Some(OneOrMany::Many(v)) => Some(v),
+    })
 }
 
 /// Normalize one SPDX 3.0 `ai_metric` value into the typed `MetricEntry`.


### PR DESCRIPTION
Fixes https://github.com/sbom-tool/sbom-tools/issues/348

The suppliedBy property has cardinality 0..1 and should allow strings: <https://spdx.github.io/spdx-spec/v3.0.1/model/Software/Classes/Package/>.

This fixes the parsing error when trying to parse Yocto generated SPDX SBOM:

```
2026-08-22T15:15:36.806063Z  INFO Parsing SBOM:
"core-image-minimal-qemux86-64.rootfs.spdx.json" 2026-08-22T15:15:36.826473Z
DEBUG Format detection: CycloneDX=0.00, SPDX=0.00, SPDX3=1.00, threshold=0.25
Error: Parse failed for core-image-minimal-qemux86-64.rootfs.spdx.json: JSON
parse error: invalid type: string
"http://spdx.org/spdxdocs/core-image-minimal-d87a4dff-5991-524d-b994-
a37645cdb1fc/66c81b16a76152f9e35e0c619d2d7e7a244dfff482cc5ae52673def2300e7651/
agent/Test_Supplier",
expected a sequence at line 1 column 535682

Caused by: JSON parse error: invalid type: string
    "http://spdx.org/spdxdocs/core-image-minimal-d87a4dff-5991-524d-b994-
    a37645cdb1fc/66c81b16a76152f9e35e0c619d2d7e7a244dfff482cc5ae52673def23
    00e7651/agent/Test_Supplier",
    expected a sequence at line 1 column 535682
```