### PR TITLE
chore(deps): migrate to quick-xml 0.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2242,9 +2242,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml_ng = "0.10"
-quick-xml = { version = "0.41", features = ["serialize"] }
+quick-xml = { version = "0.42", features = ["serialize"] }
 
 # TUI (ratatui ecosystem) — gated behind the `tui` feature
 ratatui = { version = "0.30", features = ["crossterm"], optional = true }

--- a/src/parsers/spdx.rs
+++ b/src/parsers/spdx.rs
@@ -435,8 +435,7 @@ impl SpdxParser {
                             for attr in e.attributes().filter_map(std::result::Result::ok) {
                                 let attr_name = Self::local_name(attr.key.as_ref());
                                 if attr_name == "about" {
-                                    doc.document_namespace =
-                                        Some(String::from_utf8_lossy(&attr.value).to_string());
+                                    doc.document_namespace = Some(attr.value.to_string());
                                 }
                             }
                         }
@@ -449,7 +448,7 @@ impl SpdxParser {
                             for attr in e.attributes().filter_map(std::result::Result::ok) {
                                 let attr_name = Self::local_name(attr.key.as_ref());
                                 if attr_name == "about" {
-                                    let uri = String::from_utf8_lossy(&attr.value).to_string();
+                                    let uri = attr.value.to_string();
                                     // Extract SPDX ID from URI fragment
                                     if let Some(idx) = uri.rfind('#') {
                                         pkg.spdx_id = uri[idx + 1..].to_string();
@@ -492,7 +491,7 @@ impl SpdxParser {
                             for attr in e.attributes().filter_map(std::result::Result::ok) {
                                 let attr_name = Self::local_name(attr.key.as_ref());
                                 if attr_name == "resource" {
-                                    let uri = String::from_utf8_lossy(&attr.value).to_string();
+                                    let uri = attr.value.to_string();
                                     // Extract license from URI
                                     if let Some(idx) = uri.rfind('/') {
                                         doc.data_license = uri[idx + 1..].to_string();
@@ -507,7 +506,7 @@ impl SpdxParser {
                                 for attr in e.attributes().filter_map(std::result::Result::ok) {
                                     let attr_name = Self::local_name(attr.key.as_ref());
                                     if attr_name == "resource" {
-                                        let uri = String::from_utf8_lossy(&attr.value).to_string();
+                                        let uri = attr.value.to_string();
                                         let id = Self::extract_spdx_id_from_uri(&uri);
                                         if local_name == "spdxElementId" {
                                             rel.spdx_element_id = id;
@@ -523,7 +522,7 @@ impl SpdxParser {
                                 for attr in e.attributes().filter_map(std::result::Result::ok) {
                                     let attr_name = Self::local_name(attr.key.as_ref());
                                     if attr_name == "resource" {
-                                        let uri = String::from_utf8_lossy(&attr.value).to_string();
+                                        let uri = attr.value.to_string();
                                         let license = Self::extract_license_from_uri(&uri);
                                         if local_name == "licenseConcluded" {
                                             pkg.license_concluded = Some(license);
@@ -539,7 +538,7 @@ impl SpdxParser {
                                 for attr in e.attributes().filter_map(std::result::Result::ok) {
                                     let attr_name = Self::local_name(attr.key.as_ref());
                                     if attr_name == "resource" {
-                                        let uri = String::from_utf8_lossy(&attr.value).to_string();
+                                        let uri = attr.value.to_string();
                                         // Extract algorithm from URI like http://spdx.org/rdf/terms#checksumAlgorithm_sha256
                                         if let Some(idx) = uri.rfind("checksumAlgorithm_") {
                                             checksum.algorithm = uri[idx + 18..].to_uppercase();
@@ -555,7 +554,7 @@ impl SpdxParser {
                                 for attr in e.attributes().filter_map(std::result::Result::ok) {
                                     let attr_name = Self::local_name(attr.key.as_ref());
                                     if attr_name == "resource" {
-                                        let uri = String::from_utf8_lossy(&attr.value).to_string();
+                                        let uri = attr.value.to_string();
                                         if let Some(idx) = uri.rfind("referenceCategory_") {
                                             ext_ref.reference_category =
                                                 uri[idx + 18..].to_string();
@@ -570,7 +569,8 @@ impl SpdxParser {
                     }
                 }
                 Ok(Event::Text(ref e)) => {
-                    current_text = e.decode().unwrap_or_default().to_string();
+                    let text: &str = e.as_ref();
+                    current_text = text.to_string();
                 }
                 Ok(Event::End(ref e)) => {
                     let local_name = Self::local_name(e.name().as_ref());
@@ -788,12 +788,9 @@ impl SpdxParser {
     }
 
     /// Extract local name from qualified XML name (strips namespace prefix)
-    fn local_name(name: &[u8]) -> String {
-        let name_str = String::from_utf8_lossy(name);
-        name_str.rfind(':').map_or_else(
-            || name_str.to_string(),
-            |idx| name_str[idx + 1..].to_string(),
-        )
+    fn local_name(name: &str) -> String {
+        name.rfind(':')
+            .map_or_else(|| name.to_string(), |idx| name[idx + 1..].to_string())
     }
 
     /// Extract SPDX ID from URI (e.g., "<http://example.org#SPDXRef-Package>" -> "SPDXRef-Package")

--- a/src/tui/app_states/source.rs
+++ b/src/tui/app_states/source.rs
@@ -34,16 +34,12 @@ pub fn xml_tree_from_str(xml: &str) -> Option<XmlTreeNode> {
     loop {
         match reader.read_event() {
             Ok(Event::Start(ref e)) => {
-                let name = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                let name = e.name().as_ref().to_string();
                 let attributes = e
                     .attributes()
                     .filter_map(|a| {
-                        a.ok().map(|attr| {
-                            (
-                                String::from_utf8_lossy(attr.key.as_ref()).to_string(),
-                                String::from_utf8_lossy(&attr.value).to_string(),
-                            )
-                        })
+                        a.ok()
+                            .map(|attr| (attr.key.as_ref().to_string(), attr.value.to_string()))
                     })
                     .collect();
                 stack.push(XmlTreeNode::Element {
@@ -61,16 +57,12 @@ pub fn xml_tree_from_str(xml: &str) -> Option<XmlTreeNode> {
                 }
             }
             Ok(Event::Empty(ref e)) => {
-                let name = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                let name = e.name().as_ref().to_string();
                 let attributes = e
                     .attributes()
                     .filter_map(|a| {
-                        a.ok().map(|attr| {
-                            (
-                                String::from_utf8_lossy(attr.key.as_ref()).to_string(),
-                                String::from_utf8_lossy(&attr.value).to_string(),
-                            )
-                        })
+                        a.ok()
+                            .map(|attr| (attr.key.as_ref().to_string(), attr.value.to_string()))
                     })
                     .collect();
                 if let Some(XmlTreeNode::Element { children, .. }) = stack.last_mut() {
@@ -82,7 +74,8 @@ pub fn xml_tree_from_str(xml: &str) -> Option<XmlTreeNode> {
                 }
             }
             Ok(Event::Text(ref e)) => {
-                let text = e.decode().unwrap_or_default().trim().to_string();
+                let raw: &str = e.as_ref();
+                let text = raw.trim().to_string();
                 if !text.is_empty()
                     && let Some(XmlTreeNode::Element { children, .. }) = stack.last_mut()
                 {


### PR DESCRIPTION
Supersedes #358, which does not compile.

## Why the Dependabot bump fails

quick-xml 0.42 moved its event API from byte slices to strings: name types now wrap `&str`, `Attribute::value` is `Cow<str>`, event types deref to `str`, and `BytesText::decode()` was removed. Our SPDX RDF/XML parser and the TUI source tree compared element names and attribute values through `String::from_utf8_lossy` and `decode()`, so the bump alone produces 25 type errors across two files.

## Change

- `Cargo.toml` / `Cargo.lock`: quick-xml 0.41 → 0.42.
- `src/parsers/spdx.rs`: `local_name` takes `&str`; attribute values and text content are used directly.
- `src/tui/app_states/source.rs`: same for the XML tree builder.

No behavioural change. The parsers always hand quick-xml an already validated `String` (`read_to_string`, or strict `String::from_utf8` in detection), so the release's new rejection of non-UTF-8 input is unreachable from our call sites. quick-xml's MSRV moves to 1.86, within our declared 1.88.

## Verification

- Full suite: 2444 passed / 0 failed (all features). fmt and clippy 1.88 clean.
- Output parity against the `main` binary on every XML fixture (SPDX RDF/XML, CycloneDX 1.4/1.5/1.6, both AI-BOM dataset fixtures) for `validate -o json`, `validate --standard cra -o json`, `quality -o json`, `convert --to cyclonedx`, `convert --to spdx`: byte-identical, same exit codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dVZ9LY4MJH5iFji7kyXr1
