### PR TITLE
test(aibom): third-party AI-BOM corpus + nested-dataset evidence for AI-003

### DIFF
--- a/scripts/test-aibom.sh
+++ b/scripts/test-aibom.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Exercise the AI-BOM test dataset end-to-end through sbom-tools.
+#
+# For every AI-BOM in the corpus this runs, in order:
+#   view     -o json                        -> parses at all? component count
+#   quality  --profile ai-readiness -o json -> AI-readiness score, grade, per-check
+#   validate --standard bsi-ai      -o json -> BSI/G7 "SBOM for AI" readiness
+#   validate --standard ai-act      -o json -> EU AI Act Annex IV readiness
+#
+# and prints one row per document.
+#
+# Usage: scripts/test-aibom.sh [options] [FILE...]
+#
+#   -r, --release        use the release binary (default: debug)
+#   -d, --dir DIR        add a dataset directory (repeatable)
+#   -m, --min-score N    fail if any document scores below N (default: off)
+#   -c, --check-fail     fail if any compliance profile reports non-compliant
+#   -v, --verbose        list the failing AI-readiness checks per document
+#   -n, --no-build       skip cargo build, use whatever binary is on disk
+#   -h, --help           this message
+#
+# Explicit FILE arguments replace the default dataset.
+#
+# Exit codes:
+#   0  every document parsed and every requested gate passed
+#   1  a gate tripped (--min-score / --check-fail)
+#   2  a document failed to parse, or sbom-tools hit an operational error
+#
+# Note that a compliance FAIL is a *result*, not an error: the real-world
+# documents in the corpus are expected to miss elements. Only parse failures and
+# operational errors (sbom-tools exit >= 2) fail the run by default.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+PROFILE_DIR="debug"
+CARGO_FLAGS=()
+DATASET_DIRS=()
+FILES=()
+MIN_SCORE=""
+CHECK_FAIL=0
+VERBOSE=0
+BUILD=1
+
+usage() { sed -n '2,32p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -r|--release)   PROFILE_DIR="release"; CARGO_FLAGS=(--release); shift ;;
+        -d|--dir)       DATASET_DIRS+=("$2"); shift 2 ;;
+        -m|--min-score) MIN_SCORE="$2"; shift 2 ;;
+        -c|--check-fail) CHECK_FAIL=1; shift ;;
+        -v|--verbose)   VERBOSE=1; shift ;;
+        -n|--no-build)  BUILD=0; shift ;;
+        -h|--help)      usage; exit 0 ;;
+        -*)             echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+        *)              FILES+=("$1"); shift ;;
+    esac
+done
+
+# ── JSON extraction: prefer jq, fall back to python3 ──────────────
+if command -v jq >/dev/null 2>&1; then
+    json_get() { jq -r "$1 // \"-\"" "$2" 2>/dev/null || echo "-"; }
+    failed_checks() {
+        jq -r '[.report.ai_readiness_metrics.checks[]? | select(.passed | not) | .id] | join(" ")' \
+            "$1" 2>/dev/null
+    }
+elif command -v python3 >/dev/null 2>&1; then
+    # Translate the small subset of jq paths used below into python lookups.
+    json_get() {
+        python3 -c '
+import json, sys
+path, f = sys.argv[1], sys.argv[2]
+try:
+    cur = json.load(open(f))
+    for key in path.lstrip(".").split("."):
+        cur = cur[key]
+except Exception:
+    cur = None
+print("-" if cur is None else cur)
+' "$1" "$2"
+    }
+    failed_checks() {
+        python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    checks = d["report"]["ai_readiness_metrics"]["checks"]
+    print(" ".join(c["id"] for c in checks if not c["passed"]))
+except Exception:
+    print("")
+' "$1"
+    }
+else
+    echo "error: this script needs either jq or python3 to read JSON output" >&2
+    exit 2
+fi
+
+# ── Locate the binary ─────────────────────────────────────────────
+BIN="${SBOM_TOOLS_BIN:-$REPO_ROOT/target/$PROFILE_DIR/sbom-tools}"
+if [[ -n "${SBOM_TOOLS_BIN:-}" ]]; then
+    BUILD=0
+fi
+if [[ "$BUILD" -eq 1 ]]; then
+    echo "Building sbom-tools ($PROFILE_DIR)..."
+    cargo build --bin sbom-tools "${CARGO_FLAGS[@]}" || exit 2
+fi
+if [[ ! -x "$BIN" ]]; then
+    echo "error: binary not found at $BIN (drop --no-build, or set SBOM_TOOLS_BIN)" >&2
+    exit 2
+fi
+
+# ── Assemble the dataset ──────────────────────────────────────────
+# Default corpus: the third-party AI-BOM dataset plus the hand-written AI/ML
+# fixtures already used by the bsi-ai / eu-ai-act / SARIF integration tests.
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    if [[ ${#DATASET_DIRS[@]} -eq 0 ]]; then
+        DATASET_DIRS=(tests/fixtures/aibom)
+        while IFS= read -r f; do
+            FILES+=("$f")
+        done < <(find tests/fixtures/cyclonedx -maxdepth 1 \
+                    \( -name '*aibom*' -o -name '*mlbom*' -o -name 'hf-*' \
+                       -o -name 'untyped-hf-model*' \) -type f | sort)
+    fi
+    for dir in "${DATASET_DIRS[@]}"; do
+        if [[ ! -d "$dir" ]]; then
+            echo "error: dataset directory not found: $dir" >&2
+            exit 2
+        fi
+        while IFS= read -r f; do
+            FILES+=("$f")
+        done < <(find "$dir" -maxdepth 1 -type f \
+                    \( -name '*.json' -o -name '*.xml' \) ! -name 'osv-scanner.toml' | sort)
+    done
+fi
+
+if [[ ${#FILES[@]} -eq 0 ]]; then
+    echo "error: no AI-BOM documents found" >&2
+    exit 2
+fi
+
+TMPDIR_RUN="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_RUN"' EXIT
+
+run_tool() { # run_tool <outfile> <args...>; echoes the tool's exit code
+    local out="$1"; shift
+    "$BIN" --no-color -q "$@" >"$out" 2>"$out.err"
+    echo $?
+}
+
+printf '\nAI-BOM dataset: %d document(s)\n\n' "${#FILES[@]}"
+printf '%-38s %5s %4s %7s %6s %-9s %-9s\n' \
+    DOCUMENT COMPS ML SCORE GRADE BSI-AI AI-ACT
+printf '%s\n' "$(printf '─%.0s' {1..84})"
+
+parse_errors=0
+op_errors=0
+gate_failures=0
+declare -a VERBOSE_NOTES=()
+
+for file in "${FILES[@]}"; do
+    label="$(basename "$file")"
+    [[ ${#label} -gt 38 ]] && label="${label:0:35}..."
+    stem="$TMPDIR_RUN/$(basename "$file" | tr -c 'A-Za-z0-9._-' '_')"
+
+    # ── parse ─────────────────────────────────────────────────────
+    rc=$(run_tool "$stem.view.json" view "$file" -o json)
+    if [[ "$rc" -ne 0 ]]; then
+        printf '%-38s %5s %4s %7s %6s %-9s %-9s\n' "$label" "-" "-" "-" "-" "PARSE-ERR" "-"
+        VERBOSE_NOTES+=("$label: view exited $rc — $(head -n 3 "$stem.view.json.err" | tr '\n' ' ')")
+        parse_errors=$((parse_errors + 1))
+        continue
+    fi
+    comps=$(json_get '.summary.total_components' "$stem.view.json")
+
+    # ── AI-readiness score ────────────────────────────────────────
+    rc=$(run_tool "$stem.quality.json" quality "$file" --profile ai-readiness -o json)
+    if [[ "$rc" -ge 2 ]]; then
+        score="ERR"; grade="-"; ml="-"
+        VERBOSE_NOTES+=("$label: quality exited $rc — $(head -n 3 "$stem.quality.json.err" | tr '\n' ' ')")
+        op_errors=$((op_errors + 1))
+    else
+        score=$(json_get '.report.overall_score' "$stem.quality.json")
+        grade=$(json_get '.report.grade' "$stem.quality.json")
+        ml=$(json_get '.report.ai_readiness_metrics.ml_component_count' "$stem.quality.json")
+        [[ "$score" != "-" && "$score" != "ERR" ]] && score=$(printf '%.1f' "$score")
+    fi
+
+    # ── compliance profiles ───────────────────────────────────────
+    verdicts=()
+    for standard in bsi-ai ai-act; do
+        rc=$(run_tool "$stem.$standard.json" validate "$file" --standard "$standard" -o json)
+        if [[ "$rc" -ge 2 ]]; then
+            verdicts+=("ERR")
+            VERBOSE_NOTES+=("$label: validate --standard $standard exited $rc — $(head -n 3 "$stem.$standard.json.err" | tr '\n' ' ')")
+            op_errors=$((op_errors + 1))
+            continue
+        fi
+        compliant=$(json_get '.is_compliant' "$stem.$standard.json")
+        errs=$(json_get '.error_count' "$stem.$standard.json")
+        applicability=$(json_get '.applicability.status' "$stem.$standard.json")
+        if [[ "$applicability" == "not_applicable" ]]; then
+            verdicts+=("N/A")
+        elif [[ "$compliant" == "true" || "$compliant" == "True" ]]; then
+            verdicts+=("PASS")
+        else
+            verdicts+=("FAIL($errs)")
+            [[ "$CHECK_FAIL" -eq 1 ]] && gate_failures=$((gate_failures + 1))
+        fi
+    done
+
+    printf '%-38s %5s %4s %7s %6s %-9s %-9s\n' \
+        "$label" "$comps" "$ml" "$score" "$grade" "${verdicts[0]}" "${verdicts[1]}"
+
+    # ── gates and verbose detail ──────────────────────────────────
+    if [[ -n "$MIN_SCORE" && "$score" != "-" && "$score" != "ERR" ]]; then
+        if awk -v s="$score" -v m="$MIN_SCORE" 'BEGIN { exit !(s < m) }'; then
+            VERBOSE_NOTES+=("$label: score $score below --min-score $MIN_SCORE")
+            gate_failures=$((gate_failures + 1))
+        fi
+    fi
+    if [[ "$VERBOSE" -eq 1 && -s "$stem.quality.json" ]]; then
+        failed=$(failed_checks "$stem.quality.json")
+        [[ -n "$failed" ]] && printf '%-38s   failed checks: %s\n' "" "$failed"
+    fi
+done
+
+echo
+echo "${#FILES[@]} document(s), $parse_errors parse error(s), $op_errors operational error(s)"
+
+if [[ ${#VERBOSE_NOTES[@]} -gt 0 ]]; then
+    echo
+    echo "Notes:"
+    printf '  - %s\n' "${VERBOSE_NOTES[@]}"
+fi
+
+if [[ "$parse_errors" -gt 0 || "$op_errors" -gt 0 ]]; then
+    echo
+    echo "FAILED: the corpus must parse cleanly and must not trigger operational errors."
+    exit 2
+fi
+if [[ "$gate_failures" -gt 0 ]]; then
+    echo
+    echo "FAILED: $gate_failures gate failure(s)."
+    exit 1
+fi
+echo "OK"

--- a/src/quality/compliance/ai_shared.rs
+++ b/src/quality/compliance/ai_shared.rs
@@ -26,7 +26,7 @@
 //! warning instead of letting "untype your models" evade the assessment.
 
 use super::{Violation, ViolationCategory, ViolationSeverity, truncate_list};
-use crate::model::{Component, ComponentType, ExternalRefType, NormalizedSbom};
+use crate::model::{Component, ComponentType, DependencyType, ExternalRefType, NormalizedSbom};
 
 /// The AI-BOM scope of an SBOM, as seen by the AI compliance profiles.
 pub(crate) struct AiBomScope<'a> {
@@ -90,6 +90,38 @@ pub(crate) fn ai_bom_scope(sbom: &NormalizedSbom) -> AiBomScope<'_> {
         }
     }
     scope
+}
+
+/// Whether an ML model declares its training datasets.
+///
+/// Two spec-legal shapes count:
+///
+/// 1. `modelCard.modelParameters.datasets` (or the SPDX 3.0 `trainedOn`
+///    relationship) — parsed into [`crate::model::MlModelInfo::training_datasets`].
+/// 2. Dataset components nested under the model (CycloneDX `component.components`,
+///    surfaced as a `contains` edge) that carry real dataset evidence
+///    ([`Component::dataset`], i.e. a `data[]` block). Generators such as
+///    Manifest `aibom-gen` emit datasets this way instead of via `modelParameters`.
+///
+/// A bare nested `type: data` component with no `data[]` block is **not**
+/// accepted, consistent with [`ai_bom_scope`]: CycloneDX `data` also covers
+/// configuration bundles, so the type alone is not dataset evidence.
+pub(crate) fn declares_training_datasets(sbom: &NormalizedSbom, model: &Component) -> bool {
+    if model
+        .ml_model
+        .as_ref()
+        .is_some_and(|m| !m.training_datasets.is_empty())
+    {
+        return true;
+    }
+    sbom.get_dependencies(&model.canonical_id)
+        .into_iter()
+        .filter(|e| e.relationship == DependencyType::Contains)
+        .any(|e| {
+            sbom.components
+                .get(&e.to)
+                .is_some_and(|child| child.dataset.is_some())
+        })
 }
 
 /// Whether a component references a model card via an external reference
@@ -181,6 +213,77 @@ mod tests {
         let scope = ai_bom_scope(&sbom);
         assert!(scope.dataset_components.is_empty());
         assert!(!scope.is_applicable());
+    }
+
+    #[test]
+    fn nested_dataset_with_evidence_satisfies_training_datasets() {
+        use crate::model::DependencyEdge;
+        let mut sbom = NormalizedSbom::default();
+        let mut model = component("llm");
+        model.component_type = ComponentType::MachineLearningModel;
+        let model_id = model.canonical_id.clone();
+        let mut data = component("alpaca");
+        data.component_type = ComponentType::Data;
+        data.dataset = Some(DatasetInfo::default());
+        let data_id = data.canonical_id.clone();
+        add(&mut sbom, model);
+        add(&mut sbom, data);
+        sbom.add_edge(DependencyEdge::new(
+            model_id.clone(),
+            data_id,
+            DependencyType::Contains,
+        ));
+
+        let model = &sbom.components[&model_id];
+        assert!(
+            declares_training_datasets(&sbom, model),
+            "a contained dataset component with evidence must count as a training dataset"
+        );
+    }
+
+    #[test]
+    fn bare_nested_data_component_does_not_satisfy_training_datasets() {
+        use crate::model::DependencyEdge;
+        // The Manifest aibom-gen shape: `type: data` children with properties
+        // only and no `data[]` block. Consistent with ai_bom_scope, the type
+        // alone is not dataset evidence.
+        let mut sbom = NormalizedSbom::default();
+        let mut model = component("llm");
+        model.component_type = ComponentType::MachineLearningModel;
+        let model_id = model.canonical_id.clone();
+        let mut data = component("alpaca");
+        data.component_type = ComponentType::Data;
+        let data_id = data.canonical_id.clone();
+        add(&mut sbom, model);
+        add(&mut sbom, data);
+        sbom.add_edge(DependencyEdge::new(
+            model_id.clone(),
+            data_id,
+            DependencyType::Contains,
+        ));
+
+        let model = &sbom.components[&model_id];
+        assert!(!declares_training_datasets(&sbom, model));
+    }
+
+    #[test]
+    fn model_parameters_datasets_satisfy_training_datasets() {
+        let mut sbom = NormalizedSbom::default();
+        let mut model = component("llm");
+        model.component_type = ComponentType::MachineLearningModel;
+        let mut ml = MlModelInfo::default();
+        ml.training_datasets.push(crate::model::DatasetRef {
+            reference: Some("ds-1".into()),
+            name: None,
+            purl: None,
+        });
+        model.ml_model = Some(ml);
+        let model_id = model.canonical_id.clone();
+        add(&mut sbom, model);
+        assert!(declares_training_datasets(
+            &sbom,
+            &sbom.components[&model_id]
+        ));
     }
 
     #[test]

--- a/src/quality/compliance/bsi_sbom_for_ai.rs
+++ b/src/quality/compliance/bsi_sbom_for_ai.rs
@@ -89,7 +89,7 @@ impl ComplianceChecker {
 
         self.check_bsiai_metadata_cluster(sbom, violations);
         self.check_bsiai_system_level_cluster(sbom, &ml_components, violations);
-        self.check_bsiai_models_cluster(&ml_components, violations);
+        self.check_bsiai_models_cluster(sbom, &ml_components, violations);
         self.check_bsiai_datasets_cluster(&dataset_components, violations);
         self.check_bsiai_infrastructure_cluster(sbom, &ml_components, violations);
         self.check_bsiai_security_cluster(violations);
@@ -282,6 +282,7 @@ impl ComplianceChecker {
     /// card, architecture, training datasets, limitations, and license.
     fn check_bsiai_models_cluster(
         &self,
+        sbom: &NormalizedSbom,
         ml_components: &[&crate::model::Component],
         violations: &mut Vec<Violation>,
     ) {
@@ -331,8 +332,9 @@ impl ComplianceChecker {
             if !has_architecture {
                 without_architecture.push(c.name.clone());
             }
-            // Training datasets referenced (AI-003).
-            if ml.is_none_or(|m| m.training_datasets.is_empty()) {
+            // Training datasets referenced (AI-003): modelParameters.datasets or
+            // dataset-evidenced components nested under the model.
+            if !super::ai_shared::declares_training_datasets(sbom, c) {
                 without_datasets.push(c.name.clone());
             }
             // Limitations stated (AI-008).

--- a/src/quality/scorer.rs
+++ b/src/quality/scorer.rs
@@ -920,8 +920,9 @@ impl QualityScorer {
                 ml.and_then(|m| m.model_card_url.as_ref()).is_some(),
                 // AI-002: architecture family
                 ml.and_then(|m| m.architecture_family.as_ref()).is_some(),
-                // AI-003: training datasets
-                ml.is_some_and(|m| !m.training_datasets.is_empty()),
+                // AI-003: training datasets — modelParameters.datasets, or
+                // dataset-evidenced components nested under the model.
+                super::compliance::ai_shared::declares_training_datasets(sbom, component),
                 // AI-004: quantitative analysis — typed performance metrics, with
                 // a raw-pointer fallback for SBOMs parsed before typed extraction.
                 ml.is_some_and(|m| !m.performance_metrics.is_empty())

--- a/tests/aibom_corpus_tests.rs
+++ b/tests/aibom_corpus_tests.rs
@@ -1,0 +1,123 @@
+//! Regression pins for the third-party AI-BOM corpus in `tests/fixtures/aibom/`.
+//!
+//! These documents were produced by other vendors' generators (see the README
+//! there for provenance) and are kept verbatim. The assertions below record
+//! how sbom-tools reads them *today*, so a parser or scoring change that
+//! shifts the result is a deliberate decision rather than silent drift.
+//! `scripts/test-aibom.sh` runs the same corpus through the CLI.
+
+use sbom_tools::model::{ComponentType, DependencyType, NormalizedSbom};
+use sbom_tools::quality::{QualityScorer, ScoringProfile};
+
+fn corpus(name: &str) -> NormalizedSbom {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/aibom")
+        .join(name);
+    sbom_tools::parse_sbom(&path).unwrap_or_else(|e| panic!("parse {name}: {e}"))
+}
+
+fn check_passed(sbom: &NormalizedSbom, id: &str) -> bool {
+    let report = QualityScorer::new(ScoringProfile::AiReadiness).score(sbom);
+    let metrics = report
+        .ai_readiness_metrics
+        .as_ref()
+        .expect("AI readiness metrics");
+    assert_eq!(
+        metrics.ml_component_count, 1,
+        "exactly one model per corpus document"
+    );
+    metrics
+        .checks
+        .iter()
+        .find(|c| c.id == id)
+        .unwrap_or_else(|| panic!("check {id} missing"))
+        .passed
+}
+
+/// Manifest `aibom-gen` nests weight files and datasets under the model as
+/// sub-components. The parser must flatten them into the inventory and keep
+/// the containment edges.
+#[test]
+fn manifest_corpus_nested_components_are_flattened_with_containment() {
+    for (name, total, nested_data) in [
+        ("Llama-3.2-1B-Instruct.cdx.json", 36, 21),
+        ("Qwen2.5-7B-Instruct.cdx.json", 59, 45),
+    ] {
+        let sbom = corpus(name);
+        assert_eq!(
+            sbom.component_count(),
+            total,
+            "{name}: flattened component count"
+        );
+
+        let models: Vec<_> = sbom
+            .components
+            .values()
+            .filter(|c| c.component_type == ComponentType::MachineLearningModel)
+            .collect();
+        assert_eq!(models.len(), 1, "{name}: one machine-learning-model");
+        let model = models[0];
+
+        let contained: Vec<_> = sbom
+            .get_dependencies(&model.canonical_id)
+            .into_iter()
+            .filter(|e| e.relationship == DependencyType::Contains)
+            .filter_map(|e| sbom.components.get(&e.to))
+            .collect();
+        assert!(
+            !contained.is_empty(),
+            "{name}: nested sub-components must be parented to the model"
+        );
+        let data_children = contained
+            .iter()
+            .filter(|c| c.component_type == ComponentType::Data)
+            .count();
+        assert_eq!(
+            data_children, nested_data,
+            "{name}: nested `type: data` children"
+        );
+    }
+}
+
+/// The corpus datasets are bare `type: data` children with properties only
+/// (no `data[]` block), which is not dataset evidence under the shared AI
+/// scope. AI-003 therefore fails for both documents by policy, even though
+/// Llama declares 21 datasets that way. Flip this assertion only with a
+/// deliberate change to `ai_shared::declares_training_datasets`.
+#[test]
+fn manifest_corpus_bare_nested_datasets_do_not_satisfy_ai_003() {
+    for name in [
+        "Llama-3.2-1B-Instruct.cdx.json",
+        "Qwen2.5-7B-Instruct.cdx.json",
+    ] {
+        let sbom = corpus(name);
+        assert!(
+            sbom.components.values().all(|c| c.dataset.is_none()),
+            "{name}: corpus datasets carry no `data[]` evidence (fixture drift?)"
+        );
+        assert!(
+            !check_passed(&sbom, "AI-003"),
+            "{name}: AI-003 must not pass on bare nested data components"
+        );
+    }
+}
+
+/// What the corpus *does* satisfy today: the model-card external reference
+/// (AI-001) and the declared architecture (AI-002) are read from both files.
+#[test]
+fn manifest_corpus_model_card_and_architecture_are_read() {
+    for name in [
+        "Llama-3.2-1B-Instruct.cdx.json",
+        "Qwen2.5-7B-Instruct.cdx.json",
+    ] {
+        let sbom = corpus(name);
+        assert!(
+            check_passed(&sbom, "AI-001"),
+            "{name}: model card reference"
+        );
+        assert!(
+            check_passed(&sbom, "AI-002"),
+            "{name}: architecture declared"
+        );
+    }
+}

--- a/tests/fixtures/aibom/Llama-3.2-1B-Instruct.cdx.json
+++ b/tests/fixtures/aibom/Llama-3.2-1B-Instruct.cdx.json
@@ -1,0 +1,1053 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:879dd526-2afe-458f-bbac-92e3bc5e9374",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-10-24T16:42:35Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "author": "Manifest Cyber",
+          "publisher": "Manifest Cyber",
+          "name": "aibom-gen",
+          "version": "0.1.0-alpha.10",
+          "description": "Email info@manifestcyber.com for more information about this tool."
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "meta-llama-llama-3.2-1b-instruct-66eaedefece5ee215637cc82",
+      "type": "machine-learning-model",
+      "supplier": {
+        "name": "meta-llama"
+      },
+      "name": "meta-llama/Llama-3.2-1B-Instruct",
+      "version": "9213176726f574b556790deb65791e0c5aa438b6",
+      "licenses": [
+        {
+          "license": {
+            "name": "Llama 3.2 Community License"
+          }
+        }
+      ],
+      "externalReferences": [
+        {
+          "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
+          "type": "model-card"
+        },
+        {
+          "url": "https://huggingface.co/meta-llama/Llama-3.2-1B-Instruct",
+          "type": "website"
+        },
+        {
+          "url": "https://arxiv.org/pdf/2204.05149",
+          "type": "documentation"
+        },
+        {
+          "url": "https://arxiv.org/pdf/2405.16406",
+          "type": "documentation"
+        },
+        {
+          "url": "https://github.com/meta-llama/llama-models",
+          "type": "vcs"
+        },
+        {
+          "url": "https://llama.meta.com/responsible-use-guide/",
+          "type": "documentation"
+        }
+      ],
+      "properties": [
+        {
+          "name": "createdAt",
+          "value": "2024-09-18T15:12:47.000Z"
+        },
+        {
+          "name": "lastModified",
+          "value": "2024-10-24T15:07:51.000Z"
+        },
+        {
+          "name": "downloads",
+          "value": "4127952"
+        },
+        {
+          "name": "likes",
+          "value": "1131"
+        },
+        {
+          "name": "libraryName",
+          "value": "transformers"
+        },
+        {
+          "name": "tags",
+          "value": "transformers, safetensors, llama, text-generation, facebook, meta, pytorch, llama-3, conversational, en, de, fr, it, pt, hi, es, th, arxiv:2204.05149, arxiv:2405.16406, license:llama3.2, autotrain_compatible, text-generation-inference, endpoints_compatible, region:us"
+        },
+        {
+          "name": "softwareRequiredForExecution",
+          "value": "true"
+        },
+        {
+          "name": "intendedUse",
+          "value": "Commercial and research use in multiple languages. Instruction tuned text only models are intended for assistant-like chat and agentic applications like knowledge retrieval and summarization, mobile AI powered writing assistants and query and prompt rewriting."
+        },
+        {
+          "name": "outOfScopeUse",
+          "value": "Use in violation of applicable laws, regulations, or the Acceptable Use Policy; use in languages not officially supported by the model; deployment without adequate safeguards for the specific use case."
+        }
+      ],
+      "components": [
+        {
+          "bom-ref": ".gitattributes-25-10-24_16:41:59",
+          "type": "file",
+          "name": ".gitattributes"
+        },
+        {
+          "bom-ref": "license.txt-25-10-24_16:41:59",
+          "type": "file",
+          "name": "LICENSE.txt"
+        },
+        {
+          "bom-ref": "readme.md-25-10-24_16:41:59",
+          "type": "file",
+          "name": "README.md"
+        },
+        {
+          "bom-ref": "use_policy.md-25-10-24_16:41:59",
+          "type": "file",
+          "name": "USE_POLICY.md"
+        },
+        {
+          "bom-ref": "config.json-25-10-24_16:41:59",
+          "type": "file",
+          "name": "config.json"
+        },
+        {
+          "bom-ref": "generation_config.json-25-10-24_16:41:59",
+          "type": "file",
+          "name": "generation_config.json"
+        },
+        {
+          "bom-ref": "model.safetensors-25-10-24_16:41:59",
+          "type": "file",
+          "name": "model.safetensors"
+        },
+        {
+          "bom-ref": "original-consolidated.00.pth-25-10-24_16:41:59",
+          "type": "file",
+          "name": "original/consolidated.00.pth"
+        },
+        {
+          "bom-ref": "original-params.json-25-10-24_16:41:59",
+          "type": "file",
+          "name": "original/params.json"
+        },
+        {
+          "bom-ref": "original-tokenizer.model-25-10-24_16:41:59",
+          "type": "file",
+          "name": "original/tokenizer.model"
+        },
+        {
+          "bom-ref": "special_tokens_map.json-25-10-24_16:41:59",
+          "type": "file",
+          "name": "special_tokens_map.json"
+        },
+        {
+          "bom-ref": "tokenizer.json-25-10-24_16:41:59",
+          "type": "file",
+          "name": "tokenizer.json"
+        },
+        {
+          "bom-ref": "tokenizer_config.json-25-10-24_16:41:59",
+          "type": "file",
+          "name": "tokenizer_config.json"
+        },
+        {
+          "type": "data",
+          "name": "Alpaca",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2204.05149",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-SA-4.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            },
+            {
+              "name": "usage",
+              "value": "training"
+            },
+            {
+              "name": "description",
+              "value": "Used as an instruction-following dataset to fine-tune the Llama-3.2-1B-Instruct model."
+            },
+            {
+              "name": "owner",
+              "value": "Stanford University"
+            },
+            {
+              "name": "full_name",
+              "value": "Alpaca: An Instruction-Following Model"
+            },
+            {
+              "name": "source_url",
+              "value": "https://crfm.stanford.edu/2023/03/13/alpaca.html"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "ShareGPT",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2204.05149",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            },
+            {
+              "name": "usage",
+              "value": "training"
+            },
+            {
+              "name": "description",
+              "value": "Used to provide high-quality conversational data collected from interactions with GPT models to improve instruction tuning."
+            },
+            {
+              "name": "owner",
+              "value": "ShareGPT community"
+            },
+            {
+              "name": "full_name",
+              "value": "ShareGPT Conversation Dataset"
+            },
+            {
+              "name": "source_url",
+              "value": "https://shareg.pt/"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "Code Alpaca",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2204.05149",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            },
+            {
+              "name": "usage",
+              "value": "training"
+            },
+            {
+              "name": "description",
+              "value": "A code-related instruction dataset used to enhance the programming capabilities of the model during fine-tuning."
+            },
+            {
+              "name": "owner",
+              "value": "meta-llama (Meta AI)"
+            },
+            {
+              "name": "full_name",
+              "value": "Code Alpaca Instruction Dataset"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/facebookresearch/CodeAlpaca"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "Open Assistant Conversations",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2204.05149",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-SA-4.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            },
+            {
+              "name": "usage",
+              "value": "training"
+            },
+            {
+              "name": "description",
+              "value": "Conversations dataset used to fine-tune the model for better instruction-following in dialogues."
+            },
+            {
+              "name": "owner",
+              "value": "LAION community"
+            },
+            {
+              "name": "full_name",
+              "value": "Open Assistant Conversations Dataset"
+            },
+            {
+              "name": "source_url",
+              "value": "https://open-assistant.io/"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "HumanEval",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2204.05149",
+          "licenses": [
+            {
+              "license": {
+                "id": "MIT"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation"
+            },
+            {
+              "name": "description",
+              "value": "Benchmark dataset for evaluating the model's code generation capabilities."
+            },
+            {
+              "name": "owner",
+              "value": "OpenAI"
+            },
+            {
+              "name": "full_name",
+              "value": "HumanEval: A Code Generation Evaluation Dataset"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/openai/human-eval"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "MMLU",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2204.05149",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            },
+            {
+              "name": "usage",
+              "value": "benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Used for evaluating the model's general knowledge and multi-task capabilities across various subjects."
+            },
+            {
+              "name": "owner",
+              "value": "Stanford CRFM"
+            },
+            {
+              "name": "full_name",
+              "value": "Massive Multitask Language Understanding (MMLU)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/hendrycks/test"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "SQuAD",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2204.05149",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-SA-3.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation"
+            },
+            {
+              "name": "description",
+              "value": "Used to evaluate the question answering abilities of the model."
+            },
+            {
+              "name": "owner",
+              "value": "Stanford University"
+            },
+            {
+              "name": "full_name",
+              "value": "Stanford Question Answering Dataset (SQuAD)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://rajpurkar.github.io/SQuAD-explorer/"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "GSM8K",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2204.05149",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            },
+            {
+              "name": "usage",
+              "value": "benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Used to assess the model's mathematical reasoning capabilities."
+            },
+            {
+              "name": "owner",
+              "value": "University of Washington and AI2"
+            },
+            {
+              "name": "full_name",
+              "value": "Grade School Math 8K (GSM8K)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/openai/grade-school-math"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "BBH",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2204.05149",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            },
+            {
+              "name": "usage",
+              "value": "benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Benchmark for a broad range of complex reasoning tasks used to evaluate model performance."
+            },
+            {
+              "name": "owner",
+              "value": "Stanford CRFM"
+            },
+            {
+              "name": "full_name",
+              "value": "Big-Bench Hard (BBH)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/google/BIG-bench"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2204.05149"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "WikiText2",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2405.16406",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            },
+            {
+              "name": "usage",
+              "value": "calibration|evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Used as calibration data for optimizing rotation matrices with Cayley SGD (800 samples), for calibrating GPTQ quantization (128 samples), and for evaluating perplexity score on the test set."
+            },
+            {
+              "name": "owner",
+              "value": "Stephen Merity, Caiming Xiong, James Bradbury, Richard Socher"
+            },
+            {
+              "name": "full_name",
+              "value": "WikiText-2"
+            },
+            {
+              "name": "source_url",
+              "value": "https://blog.einstein.ai/the-wikitext-long-term-dependency-language-modeling-dataset/"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "C4",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2405.16406",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            },
+            {
+              "name": "usage",
+              "value": "calibration"
+            },
+            {
+              "name": "description",
+              "value": "Used as an alternative calibration dataset to assess robustness of SpinQuant rotation optimization; experiments showed consistent results with WikiText2 calibration."
+            },
+            {
+              "name": "owner",
+              "value": "Google Research"
+            },
+            {
+              "name": "full_name",
+              "value": "Colossal Clean Crawled Corpus (C4)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://commoncrawl.org/2020/10/the-colossal-cleaned-crawl-ccnet/"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "ARC-easy",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2405.16406",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "One of eight zero-shot commonsense reasoning tasks used to evaluate the quantized models' accuracy."
+            },
+            {
+              "name": "owner",
+              "value": "Peter Clark et al."
+            },
+            {
+              "name": "full_name",
+              "value": "AI2 Reasoning Challenge Easy (ARC-Easy)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://allenai.org/data/arc"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "ARC-challenge",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2405.16406",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "One of eight zero-shot commonsense reasoning tasks used to evaluate the quantized models' accuracy."
+            },
+            {
+              "name": "owner",
+              "value": "Peter Clark et al."
+            },
+            {
+              "name": "full_name",
+              "value": "AI2 Reasoning Challenge Challenge (ARC-Challenge)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://allenai.org/data/arc"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "BoolQ",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2405.16406",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "One of eight zero-shot commonsense reasoning tasks used to evaluate the quantized models' accuracy."
+            },
+            {
+              "name": "owner",
+              "value": "Google Research"
+            },
+            {
+              "name": "full_name",
+              "value": "Boolean Questions (BoolQ)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/google-research-datasets/boolean-questions"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "PIQA",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2405.16406",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "One of eight zero-shot commonsense reasoning tasks used to evaluate the quantized models' accuracy."
+            },
+            {
+              "name": "owner",
+              "value": "Mohit Bisk et al."
+            },
+            {
+              "name": "full_name",
+              "value": "Physical Interaction QA (PIQA)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://leaderboard.allenai.org/piqa/submissions/get-started"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "SIQA",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2405.16406",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "One of eight zero-shot commonsense reasoning tasks used to evaluate the quantized models' accuracy."
+            },
+            {
+              "name": "owner",
+              "value": "Swabha Swayamdipta, Yejin Choi et al."
+            },
+            {
+              "name": "full_name",
+              "value": "Social IQa (SIQA)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://worksheets.codalab.org/worksheets/0xa789a2b76ce34518b46d8d141de8a4d6/"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "HellaSwag",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2405.16406",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "One of eight zero-shot commonsense reasoning tasks used to evaluate the quantized models' accuracy."
+            },
+            {
+              "name": "owner",
+              "value": "Rowan Zellers et al."
+            },
+            {
+              "name": "full_name",
+              "value": "HellaSwag: Can a Machine Really Finish Your Sentence?"
+            },
+            {
+              "name": "source_url",
+              "value": "https://rowanzellers.com/hellaswag/"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "OBQA",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2405.16406",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "One of eight zero-shot commonsense reasoning tasks used to evaluate the quantized models' accuracy."
+            },
+            {
+              "name": "owner",
+              "value": "Mitchell Holtzman, Eric Wallace et al."
+            },
+            {
+              "name": "full_name",
+              "value": "OpenBookQA (OBQA)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://leaderboard.allenai.org/open_book_qa/submissions/get-started"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "WinoGrande",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2405.16406",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "One of eight zero-shot commonsense reasoning tasks used to evaluate the quantized models' accuracy."
+            },
+            {
+              "name": "owner",
+              "value": "Sakaguchi et al."
+            },
+            {
+              "name": "full_name",
+              "value": "WinoGrande"
+            },
+            {
+              "name": "source_url",
+              "value": "https://leaderboard.allenai.org/winogrande/submissions/get-started"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "MMLU",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2405.16406",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Used in few-shot evaluation (5-shot) of instruction-finetuned LLaMA 3.2 1B and 3B models to assess SpinQuant quantization improvements."
+            },
+            {
+              "name": "owner",
+              "value": "Dan Hendrycks et al."
+            },
+            {
+              "name": "full_name",
+              "value": "Massive Multitask Language Understanding (MMLU)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/hendrycks/test"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "TLDR9",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2405.16406",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Used for 1-shot rouge score evaluation on summarization tasks for instruction-finetuned models quantized with SpinQuant."
+            },
+            {
+              "name": "full_name",
+              "value": "TLDR9 Summarization Benchmark"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2405.16406"
+            }
+          ]
+        }
+      ],
+      "modelCard": {
+        "modelParameters": {
+          "task": "text-generation",
+          "architectureFamily": "llama",
+          "modelArchitecture": "LlamaForCausalLM",
+          "inputs": [
+            {
+              "format": "text"
+            }
+          ],
+          "outputs": [
+            {
+              "format": "text"
+            }
+          ]
+        },
+        "considerations": {}
+      }
+    },
+    {
+      "bom-ref": "transformers-lib",
+      "type": "library",
+      "name": "transformers"
+    },
+    {
+      "bom-ref": "pytorch-lib",
+      "type": "library",
+      "name": "PyTorch"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "meta-llama-llama-3.2-1b-instruct-66eaedefece5ee215637cc82",
+      "dependsOn": [
+        "transformers-lib",
+        "pytorch-lib"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/aibom/Qwen2.5-7B-Instruct.cdx.json
+++ b/tests/fixtures/aibom/Qwen2.5-7B-Instruct.cdx.json
@@ -1,0 +1,2075 @@
+{
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "serialNumber": "urn:uuid:d2b4acaa-dc30-4f0a-80e7-abec9cff4ccf",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2025-10-24T16:43:02Z",
+    "tools": {
+      "components": [
+        {
+          "type": "application",
+          "author": "Manifest Cyber",
+          "publisher": "Manifest Cyber",
+          "name": "aibom-gen",
+          "version": "0.1.0-alpha.10",
+          "description": "Email info@manifestcyber.com for more information about this tool."
+        }
+      ]
+    }
+  },
+  "components": [
+    {
+      "bom-ref": "qwen-qwen2.5-7b-instruct-66e81cbcd683a3f4e5291bbf",
+      "type": "machine-learning-model",
+      "supplier": {
+        "name": "Qwen"
+      },
+      "name": "Qwen/Qwen2.5-7B-Instruct",
+      "version": "a09a35458c702b33eeacc393d103063234e8bc28",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0"
+          }
+        }
+      ],
+      "pedigree": {
+        "ancestors": [
+          {
+            "bom-ref": "qwen-qwen2.5-7b-25-10-24_16:41:48",
+            "type": "machine-learning-model",
+            "author": "Qwen",
+            "name": "Qwen2.5-7B",
+            "externalReferences": [
+              {
+                "url": "https://huggingface.co/Qwen/Qwen2.5-7B",
+                "type": "model-card"
+              },
+              {
+                "url": "https://huggingface.co/Qwen/Qwen2.5-7B",
+                "type": "website"
+              }
+            ]
+          }
+        ]
+      },
+      "externalReferences": [
+        {
+          "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
+          "type": "model-card"
+        },
+        {
+          "url": "https://huggingface.co/Qwen/Qwen2.5-7B-Instruct",
+          "type": "website"
+        },
+        {
+          "url": "https://arxiv.org/pdf/2309.00071",
+          "type": "documentation"
+        },
+        {
+          "url": "https://arxiv.org/pdf/2407.10671",
+          "type": "documentation"
+        },
+        {
+          "url": "https://qwenlm.github.io/blog/qwen2.5/",
+          "type": "documentation"
+        },
+        {
+          "url": "https://github.com/QwenLM/Qwen2.5",
+          "type": "vcs"
+        },
+        {
+          "url": "https://qwen.readthedocs.io/",
+          "type": "documentation"
+        }
+      ],
+      "properties": [
+        {
+          "name": "createdAt",
+          "value": "2024-09-16T11:55:40.000Z"
+        },
+        {
+          "name": "lastModified",
+          "value": "2025-01-12T02:10:10.000Z"
+        },
+        {
+          "name": "downloads",
+          "value": "7464491"
+        },
+        {
+          "name": "likes",
+          "value": "828"
+        },
+        {
+          "name": "libraryName",
+          "value": "transformers"
+        },
+        {
+          "name": "tags",
+          "value": "transformers, safetensors, qwen2, text-generation, chat, conversational, en, arxiv:2309.00071, arxiv:2407.10671, base_model:Qwen/Qwen2.5-7B, base_model:finetune:Qwen/Qwen2.5-7B, license:apache-2.0, autotrain_compatible, text-generation-inference, endpoints_compatible, region:us"
+        },
+        {
+          "name": "softwareRequiredForExecution",
+          "value": "true"
+        },
+        {
+          "name": "intendedUse",
+          "value": "General-purpose instruction-following conversational AI and text generation, supporting more than 29 languages."
+        }
+      ],
+      "components": [
+        {
+          "bom-ref": ".gitattributes-25-10-24_16:41:48",
+          "type": "file",
+          "name": ".gitattributes"
+        },
+        {
+          "bom-ref": "license-25-10-24_16:41:48",
+          "type": "file",
+          "name": "LICENSE"
+        },
+        {
+          "bom-ref": "readme.md-25-10-24_16:41:48",
+          "type": "file",
+          "name": "README.md"
+        },
+        {
+          "bom-ref": "config.json-25-10-24_16:41:48",
+          "type": "file",
+          "name": "config.json"
+        },
+        {
+          "bom-ref": "generation_config.json-25-10-24_16:41:48",
+          "type": "file",
+          "name": "generation_config.json"
+        },
+        {
+          "bom-ref": "merges.txt-25-10-24_16:41:48",
+          "type": "file",
+          "name": "merges.txt"
+        },
+        {
+          "bom-ref": "model-00001-of-00004.safetensors-25-10-24_16:41:48",
+          "type": "file",
+          "name": "model-00001-of-00004.safetensors"
+        },
+        {
+          "bom-ref": "model-00002-of-00004.safetensors-25-10-24_16:41:48",
+          "type": "file",
+          "name": "model-00002-of-00004.safetensors"
+        },
+        {
+          "bom-ref": "model-00003-of-00004.safetensors-25-10-24_16:41:48",
+          "type": "file",
+          "name": "model-00003-of-00004.safetensors"
+        },
+        {
+          "bom-ref": "model-00004-of-00004.safetensors-25-10-24_16:41:48",
+          "type": "file",
+          "name": "model-00004-of-00004.safetensors"
+        },
+        {
+          "bom-ref": "model.safetensors.index.json-25-10-24_16:41:48",
+          "type": "file",
+          "name": "model.safetensors.index.json"
+        },
+        {
+          "bom-ref": "tokenizer.json-25-10-24_16:41:48",
+          "type": "file",
+          "name": "tokenizer.json"
+        },
+        {
+          "bom-ref": "tokenizer_config.json-25-10-24_16:41:48",
+          "type": "file",
+          "name": "tokenizer_config.json"
+        },
+        {
+          "bom-ref": "vocab.json-25-10-24_16:41:48",
+          "type": "file",
+          "name": "vocab.json"
+        },
+        {
+          "type": "data",
+          "name": "PG19",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2309.00071",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            },
+            {
+              "name": "usage",
+              "value": "training"
+            },
+            {
+              "name": "description",
+              "value": "Fine-tuning dataset for extending the context window of Llama 2 models using YaRN method, chunked into 64k token segments."
+            },
+            {
+              "name": "owner",
+              "value": "Colin Raffel et al., Google Research"
+            },
+            {
+              "name": "full_name",
+              "value": "PG-19"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/google-research/google-research/tree/master/pg19"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "Proof-pile",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2309.00071",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-SA-4.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation"
+            },
+            {
+              "name": "description",
+              "value": "Dataset with long documents used for evaluating the sliding window perplexity of models with extended context windows."
+            },
+            {
+              "name": "owner",
+              "value": "EleutherAI"
+            },
+            {
+              "name": "full_name",
+              "value": "Proof-pile"
+            },
+            {
+              "name": "source_url",
+              "value": "https://huggingface.co/datasets/EleutherAI/proof-pile"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "GovReport",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2309.00071",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-4.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation"
+            },
+            {
+              "name": "description",
+              "value": "Dataset of long documents used to evaluate long sequence language modeling perplexity for models fine-tuned with extended context."
+            },
+            {
+              "name": "owner",
+              "value": "Bingjie Xu, Satoshi Okazaki, Jinho D. Choi"
+            },
+            {
+              "name": "full_name",
+              "value": "GovReport: Efficient Long Document Summarization by Selective Contextual Encoding"
+            },
+            {
+              "name": "source_url",
+              "value": "https://aclanthology.org/2021.emnlp-main.90/"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "Hugging Face Open LLM Leaderboard benchmarks",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2309.00071",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            },
+            {
+              "name": "usage",
+              "value": "benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Set of standardized benchmarks (including ARC-Challenge, HellaSwag, MMLU, and TruthfulQA) used for benchmarking and comparing model performance under extended context windows."
+            },
+            {
+              "name": "owner",
+              "value": "Hugging Face and contributing dataset authors"
+            },
+            {
+              "name": "full_name",
+              "value": "Hugging Face Open LLM Leaderboard Public Benchmark Suite"
+            },
+            {
+              "name": "source_url",
+              "value": "https://huggingface.co/spaces/HuggingFaceH4/open_llm_leaderboard"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "ARC-Challenge",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2309.00071",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-4.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            },
+            {
+              "name": "usage",
+              "value": "benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "25-shot ARC-Challenge dataset used as part of the Open LLM Leaderboard benchmarks to assess model reasoning capabilities."
+            },
+            {
+              "name": "owner",
+              "value": "AI2 (Allen Institute for AI)"
+            },
+            {
+              "name": "full_name",
+              "value": "AI2 Reasoning Challenge (ARC) - Challenge Set"
+            },
+            {
+              "name": "source_url",
+              "value": "https://allenai.org/data/arc"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "HellaSwag",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2309.00071",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            },
+            {
+              "name": "usage",
+              "value": "benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "10-shot HellaSwag used for commonsense reasoning evaluation as part of benchmark suite."
+            },
+            {
+              "name": "owner",
+              "value": "Allen Institute for AI"
+            },
+            {
+              "name": "full_name",
+              "value": "HellaSwag: Can a Machine Really Finish Your Sentence?"
+            },
+            {
+              "name": "source_url",
+              "value": "https://rowanzellers.com/hellaswag/"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "MMLU",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2309.00071",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            },
+            {
+              "name": "usage",
+              "value": "benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "5-shot MMLU dataset used to evaluate multi-domain knowledge and reasoning abilities of the model."
+            },
+            {
+              "name": "owner",
+              "value": "Dan Hendrycks et al."
+            },
+            {
+              "name": "full_name",
+              "value": "Massive Multitask Language Understanding (MMLU)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/hendrycks/test"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "TruthfulQA",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2309.00071",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            },
+            {
+              "name": "usage",
+              "value": "benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "0-shot TruthfulQA dataset evaluating models on truthful question answering abilities as part of benchmarking."
+            },
+            {
+              "name": "owner",
+              "value": "Lin et al."
+            },
+            {
+              "name": "full_name",
+              "value": "TruthfulQA: Measuring How Models Mimic Human Falsehoods"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/sylinrl/TruthfulQA"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "RedPajama",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2309.00071",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-SA-4.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            },
+            {
+              "name": "usage",
+              "value": "perplexity evaluation data analysis"
+            },
+            {
+              "name": "description",
+              "value": "Dataset used to select documents for studying the impact of scaling the softmax temperature in YaRN on perplexity. It is used to analyze token-level perplexity variation under different scaling factors."
+            },
+            {
+              "name": "owner",
+              "value": "Together.ai"
+            },
+            {
+              "name": "full_name",
+              "value": "RedPajama-Data"
+            },
+            {
+              "name": "source_url",
+              "value": "https://redpajama.org/"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "Together Computer's Long-Data Collections",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2309.00071",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            },
+            {
+              "name": "usage",
+              "value": "training"
+            },
+            {
+              "name": "description",
+              "value": "Used as training data (a mix of pre-train and fine-tune splits) for extending context windows of Mistral 7B models with YaRN."
+            },
+            {
+              "name": "owner",
+              "value": "Together Computer"
+            },
+            {
+              "name": "full_name",
+              "value": "Together Computer's Long-Data Collections"
+            },
+            {
+              "name": "source_url",
+              "value": "https://www.together.xyz/long-data"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2309.00071"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "MMLU",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "English knowledge and general question answering evaluated with few-shot prompting for base models and instruction-tuned models."
+            },
+            {
+              "name": "owner",
+              "value": "Hendrycks et al., University of California, Berkeley"
+            },
+            {
+              "name": "full_name",
+              "value": "Massive Multitask Language Understanding"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/hendrycks/test"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "MMLU-Pro",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Pro version of MMLU dataset focusing on professional knowledge; used for evaluation of general knowledge performance."
+            },
+            {
+              "name": "owner",
+              "value": "Authors of MMLU-Pro (extension of MMLU)"
+            },
+            {
+              "name": "full_name",
+              "value": "MMLU Professional Knowledge Benchmark"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/hendrycks/test"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "GPQA",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Benchmark for factual and knowledge-based question answering evaluated in a few-shot setting."
+            },
+            {
+              "name": "owner",
+              "value": "Google or original GPQA authors"
+            },
+            {
+              "name": "full_name",
+              "value": "Google Prompted Question Answering"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/microsoft/GPQA"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "Theorem QA",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Dataset for evaluating scientific and theorem-related question answering capabilities with few-shot prompts."
+            },
+            {
+              "name": "owner",
+              "value": "Original authors of Theorem QA dataset"
+            },
+            {
+              "name": "full_name",
+              "value": "Theorem Question Answering Dataset"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/allenai/theoremqa"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "BBH",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Big Bench Hard benchmark including difficult reasoning and commonsense challenges, evaluated in few-shot mode."
+            },
+            {
+              "name": "owner",
+              "value": "Google Brain/BIG-Bench contributors"
+            },
+            {
+              "name": "full_name",
+              "value": "BIG-Bench Hard"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/google/BIG-bench"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "HellaSwag",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-SA-4.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Commonsense reasoning task using multiple-choice questions to assess natural language understanding."
+            },
+            {
+              "name": "owner",
+              "value": "Allen Institute for AI (AI2)"
+            },
+            {
+              "name": "full_name",
+              "value": "HellaSwag: Can a Machine Really Finish Your Sentence?"
+            },
+            {
+              "name": "source_url",
+              "value": "https://rowanzellers.com/hellaswag/"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "Winogrande",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-4.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Commonsense reasoning benchmark built on Winograd Schema format, tested with few-shot prompting."
+            },
+            {
+              "name": "owner",
+              "value": "Allen Institute for AI (AI2)"
+            },
+            {
+              "name": "full_name",
+              "value": "Winogrande"
+            },
+            {
+              "name": "source_url",
+              "value": "https://leaderboard.allenai.org/winogrande"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "ARC-C",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-4.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "ARC Challenge dataset testing advanced question-answering in science; evaluated with multiple shots."
+            },
+            {
+              "name": "owner",
+              "value": "Allen Institute for AI (AI2)"
+            },
+            {
+              "name": "full_name",
+              "value": "AI2 Reasoning Challenge - Challenge Set"
+            },
+            {
+              "name": "source_url",
+              "value": "https://allenai.org/data/arc"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "TruthfulQA",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-4.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Benchmark designed to test model truthfulness and hallucination resistance, evaluated zero-shot."
+            },
+            {
+              "name": "owner",
+              "value": "Stanford University"
+            },
+            {
+              "name": "full_name",
+              "value": "TruthfulQA"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/sylvain-gugger/truthfulqa"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "HumanEval",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "licenses": [
+            {
+              "license": {
+                "id": "MIT"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Coding benchmark consisting of Python programming problems used to evaluate code generation capabilities."
+            },
+            {
+              "name": "owner",
+              "value": "OpenAI"
+            },
+            {
+              "name": "full_name",
+              "value": "HumanEval: Evaluating Code Generation Models"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/openai/human-eval"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "MBPP",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "licenses": [
+            {
+              "license": {
+                "id": "Apache-2.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Multi-lingual benchmark for code generation problems, focusing on Python programming tasks evaluated zero-shot."
+            },
+            {
+              "name": "owner",
+              "value": "Google Brain"
+            },
+            {
+              "name": "full_name",
+              "value": "Multi-lingual Programming by Prompting"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/google-research/google-research/tree/master/mbpp"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "EvalPlus",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Evaluation benchmark for code generation across multiple programming languages, conducted at zero-shot."
+            },
+            {
+              "name": "owner",
+              "value": "Authors of EvalPlus dataset"
+            },
+            {
+              "name": "full_name",
+              "value": "EvalPlus Code Generation Benchmark"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/code-evalplus/code-evalplus"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "MultiPL-E",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Multilingual Programming Language Evaluation for multiple languages (Python, C++, Java, etc.), zero-shot tested."
+            },
+            {
+              "name": "owner",
+              "value": "Authors of MultiPL-E dataset"
+            },
+            {
+              "name": "full_name",
+              "value": "MultiPL-E: Multilingual Programming Language Evaluation"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/eth-sri/multiple"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "GSM8K",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Grade School Math dataset to evaluate multi-step mathematical reasoning with few-shot prompting."
+            },
+            {
+              "name": "owner",
+              "value": "DeepMind"
+            },
+            {
+              "name": "full_name",
+              "value": "Grade School Math 8K"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/openai/grade-school-math"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "MATH",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Mathematics competition problems dataset used to evaluate advanced math problem-solving capabilities."
+            },
+            {
+              "name": "owner",
+              "value": "MIT"
+            },
+            {
+              "name": "full_name",
+              "value": "MATH Dataset: Mathematics Dataset from High School Contests"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/hendrycks/math"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "C-Eval",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Chinese evaluation dataset for knowledge and multi-domain assessment, evaluated with few-shot prompting."
+            },
+            {
+              "name": "owner",
+              "value": "Authors of C-Eval dataset"
+            },
+            {
+              "name": "full_name",
+              "value": "C-Eval: A Comprehensive Chinese Evaluation Benchmark"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/PhoebusSi/CEval"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "CMMLU",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Chinese Multi-domain Multi-level Understanding benchmark evaluating complex Chinese language comprehension."
+            },
+            {
+              "name": "owner",
+              "value": "Authors of CMMLU dataset"
+            },
+            {
+              "name": "full_name",
+              "value": "Chinese Multi-domain Multi-level Understanding (CMMLU)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/ymcui/cmmlu"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "M3Exam",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Multilingual multiple-choice exam dataset focusing on educational tests in multiple languages, excluding images."
+            },
+            {
+              "name": "owner",
+              "value": "Authors of M3Exam dataset"
+            },
+            {
+              "name": "full_name",
+              "value": "Multilingual Million Multiple Choice Exams"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/kevinrobinson/m3exam"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "IndoMMLU",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Multilingual language understanding benchmark in Indonesian language, used for multilingual evaluation."
+            },
+            {
+              "name": "owner",
+              "value": "Koto et al."
+            },
+            {
+              "name": "full_name",
+              "value": "Indonesian MMLU (IndoMMLU)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/facebookresearch/IndoNLG"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "ruMMLU",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Russian version of MMLU for multilingual language understanding evaluation in Russian."
+            },
+            {
+              "name": "owner",
+              "value": "Mera et al."
+            },
+            {
+              "name": "full_name",
+              "value": "Russian MMLU (ruMMLU)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/ai-forever/RuOpenAI"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "PAWS-X",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-4.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Paraphrase Adversaries from Word Scrambling cross-lingual dataset, assessing paraphrase identification capability in multiple languages."
+            },
+            {
+              "name": "owner",
+              "value": "Google Research"
+            },
+            {
+              "name": "full_name",
+              "value": "PAWS-X: Cross-lingual Adversarial Paraphrase Identification"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/google-research-datasets/paws"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "BELEBELE",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Multilingual benchmark assessing natural language understanding across several low-resource languages."
+            },
+            {
+              "name": "owner",
+              "value": "Authors of BELEBELE dataset"
+            },
+            {
+              "name": "full_name",
+              "value": "BELEBELE Multilingual Benchmark"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/allenai/belebele"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "XCOPA",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Cross-lingual Choice of Plausible Alternatives dataset for causal reasoning across languages."
+            },
+            {
+              "name": "owner",
+              "value": "Allen Institute for AI"
+            },
+            {
+              "name": "full_name",
+              "value": "Cross-lingual Choice of Plausible Alternatives (XCOPA)"
+            },
+            {
+              "name": "source_url",
+              "value": "https://allenai.org/data/xling_copa"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "XWinograd",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Multilingual Winograd Schema Challenge, assessing commonsense reasoning across multiple languages."
+            },
+            {
+              "name": "owner",
+              "value": "Authors of XWinograd dataset"
+            },
+            {
+              "name": "full_name",
+              "value": "Cross-lingual Winograd Schema Challenge"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/yahoo/xwinograd"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "XStoryCloze",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Multilingual story completion dataset, zero-shot evaluated for narrative understanding."
+            },
+            {
+              "name": "owner",
+              "value": "Original StoryCloze authors"
+            },
+            {
+              "name": "full_name",
+              "value": "Cross-lingual Story Cloze Test"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/AllenAI/rocstories"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "Flores-101",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "licenses": [
+            {
+              "license": {
+                "id": "CC-BY-SA-4.0"
+              }
+            }
+          ],
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Multilingual dataset for machine translation evaluation across 101 languages, used for translation benchmarking."
+            },
+            {
+              "name": "owner",
+              "value": "Facebook AI"
+            },
+            {
+              "name": "full_name",
+              "value": "Flores-101 Multilingual Translation Benchmark"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/facebookresearch/flores"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "MT-Bench",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Multi-turn human preference benchmark to assess instruction-following and preference alignment in instruction-tuned models."
+            },
+            {
+              "name": "owner",
+              "value": "Authors of MT-Bench"
+            },
+            {
+              "name": "full_name",
+              "value": "MT-Bench Multi-turn Instruction Following Benchmark"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/liuhaolun/mt-bench"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "Arena-Hard",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Difficult evaluation set from Chatbot Arena to test human preference alignment and instruction-following."
+            },
+            {
+              "name": "owner",
+              "value": "Chatbot Arena contributors"
+            },
+            {
+              "name": "full_name",
+              "value": "Arena-Hard Benchmark from Chatbot Arena"
+            },
+            {
+              "name": "source_url",
+              "value": "https://chatbotarena.com"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "AlignBench",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Benchmark designed to assess alignment and instruction-following quality for LLMs."
+            },
+            {
+              "name": "owner",
+              "value": "AlignBench authors"
+            },
+            {
+              "name": "full_name",
+              "value": "Alignment Benchmark for Instruction-Following"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/alignmentbench/alignbench"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "MixEval",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Aggregate benchmark approximating Chatbot Arena results, assessing human preference and instruction adherence."
+            },
+            {
+              "name": "owner",
+              "value": "MixEval authors"
+            },
+            {
+              "name": "full_name",
+              "value": "MixEval Human Preference Benchmark"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/mixeval/mixeval"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "IFEval",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Instruction-following evaluation benchmark, results reported on strict-prompt subset."
+            },
+            {
+              "name": "owner",
+              "value": "IFEval authors"
+            },
+            {
+              "name": "full_name",
+              "value": "Instruction-Following Evaluation"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/IFEval/IFEval"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "LiveCodeBench v1",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Benchmark for evaluating coding capabilities of instruction-tuned models."
+            },
+            {
+              "name": "owner",
+              "value": "LiveCodeBench authors"
+            },
+            {
+              "name": "full_name",
+              "value": "LiveCodeBench Version 1"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/livecodebench/livecodebench"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "Needle in a Haystack (NIAH)",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Long context understanding test that evaluates the ability to locate facts buried in long text streams of varying lengths."
+            },
+            {
+              "name": "owner",
+              "value": "Authors of NIAH"
+            },
+            {
+              "name": "full_name",
+              "value": "Needle in a Haystack Test"
+            },
+            {
+              "name": "source_url",
+              "value": "https://arxiv.org/abs/2305.17188"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "NeedleBench",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Enhanced NIAH benchmark with multiple facts requiring multi-hop reasoning in passages up to 256k tokens."
+            },
+            {
+              "name": "owner",
+              "value": "OpenCompass Authors"
+            },
+            {
+              "name": "full_name",
+              "value": "NeedleBench Long-Context Benchmark"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/OpenCompass/Evaluation/tree/main/needlebench"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        },
+        {
+          "type": "data",
+          "name": "LV-Eval",
+          "description": "Dataset extracted from arXiv paper: https://arxiv.org/pdf/2407.10671",
+          "properties": [
+            {
+              "name": "source",
+              "value": "arXiv paper analysis"
+            },
+            {
+              "name": "paper_url",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            },
+            {
+              "name": "usage",
+              "value": "evaluation|benchmarking"
+            },
+            {
+              "name": "description",
+              "value": "Long-context evaluation with 11 diverse QA datasets demanding comprehension of multiple evidences simultaneously."
+            },
+            {
+              "name": "owner",
+              "value": "Authors of LV-Eval"
+            },
+            {
+              "name": "full_name",
+              "value": "LV-Eval: Long-View Evaluation suite for Long Context QA"
+            },
+            {
+              "name": "source_url",
+              "value": "https://github.com/lv-eval/lv-eval"
+            },
+            {
+              "name": "arxiv_paper",
+              "value": "https://arxiv.org/pdf/2407.10671"
+            }
+          ]
+        }
+      ],
+      "modelCard": {
+        "modelParameters": {
+          "task": "text-generation",
+          "architectureFamily": "qwen2",
+          "modelArchitecture": "Qwen2ForCausalLM",
+          "inputs": [
+            {
+              "format": "text"
+            }
+          ],
+          "outputs": [
+            {
+              "format": "text"
+            }
+          ]
+        },
+        "considerations": {
+          "technicalLimitations": [
+            "Static YARN scaling in vLLM deployment may impact performance on shorter texts when configured for long contexts."
+          ]
+        }
+      }
+    },
+    {
+      "bom-ref": "transformers-lib",
+      "type": "library",
+      "name": "transformers"
+    },
+    {
+      "bom-ref": "pytorch-lib",
+      "type": "library",
+      "name": "PyTorch"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "qwen-qwen2.5-7b-instruct-66e81cbcd683a3f4e5291bbf",
+      "dependsOn": [
+        "transformers-lib",
+        "pytorch-lib"
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/aibom/README.md
+++ b/tests/fixtures/aibom/README.md
@@ -1,0 +1,75 @@
+# AI-BOM test dataset
+
+Real-world AI-BOMs produced by **third-party** generators, kept verbatim as a
+regression corpus for the AI/ML surface of sbom-tools (parsing, AI-readiness
+scoring, `bsi-ai` / `ai-act` compliance profiles).
+
+Unlike the hand-written fixtures in `tests/fixtures/cyclonedx/`, nothing here is
+authored to make a check pass. These files exercise how other tools actually
+emit AI-BOMs in the wild, so drift in our parser or scoring is caught against
+documents we do not control.
+
+Run the corpus with:
+
+```bash
+./scripts/test-aibom.sh
+```
+
+## Provenance
+
+| File | Upstream | Generator |
+|------|----------|-----------|
+| `Llama-3.2-1B-Instruct.cdx.json` | [manifest-cyber/aibom `examples/Llama-3.2-1B-Instruct.json`](https://github.com/manifest-cyber/aibom/blob/main/examples/Llama-3.2-1B-Instruct.json) | Manifest Cyber `aibom-gen` 0.1.0-alpha.10 |
+| `Qwen2.5-7B-Instruct.cdx.json` | [manifest-cyber/aibom `examples/Qwen2.5-7B-Instruct.json`](https://github.com/manifest-cyber/aibom/blob/main/examples/Qwen2.5-7B-Instruct.json) | Manifest Cyber `aibom-gen` 0.1.0-alpha.10 |
+
+Both files were retrieved from upstream commit `bc2cc7a8839ac495c39ff0b982d226b17a079822`
+(2026-07-16) and are unmodified apart from the `.cdx.json` extension, which
+matches this repo's fixture naming. The upstream repository is Apache-2.0.
+
+## What these two documents cover
+
+CycloneDX 1.5, HuggingFace-sourced, 3 top-level components each
+(1 `machine-learning-model` + 2 `library`), with the model carrying **nested**
+sub-components:
+
+- weight and config files as nested `type: file` components, each with a hash —
+  the flattened component count is therefore much higher than the top-level
+  count (36 for Llama, 59 for Qwen);
+- training/eval datasets as nested `type: data` components (21 for Llama, 45 for Qwen)
+  rather than `modelCard.modelParameters.datasets`;
+- a `model-card` external reference pointing back at the HuggingFace repo.
+
+That nesting is the point of including them: it is a spec-legal shape that our
+own fixtures did not previously exercise.
+
+## Expected results
+
+`tests/aibom_corpus_tests.rs` pins how sbom-tools reads these files today so
+that drift is a deliberate decision:
+
+| File | Flattened components | Nested `type: data` | AI-001 | AI-002 | AI-003 |
+|------|---------------------:|--------------------:|:------:|:------:|:------:|
+| `Llama-3.2-1B-Instruct.cdx.json` | 36 | 21 | pass | pass | **fail** |
+| `Qwen2.5-7B-Instruct.cdx.json`   | 59 | 45 | pass | pass | **fail** |
+
+AI-003 ("Training datasets referenced") fails on both **by policy**. The
+Manifest generator declares datasets as bare nested `type: data` components
+carrying only `properties` (`usage: training`, `source`, …) and no `data[]`
+block. sbom-tools accepts two shapes as training-dataset evidence:
+
+1. `modelCard.modelParameters.datasets` (CycloneDX) / `trainedOn` (SPDX 3.0);
+2. dataset components nested under the model **with** a `data[]` block
+   (`Component::dataset` evidence).
+
+A bare `type: data` component is not dataset evidence — the same rule the
+`bsi-ai` / `ai-act` profiles apply, because CycloneDX `data` also covers
+configuration bundles. If Manifest starts emitting `data[]` blocks or
+`modelParameters.datasets`, AI-003 will pass and the pinned test must be
+updated on purpose.
+
+## Adding to the dataset
+
+Drop a `.cdx.json` / `.cdx.xml` / `.spdx.json` file in this directory, add a row
+to the provenance table above with the upstream URL and commit, and confirm the
+source license permits redistribution. `scripts/test-aibom.sh` picks up new
+files automatically.


### PR DESCRIPTION
## What

Two commits:

1. **AI-BOM corpus + harness.** Two real-world CycloneDX 1.5 AI-BOMs generated by Manifest Cyber `aibom-gen` (from manifest-cyber/aibom, Apache-2.0, upstream `bc2cc7a`), kept verbatim under `tests/fixtures/aibom/` with a provenance README. `scripts/test-aibom.sh` runs `view` / `quality --profile ai-readiness` / `validate --standard bsi-ai,ai-act` over the corpus plus the in-repo AI fixtures and prints one row per document. `tests/aibom_corpus_tests.rs` pins how we read the two files today: flattened component counts (36 / 59), containment edges from the model to its 21 / 45 nested `type: data` children, AI-001 and AI-002 pass, AI-003 fails.

2. **AI-003 accepts nested dataset evidence.** AI-003 and the BSI/G7 SBOM-for-AI model-cluster check only read `MlModelInfo::training_datasets` (from `modelCard.modelParameters.datasets`). A model that nests its datasets as sub-components with a real `data[]` block declared them in a spec-legal way and still failed. New `ai_shared::declares_training_datasets` is shared by both call sites: `modelParameters.datasets` **or** a `contains`-edge child carrying `Component::dataset` evidence.

## What deliberately does not change

A bare nested `type: data` component with only `properties` and no `data[]` block is still **not** dataset evidence, consistent with `ai_bom_scope` (CycloneDX `data` also covers configuration bundles). The Manifest corpus emits exactly that bare shape, so both corpus files keep failing AI-003 — the corpus test asserts this so a future flip is a deliberate decision. The README documents the policy.

## Verification

- Full suite 2450 passed / 0 failed (all features); fmt clean; clippy 1.88 clean under the CI invocation.
- `./scripts/test-aibom.sh`: 11 documents, 0 parse errors, 0 operational errors.
- New unit tests cover the three shapes (modelParameters, nested-with-evidence, bare nested) and the corpus tests cover counts, containment, AI-001/002/003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dVZ9LY4MJH5iFji7kyXr1
