### PR TITLE
fix(tui): size the Violation Detail overlay to its content; fix supplier-rule remediation (#347)

### DIFF
--- a/src/quality/compliance/mod.rs
+++ b/src/quality/compliance/mod.rs
@@ -3519,6 +3519,33 @@ mod tests {
         assert_eq!(pren_count, 1, "PRE-7-RQ-07 should appear exactly once");
     }
 
+    /// #347: the SUPPLY-CHAIN rule is emitted only by the supplier checks,
+    /// but its remediation was copied from the DEPENDENCY rule and told the
+    /// user to add DEPENDS_ON relationships.
+    #[test]
+    fn supply_chain_remediation_is_about_suppliers() {
+        let v = Violation {
+            severity: ViolationSeverity::Error,
+            category: ViolationCategory::SupplierInfo,
+            message: String::new(),
+            element: None,
+            requirement: String::new(),
+            rule_id: "SBOM-CRA-ANNEX-I-SUPPLY-CHAIN",
+            component_id: None,
+            counts: None,
+            standard_refs: Vec::new(),
+        };
+        let guidance = v.remediation_guidance();
+        assert!(
+            guidance.contains("supplier") && guidance.contains("PackageSupplier"),
+            "supplier-rule guidance must name the supplier fields; got: {guidance}"
+        );
+        assert!(
+            !guidance.contains("DEPENDS_ON"),
+            "supplier-rule guidance must not be the dependency-relationship text; got: {guidance}"
+        );
+    }
+
     #[test]
     fn registry_refs_for_supply_chain_include_annex_and_pren() {
         let refs = refs_for("SBOM-CRA-ANNEX-I-SUPPLY-CHAIN");

--- a/src/quality/compliance/registry.rs
+++ b/src/quality/compliance/registry.rs
@@ -351,7 +351,10 @@ pub fn rule_meta(rule_id: &str) -> Option<RuleMeta> {
                 (PREN, "PRE-7-RQ-01"),
                 (PREN, "PRE-7-RQ-03"),
             ],
-            remediation: "Add dependency relationships between components. CycloneDX: use the dependencies array. SPDX: use DEPENDS_ON relationships.",
+            // Emitted only by the supplier checks in cra.rs (direct = mandatory,
+            // transitive = recommended); the guidance must talk about suppliers,
+            // not dependency relationships (#347).
+            remediation: "Identify each component's supplier, starting with direct dependencies (mandatory under PRE-7-RQ-03; transitive dependencies are recommended). CycloneDX: set component.supplier (or authors). SPDX: set PackageSupplier (or PackageOriginator).",
         },
         "SBOM-CRA-ANNEX-I-INTEGRITY" => RuleMeta {
             sarif_id: "SBOM-CRA-ANNEX-I",

--- a/src/tui/shared/compliance.rs
+++ b/src/tui/shared/compliance.rs
@@ -1,6 +1,7 @@
 //! Shared compliance rendering functions used by both App (diff mode) and `ViewApp` (view mode).
 
 use crate::quality::ViolationSeverity;
+use crate::tui::shared::text::wrapped_line_count;
 use crate::tui::theme::colors;
 use ratatui::{
     prelude::*,
@@ -9,6 +10,12 @@ use ratatui::{
 };
 
 /// Render a modal overlay showing violation details, centered on the given area.
+///
+/// The overlay is sized to its content: every field, reference and the
+/// wrapped remediation text is measured first, and the box grows (up to the
+/// full area height) to hold all of it plus the close hint. When even the
+/// full height is too small, trailing lines are replaced by an explicit
+/// "+N more lines" marker rather than being clipped silently (#347).
 pub fn render_violation_detail_overlay(
     frame: &mut Frame,
     area: Rect,
@@ -19,14 +26,8 @@ pub fn render_violation_detail_overlay(
     let overlay_width = (f32::from(area.width) * 0.7)
         .max(40.0)
         .min(f32::from(area.width)) as u16;
-    let overlay_height = (f32::from(area.height) * 0.6)
-        .max(12.0)
-        .min(f32::from(area.height)) as u16;
-    let x = area.x + (area.width.saturating_sub(overlay_width)) / 2;
-    let y = area.y + (area.height.saturating_sub(overlay_height)) / 2;
-    let overlay_area = Rect::new(x, y, overlay_width, overlay_height);
-
-    frame.render_widget(Clear, overlay_area);
+    // Inner text width: the block draws a 1-column border on each side.
+    let inner_width = overlay_width.saturating_sub(2);
 
     let (severity_text, severity_color) = match violation.severity {
         ViolationSeverity::Error => ("ERROR", scheme.error),
@@ -108,19 +109,48 @@ pub fn render_violation_detail_overlay(
     )));
 
     let guidance = violation.remediation_guidance();
-    let max_line_width = overlay_width.saturating_sub(4) as usize;
-    for wrapped_line in textwrap_simple(guidance, max_line_width) {
+    for wrapped_line in textwrap_simple(guidance, inner_width as usize) {
         lines.push(Line::from(Span::styled(
             wrapped_line,
             Style::default().fg(scheme.text),
         )));
     }
 
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
+    // Size the box to the wrapped content (+2 for the border). The close hint
+    // is appended last so it is always the final visible row.
+    let close_hint = Line::from(Span::styled(
         " Press Enter or Esc to close ",
         Style::default().fg(scheme.text_muted),
-    )));
+    ));
+    let max_inner_height = area.height.saturating_sub(2) as usize;
+    // Content rows + blank spacer + close hint.
+    let mut rows = wrapped_line_count(&lines, inner_width) + 2;
+    if rows > max_inner_height && max_inner_height >= 3 {
+        // Never clip silently: drop trailing content until the marker and the
+        // close hint fit, then say how much is hidden.
+        let total = lines.len();
+        let budget = max_inner_height - 2;
+        while !lines.is_empty() && wrapped_line_count(&lines, inner_width) > budget {
+            lines.pop();
+        }
+        let hidden = total - lines.len();
+        lines.push(Line::from(Span::styled(
+            format!("\u{2026} +{hidden} more lines \u{2014} enlarge the terminal to see all"),
+            Style::default().fg(scheme.text_muted),
+        )));
+        lines.push(close_hint);
+        rows = wrapped_line_count(&lines, inner_width);
+    } else {
+        lines.push(Line::from(""));
+        lines.push(close_hint);
+    }
+
+    let overlay_height = u16::try_from(rows + 2).unwrap_or(u16::MAX).min(area.height);
+    let x = area.x + (area.width.saturating_sub(overlay_width)) / 2;
+    let y = area.y + (area.height.saturating_sub(overlay_height)) / 2;
+    let overlay_area = Rect::new(x, y, overlay_width, overlay_height);
+
+    frame.render_widget(Clear, overlay_area);
 
     let detail = Paragraph::new(lines)
         .block(
@@ -198,6 +228,73 @@ mod tests {
             text.contains("EU AI Act: Annex IV"),
             "overlay must render 'label: id' refs; got:\n{text}"
         );
+    }
+
+    /// #347: the reporter's CRA Annex I violation (3 references + a two-line
+    /// remediation) overflowed the old fixed 60%-height box at 24 rows, so
+    /// the remediation text after "SPDX: use" and the close hint were clipped.
+    fn cra_supply_chain_violation() -> Violation {
+        Violation {
+            severity: ViolationSeverity::Warning,
+            category: ViolationCategory::DependencyInfo,
+            message: "No dependency relationships found; 42 components have no dependency \
+                      information"
+                .to_string(),
+            element: None,
+            component_id: None,
+            counts: None,
+            requirement: "CRA Annex I: Technical documentation".to_string(),
+            rule_id: "SBOM-CRA-ANNEX-I-SUPPLY-CHAIN",
+            standard_refs: vec![
+                StandardRef::new(StandardKind::CraAnnex, "Annex I Part II"),
+                StandardRef::new(StandardKind::Pren40000_1_3, "PRE-7-RQ-01"),
+                StandardRef::new(StandardKind::Pren40000_1_3, "PRE-7-RQ-03"),
+            ],
+        }
+    }
+
+    #[test]
+    fn overlay_grows_to_fit_remediation_and_close_hint() {
+        let violation = cra_supply_chain_violation();
+        for (width, height) in [(166u16, 24u16), (120, 24), (100, 24), (80, 24), (166, 40)] {
+            let text = render_to_text(width, height, |frame| {
+                super::render_violation_detail_overlay(frame, frame.area(), &violation);
+            });
+            assert!(
+                text.contains("DEPENDS_ON") && text.contains("relationships."),
+                "remediation must be fully visible at {width}x{height}; got:\n{text}"
+            );
+            assert!(
+                text.contains("Press Enter or Esc to close"),
+                "close hint must be visible at {width}x{height}; got:\n{text}"
+            );
+            assert!(
+                !text.contains("more lines"),
+                "no truncation marker when the detail fits at {width}x{height}; got:\n{text}"
+            );
+        }
+    }
+
+    #[test]
+    fn overlay_marks_hidden_lines_on_tiny_terminal() {
+        let violation = cra_supply_chain_violation();
+        let text = render_to_text(80, 10, |frame| {
+            super::render_violation_detail_overlay(frame, frame.area(), &violation);
+        });
+        assert!(
+            text.contains("more lines"),
+            "overflow must be marked explicitly, not clipped silently; got:\n{text}"
+        );
+        assert!(
+            text.contains("Press Enter or Esc to close"),
+            "close hint must survive truncation; got:\n{text}"
+        );
+        // Degenerate sizes must not panic.
+        for (width, height) in [(40u16, 4u16), (40, 2), (10, 1)] {
+            let _ = render_to_text(width, height, |frame| {
+                super::render_violation_detail_overlay(frame, frame.area(), &violation);
+            });
+        }
     }
 
     #[test]

--- a/src/tui/shared/compliance.rs
+++ b/src/tui/shared/compliance.rs
@@ -230,9 +230,9 @@ mod tests {
         );
     }
 
-    /// #347: the reporter's CRA Annex I violation (3 references + a two-line
+    /// #347: the reporter's CRA Annex I violation (3 references + a multi-line
     /// remediation) overflowed the old fixed 60%-height box at 24 rows, so
-    /// the remediation text after "SPDX: use" and the close hint were clipped.
+    /// the end of the remediation text and the close hint were clipped.
     fn cra_supply_chain_violation() -> Violation {
         Violation {
             severity: ViolationSeverity::Warning,
@@ -261,8 +261,8 @@ mod tests {
                 super::render_violation_detail_overlay(frame, frame.area(), &violation);
             });
             assert!(
-                text.contains("DEPENDS_ON") && text.contains("relationships."),
-                "remediation must be fully visible at {width}x{height}; got:\n{text}"
+                text.contains("PackageOriginator).") && text.contains("Remediation:"),
+                "remediation must be fully visible to its last word at {width}x{height}; got:\n{text}"
             );
             assert!(
                 text.contains("Press Enter or Esc to close"),


### PR DESCRIPTION
Fixes #347.

## Problem 1 — clipped overlay

The Violation Detail overlay was a fixed 60% of the terminal height (min 12 rows) regardless of content. At 24 rows that is a 14-row box, and a CRA Annex I violation with three standard references needs ~17 rows once the remediation wraps. The bottom of the content — the remediation text after `SPDX: use` and the `Press Enter or Esc to close` hint — was clipped silently. Reproduced at 166, 120, 100 and 80 columns; the failure is height-driven, not width-driven.

### Fix

- Measure the wrapped content first with `shared::text::wrapped_line_count` (the helper the detail panels already use for scroll bounds) and size the box to it, capped at the full area height.
- When even the full height is too small, drop trailing content and render an explicit `… +N more lines — enlarge the terminal to see all` marker, keeping the close hint as the last visible row. Same never-clip-silently convention as the PQC detail pane.
- Remediation is pre-wrapped to the real inner width (border only) instead of `overlay_width - 4`.

## Problem 2 — wrong remediation text (visible in the same screenshot)

`SBOM-CRA-ANNEX-I-SUPPLY-CHAIN` is emitted only by the CRA supplier checks (direct = mandatory, transitive = recommended), but its registry remediation was a copy of the DEPENDENCY rule and told the user to add `DEPENDS_ON` relationships under a "Direct dependency supplier (mandatory)" violation.

### Fix

Reword the guidance to name the supplier fields (CycloneDX `component.supplier` / `authors`, SPDX `PackageSupplier` / `PackageOriginator`) and pin it with a test so the two rules cannot be cross-wired again.

## Tests

- `overlay_grows_to_fit_remediation_and_close_hint`: the reporter's violation at 166/120/100/80 x 24 and 166x40 — remediation visible to its last word, close hint visible, no marker.
- `overlay_marks_hidden_lines_on_tiny_terminal`: 80x10 shows the marker and the close hint; 40x4, 40x2, 10x1 do not panic.
- `supply_chain_remediation_is_about_suppliers`: the supplier rule's guidance names `PackageSupplier` and never says `DEPENDS_ON`.
- Full suite: 2444 passed / 0 failed (all features); fmt and clippy 1.88 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dVZ9LY4MJH5iFji7kyXr1
