### PR TITLE
fix(ci): restore benchmark and security gates

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -9,9 +9,9 @@ name: Benchmarks
 # cargo-deny's all-features scan; that risk was not worth taking here.
 #
 # Instead:
-#   * On PRs/pushes that touch benchable code, we run `cargo bench --no-run` as a
-#     fast SMOKE GATE — it guarantees the bench suite keeps compiling without
-#     spending minutes measuring.
+#   * On PRs/pushes that touch benchable code, we run
+#     `cargo bench --benches --no-run` as a fast SMOKE GATE — it guarantees the
+#     Criterion bench targets keep compiling without spending minutes measuring.
 #   * On a weekly SCHEDULE (and manual dispatch) we run the full criterion suite
 #     with `--save-baseline`, uploading the saved baseline as an artifact for
 #     out-of-band trend tracking. This is informational, never a gate.
@@ -49,8 +49,8 @@ jobs:
   # ── PR smoke gate: benches must keep compiling (no measurement) ─────────────
   bench-smoke:
     name: Bench compile smoke
-    # Skip on the schedule — the full run below covers compilation there.
-    if: github.event_name != 'schedule'
+    # Full schedule/dispatch runs already compile every Criterion target.
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -68,7 +68,7 @@ jobs:
           shared-key: bench
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Compile benches (no run)
-        run: cargo bench --locked --no-run
+        run: cargo bench --locked --benches --no-run
 
   # ── Scheduled full run with saved baseline (informational, not a gate) ──────
   bench-run:
@@ -89,7 +89,7 @@ jobs:
         with:
           shared-key: bench
       - name: Run benches and save baseline
-        run: cargo bench --locked -- --save-baseline ci
+        run: cargo bench --locked --benches -- --save-baseline ci
       - name: Upload criterion baseline
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ exclude = [
 [lib]
 name = "sbom_tools"
 crate-type = ["rlib"]
+bench = false
 
 # The binary drives the interactive TUI and parses arguments, so it needs both
 # heavy feature sets. Building with `--no-default-features` (e.g. for the FFI or
@@ -30,6 +31,7 @@ crate-type = ["rlib"]
 name = "sbom-tools"
 path = "src/main.rs"
 required-features = ["cli", "tui"]
+bench = false
 
 [dependencies]
 # Signal Handling (watch mode, reached only through the `cli` feature)

--- a/crates/sbom-tools-ffi/Cargo.toml
+++ b/crates/sbom-tools-ffi/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 [lib]
 name = "sbom_tools_ffi"
 crate-type = ["cdylib", "staticlib"]
+bench = false
 
 [dependencies]
 # The C ABI only touches model/parsers/diff/quality (see ../../src/ffi.rs), so


### PR DESCRIPTION
```text
QA_IDs:         [QA-BENCH-001, QA-BENCH-002, QA-BENCH-003, QA-SEC-001]
ADRs:           []
Verification:   [Actionlint, benchmarks, Clippy, tests, cargo-audit, cargo-deny]
Evidence:       [runs 31995183298, 32690903901, 33232701994, local commands]
BPL_ref:        N/A (not promotion-critical)
Orchestration:  Existing workflow topology; manual duplicate removed
Failure_modes:  [libtest flag rejection, duplicate compilation, h2 advisory]
Risks:          [lib/bin benchmark harnesses disabled, transitive h2 update]
Locks_compiled: [Cargo.lock:h2@0.4.19]
```

## Summary

- Declare the library and CLI binary as non-benchmark harness targets.
- Limit benchmark smoke and baseline commands to registered Criterion targets.
- Skip the smoke job during manual full-baseline dispatches.
- Update the transitive `h2` lock entry beyond `RUSTSEC-2026-0258`.

Refs #350.

## Problem

The weekly baseline command compiled the optimized benchmark profile and then
launched the library's libtest harness before the Criterion binaries. Libtest
does not accept Criterion's `--save-baseline` option, so the workflow failed
after paying the full compile cost:

- https://github.com/sbom-tool/sbom-tools/actions/runs/31995183298
- https://github.com/sbom-tool/sbom-tools/actions/runs/32690903901

The latter run spent 8 minutes 22 seconds compiling before failing with:

```text
error: Unrecognized option: 'save-baseline'
```

Adding `--benches` alone is insufficient because Cargo treats the package
library and binary as benchmark targets by default. Marking those targets with
`bench = false` makes `--benches` select only the three explicit
`harness = false` Criterion targets.

Manual dispatch previously ran both the smoke job and the full baseline job,
duplicating the benchmark-profile compilation. The smoke condition now applies
only to push and pull-request events.

While this branch was under CI, upstream `main` also became red because
`RUSTSEC-2026-0258` rejects `h2 0.4.15`. The branch now includes current
upstream and updates only that transitive lock entry to `h2 0.4.19`, the latest
compatible release. Its declared Rust floor is 1.63, below this project's 1.88
MSRV. The security gate is not suppressed or allowlisted.

## Verification

```text
actionlint .github/workflows/bench.yml
ruby YAML parse
cargo fmt --all -- --check
cargo clippy --locked --all-features -- -D warnings
cargo test --locked --all-features
cargo bench --locked --benches --no-run
cargo bench --locked --benches -- --save-baseline ci
cargo audit
cargo deny check advisories
cargo deny check bans licenses sources
```

Results:

- Actionlint, YAML parsing, formatting, and Clippy passed.
- All-feature tests passed. The existing large-fixture test and documentation
  examples remained explicitly ignored.
- The smoke executable list contained only `diff_benchmark`, `hot_paths`, and
  `large_sbom`; no `src/lib.rs` or `src/main.rs` harness was selected.
- The exact scheduled command completed all three Criterion binaries and wrote
  37 `ci` baseline directories.
- `cargo audit` and `cargo-deny advisories` report no vulnerability; the two
  existing allowed unsoundness warnings remain visible.
- Bans, licenses, and sources checks passed.
- Existing test-only `httpmock` deprecation warnings remain unchanged.

## Scope

This starts delivery slice 1 from #350 and restores the security baseline that
drifted while the PR was running. It does not implement receipts,
artifact-sharing, or Dagger concurrency, and it makes no runtime or
cost-reduction claim.
