### PR TITLE
chore(clippy): clear the 34 lints raised by clippy 1.98

### DIFF
--- a/src/enrichment/vex/csaf.rs
+++ b/src/enrichment/vex/csaf.rs
@@ -244,10 +244,10 @@ pub(crate) struct CsafVexResult {
 // ============================================================================
 
 fn pick_vuln_id(vuln: &CsafVulnerability) -> Option<String> {
-    if let Some(cve) = vuln.cve.as_deref() {
-        if !cve.is_empty() {
-            return Some(cve.to_string());
-        }
+    if let Some(cve) = vuln.cve.as_deref()
+        && !cve.is_empty()
+    {
+        return Some(cve.to_string());
     }
     vuln.ids
         .iter()

--- a/src/matching/index.rs
+++ b/src/matching/index.rs
@@ -516,33 +516,27 @@ impl ComponentIndex {
         let ecosystems = self.by_ecosystem.len();
         let prefixes = self.by_prefix.len();
         let trigrams = self.by_trigram.len();
-        let avg_per_ecosystem = if ecosystems > 0 {
-            self.by_ecosystem
-                .values()
-                .map(std::vec::Vec::len)
-                .sum::<usize>()
-                / ecosystems
-        } else {
-            0
-        };
-        let avg_per_prefix = if prefixes > 0 {
-            self.by_prefix
-                .values()
-                .map(std::vec::Vec::len)
-                .sum::<usize>()
-                / prefixes
-        } else {
-            0
-        };
-        let avg_per_trigram = if trigrams > 0 {
-            self.by_trigram
-                .values()
-                .map(std::vec::Vec::len)
-                .sum::<usize>()
-                / trigrams
-        } else {
-            0
-        };
+        let avg_per_ecosystem = self
+            .by_ecosystem
+            .values()
+            .map(std::vec::Vec::len)
+            .sum::<usize>()
+            .checked_div(ecosystems)
+            .unwrap_or(0);
+        let avg_per_prefix = self
+            .by_prefix
+            .values()
+            .map(std::vec::Vec::len)
+            .sum::<usize>()
+            .checked_div(prefixes)
+            .unwrap_or(0);
+        let avg_per_trigram = self
+            .by_trigram
+            .values()
+            .map(std::vec::Vec::len)
+            .sum::<usize>()
+            .checked_div(trigrams)
+            .unwrap_or(0);
 
         IndexStats {
             total_components: self.entries.len(),

--- a/src/parsers/cyclonedx.rs
+++ b/src/parsers/cyclonedx.rs
@@ -164,10 +164,10 @@ impl CycloneDxParser {
                     ExternalRefType::SecurityContact => {
                         sbom.document.security_contact = Some(ext_ref.url.clone());
                     }
-                    ExternalRefType::Advisories | ExternalRefType::Support => {
-                        if sbom.document.vulnerability_disclosure_url.is_none() {
-                            sbom.document.vulnerability_disclosure_url = Some(ext_ref.url.clone());
-                        }
+                    ExternalRefType::Advisories | ExternalRefType::Support
+                        if sbom.document.vulnerability_disclosure_url.is_none() =>
+                    {
+                        sbom.document.vulnerability_disclosure_url = Some(ext_ref.url.clone());
                     }
                     _ => {}
                 }

--- a/src/reports/analyst.rs
+++ b/src/reports/analyst.rs
@@ -316,7 +316,7 @@ impl AnalystReport {
             md.push_str("## Recommendations\n\n");
 
             let mut sorted_recs = self.recommendations.clone();
-            sorted_recs.sort_by(|a, b| a.priority.cmp(&b.priority));
+            sorted_recs.sort_by_key(|a| a.priority);
 
             for rec in &sorted_recs {
                 let _ = writeln!(

--- a/src/tui/app_states/sidebyside.rs
+++ b/src/tui/app_states/sidebyside.rs
@@ -517,14 +517,9 @@ impl SideBySideState {
         }
 
         let next_idx = match self.current_change_idx {
-            Some(idx) => {
-                if idx + 1 < self.change_indices.len() {
-                    idx + 1
-                } else {
-                    0 // Wrap around
-                }
-            }
-            None => 0,
+            Some(idx) if idx + 1 < self.change_indices.len() => idx + 1,
+            // Wrap around (or start from the top when nothing is selected).
+            _ => 0,
         };
 
         self.current_change_idx = Some(next_idx);

--- a/src/tui/app_states/source.rs
+++ b/src/tui/app_states/source.rs
@@ -2472,7 +2472,7 @@ fn insert_gap_items(
 ) {
     // Process insertions from the highest position to lowest
     let mut sorted: Vec<(usize, usize)> = insertions.to_vec();
-    sorted.sort_by(|a, b| b.0.cmp(&a.0));
+    sorted.sort_by_key(|a| std::cmp::Reverse(a.0));
 
     for (pos, count) in sorted {
         let insert_pos = pos.min(items.len());

--- a/src/tui/events/dependencies.rs
+++ b/src/tui/events/dependencies.rs
@@ -83,10 +83,7 @@ pub(super) fn update_dependencies_search_matches(app: &mut App) {
 }
 
 pub(super) fn skip_dependency_placeholders(app: &mut App, forward: bool) {
-    loop {
-        let Some(node_id) = app.dependencies_state().get_selected_node_id() else {
-            break;
-        };
+    while let Some(node_id) = app.dependencies_state().get_selected_node_id() {
         if !node_id.starts_with("__") {
             break;
         }

--- a/src/tui/license_conflicts.rs
+++ b/src/tui/license_conflicts.rs
@@ -296,7 +296,7 @@ impl ConflictDetector {
         }
 
         // Sort by severity (errors first)
-        conflicts.sort_by(|a, b| b.rule.severity.cmp(&a.rule.severity));
+        conflicts.sort_by_key(|a| std::cmp::Reverse(a.rule.severity));
 
         conflicts
     }

--- a/src/tui/security.rs
+++ b/src/tui/security.rs
@@ -597,7 +597,7 @@ pub fn find_attack_paths(
 
                         if paths.len() >= max_paths {
                             // Sort by risk score before returning
-                            paths.sort_by(|a, b| b.risk_score.cmp(&a.risk_score));
+                            paths.sort_by_key(|a| std::cmp::Reverse(a.risk_score));
                             return paths;
                         }
                     } else if !visited.contains(dep) {

--- a/src/tui/shared/source.rs
+++ b/src/tui/shared/source.rs
@@ -193,11 +193,9 @@ fn render_source_tree(
     // Pre-compute item count for status bar
     state.ensure_flat_cache();
     let pre_item_count = state.cached_flat_items.len();
-    let percent = if pre_item_count > 0 {
-        (state.selected + 1) * 100 / pre_item_count
-    } else {
-        0
-    };
+    let percent = ((state.selected + 1) * 100)
+        .checked_div(pre_item_count)
+        .unwrap_or(0);
     let status_bar = format!(
         " Ln {}/{} ({}%) ",
         state.selected + 1,
@@ -800,11 +798,9 @@ fn render_source_raw(
 
     // Status bar
     let total_lines = state.raw_lines.len();
-    let percent = if total_lines > 0 {
-        (state.selected + 1) * 100 / total_lines
-    } else {
-        0
-    };
+    let percent = ((state.selected + 1) * 100)
+        .checked_div(total_lines)
+        .unwrap_or(0);
     let col_info = if !state.word_wrap && state.h_scroll_offset > 0 {
         format!(" Col {}", state.h_scroll_offset)
     } else {

--- a/src/tui/view/events.rs
+++ b/src/tui/view/events.rs
@@ -92,10 +92,10 @@ impl Default for EventHandler {
                                 break;
                             }
                         }
-                        Ok(CrosstermEvent::Resize(w, h)) => {
-                            if event_tx.send(Event::Resize(w, h)).is_err() {
-                                break;
-                            }
+                        Ok(CrosstermEvent::Resize(w, h))
+                            if event_tx.send(Event::Resize(w, h)).is_err() =>
+                        {
+                            break;
                         }
                         _ => {}
                     }
@@ -672,10 +672,8 @@ fn handle_view_key(app: &mut ViewApp, key: KeyEvent) {
                 app.compliance_state.selected_violation = 0;
                 app.compliance_state.scroll_offset = 0;
             }
-            ViewTab::Source => {
-                if app.source_state.view_mode == SourceViewMode::Tree {
-                    app.source_state.cycle_filter_type();
-                }
+            ViewTab::Source if app.source_state.view_mode == SourceViewMode::Tree => {
+                app.source_state.cycle_filter_type();
             }
             _ => {}
         },
@@ -1122,7 +1120,6 @@ fn handle_search_key(app: &mut ViewApp, key: KeyEvent) {
                     super::app::SearchResult::Vulnerability {
                         id: _,
                         component_id,
-                        component_name: _,
                         ..
                     } => {
                         // Navigate directly by ID - no name lookup needed
@@ -1208,11 +1205,11 @@ pub fn handle_mouse_event(app: &mut ViewApp, mouse: event::MouseEvent) {
             // return None and are left as no-ops — a no-op is safer than selecting the
             // wrong row (which is what the old fixed `list_start_row = 4` did on every
             // tab, since content starts at row 5 and each list body is lower still).
-            if let Some(body_start) = view_list_body_start(app.active_tab) {
-                if y >= body_start {
-                    let row = (y - body_start) as usize;
-                    handle_list_click(app, row, x);
-                }
+            if let Some(body_start) = view_list_body_start(app.active_tab)
+                && y >= body_start
+            {
+                let row = (y - body_start) as usize;
+                handle_list_click(app, row, x);
             }
         }
         MouseEventKind::ScrollDown => {

--- a/src/tui/view/views/dependencies.rs
+++ b/src/tui/view/views/dependencies.rs
@@ -684,11 +684,7 @@ fn render_dependency_stats(
 
             for (label, count) in &rel_entries {
                 let count = **count;
-                let bar_len = if max_rel_count > 0 {
-                    (count * bar_width) / max_rel_count
-                } else {
-                    0
-                };
+                let bar_len = (count * bar_width).checked_div(max_rel_count).unwrap_or(0);
                 let bar = "█".repeat(bar_len);
                 lines.push(Line::from(vec![
                     Span::styled(format!("  {label:12}"), Style::default().fg(scheme.info)),
@@ -767,12 +763,10 @@ fn render_dependency_stats(
             if count == 0 && *key != "clean" {
                 continue;
             }
-            let bar_len = if max_vuln_count > 0 {
-                (count * bar_width) / max_vuln_count
-            } else {
-                0
-            }
-            .max(if count > 0 { 1 } else { 0 }); // at least 1 char if non-zero
+            let bar_len = (count * bar_width)
+                .checked_div(max_vuln_count)
+                .unwrap_or(0)
+                .max(usize::from(count > 0)); // at least 1 char if non-zero
             let bar = "█".repeat(bar_len);
 
             let badge_style = Style::default().fg(scheme.badge_fg_dark).bg(*color).bold();

--- a/src/tui/view/views/overview.rs
+++ b/src/tui/view/views/overview.rs
@@ -1431,7 +1431,7 @@ fn render_top_vulnerable(frame: &mut Frame, area: Rect, app: &ViewApp) {
         .map(|c| (c.name.clone(), c.vulnerabilities.len(), c.max_severity()))
         .collect();
 
-    vuln_comps.sort_by(|a, b| b.1.cmp(&a.1));
+    vuln_comps.sort_by_key(|a| std::cmp::Reverse(a.1));
 
     // Dynamic row count based on available area height
     let max_rows = area.height.saturating_sub(3) as usize; // subtract header + borders

--- a/src/tui/view/views/tree.rs
+++ b/src/tui/view/views/tree.rs
@@ -1163,11 +1163,7 @@ fn render_component_stats_panel(frame: &mut Frame, area: Rect, app: &ViewApp, bo
         let count = *count;
         let color = palette[i % palette.len()];
         let pct = (count * 100) / total;
-        let bar_len = if max_type_count > 0 {
-            (count * bar_width) / max_type_count
-        } else {
-            0
-        };
+        let bar_len = (count * bar_width).checked_div(max_type_count).unwrap_or(0);
         let bar = "█".repeat(bar_len);
         lines.push(Line::from(vec![
             Span::styled(format!("  {label:12}"), Style::default().fg(color)),
@@ -1201,11 +1197,7 @@ fn render_component_stats_panel(frame: &mut Frame, area: Rect, app: &ViewApp, bo
     for (key, label, color) in &vuln_order {
         let count = vuln_counts.get(key).copied().unwrap_or(0);
         let pct = (count * 100) / total;
-        let bar_len = if max_vuln_count > 0 {
-            (count * bar_width) / max_vuln_count
-        } else {
-            0
-        };
+        let bar_len = (count * bar_width).checked_div(max_vuln_count).unwrap_or(0);
         let bar = "█".repeat(bar_len);
         lines.push(Line::from(vec![
             Span::styled(format!("  {label:12}"), Style::default().fg(*color)),
@@ -1255,11 +1247,7 @@ fn render_component_stats_panel(frame: &mut Frame, area: Rect, app: &ViewApp, bo
                 continue;
             }
             let pct = (count * 100) / total;
-            let bar_len = if max_eol_count > 0 {
-                (count * bar_width) / max_eol_count
-            } else {
-                0
-            };
+            let bar_len = (count * bar_width).checked_div(max_eol_count).unwrap_or(0);
             let bar = "█".repeat(bar_len);
             lines.push(Line::from(vec![
                 Span::styled(format!("  {label:12}"), Style::default().fg(*color)),
@@ -1363,11 +1351,7 @@ fn render_group_stats_panel(
         if count == 0 {
             continue;
         }
-        let bar_len = if max_vuln > 0 {
-            (count * bar_width) / max_vuln
-        } else {
-            0
-        };
+        let bar_len = (count * bar_width).checked_div(max_vuln).unwrap_or(0);
         lines.push(Line::from(vec![
             Span::styled(format!("  {label:12}"), Style::default().fg(*color)),
             Span::styled(format!("{count:>5} "), Style::default().fg(scheme.text)),
@@ -1411,11 +1395,7 @@ fn render_group_stats_panel(
             if count == 0 {
                 continue;
             }
-            let bar_len = if max_eol > 0 {
-                (count * bar_width) / max_eol
-            } else {
-                0
-            };
+            let bar_len = (count * bar_width).checked_div(max_eol).unwrap_or(0);
             lines.push(Line::from(vec![
                 Span::styled(format!("  {label:12}"), Style::default().fg(*color)),
                 Span::styled(format!("{count:>5} "), Style::default().fg(scheme.text)),
@@ -1432,7 +1412,7 @@ fn render_group_stats_panel(
         .filter(|c| !c.vulnerabilities.is_empty())
         .map(|c| (c.name.as_str(), c.vulnerabilities.len()))
         .collect();
-    vuln_comps.sort_by(|a, b| b.1.cmp(&a.1));
+    vuln_comps.sort_by_key(|a| std::cmp::Reverse(a.1));
 
     if !vuln_comps.is_empty() {
         lines.push(Line::styled(

--- a/src/tui/view/views/vulnerabilities.rs
+++ b/src/tui/view/views/vulnerabilities.rs
@@ -351,11 +351,9 @@ fn render_severity_card(
     };
 
     let bar_width = (area.width.saturating_sub(4)) as usize;
-    let filled = if total > 0 {
-        (count * bar_width / total).max(usize::from(count > 0))
-    } else {
-        0
-    };
+    let filled = (count * bar_width)
+        .checked_div(total)
+        .map_or(0, |v| v.max(usize::from(count > 0)));
 
     let mut lines = vec![Line::from(vec![Span::styled(
         format!(" {label} "),
@@ -681,7 +679,7 @@ fn group_affected_components(
     }
 
     let mut sorted: Vec<_> = groups.into_iter().collect();
-    sorted.sort_by(|a, b| b.1.cmp(&a.1)); // Most frequent first
+    sorted.sort_by_key(|a| std::cmp::Reverse(a.1)); // Most frequent first
     sorted
 }
 
@@ -1016,7 +1014,7 @@ pub(crate) fn build_vuln_cache(app: &ViewApp) -> VulnCache {
             *comp_counts.entry(v.display_name.clone()).or_insert(0) += 1;
         }
         let mut sorted: Vec<_> = comp_counts.into_iter().collect();
-        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted.sort_by_key(|a| std::cmp::Reverse(a.1));
         sorted
     };
 
@@ -2071,7 +2069,7 @@ fn render_group_detail_panel(
         }
         if !cwe_counts.is_empty() {
             let mut cwe_sorted: Vec<_> = cwe_counts.into_iter().collect();
-            cwe_sorted.sort_by(|a, b| b.1.cmp(&a.1));
+            cwe_sorted.sort_by_key(|a| std::cmp::Reverse(a.1));
             lines.push(Line::from(""));
             lines.push(Line::styled("Top CWEs:", Style::default().fg(scheme.muted)));
             for (cwe, cnt) in cwe_sorted.iter().take(5) {

--- a/src/tui/views/licenses.rs
+++ b/src/tui/views/licenses.rs
@@ -702,7 +702,7 @@ fn render_compatibility_panel(frame: &mut Frame, area: Rect, ctx: &RenderContext
     ));
 
     let mut families: Vec<_> = report.families.iter().collect();
-    families.sort_by(|a, b| b.1.len().cmp(&a.1.len()));
+    families.sort_by_key(|a| std::cmp::Reverse(a.1.len()));
 
     for (family, licenses) in families.iter().take(6) {
         lines.push(Line::from(vec![
@@ -775,7 +775,7 @@ fn build_license_list(
     // Apply sorting
     match sort {
         LicenseSort::License => entries.sort_by(|a, b| a.license.cmp(&b.license)),
-        LicenseSort::Count => entries.sort_by(|a, b| b.components.len().cmp(&a.components.len())),
+        LicenseSort::Count => entries.sort_by_key(|a| std::cmp::Reverse(a.components.len())),
         LicenseSort::Permissiveness => {
             entries.sort_by(|a, b| {
                 a.category
@@ -784,7 +784,7 @@ fn build_license_list(
             });
         }
         LicenseSort::Risk => {
-            entries.sort_by(|a, b| b.risk_level.cmp(&a.risk_level));
+            entries.sort_by_key(|a| std::cmp::Reverse(a.risk_level));
         }
     }
 
@@ -801,7 +801,7 @@ fn build_license_list(
             });
         }
         LicenseGroupBy::Risk => {
-            entries.sort_by(|a, b| b.risk_level.cmp(&a.risk_level));
+            entries.sort_by_key(|a| std::cmp::Reverse(a.risk_level));
         }
         _ => {} // License and Component grouping use default sort
     }


### PR DESCRIPTION
CI lints on the pinned 1.88 toolchain, so `main` is clean there, but current stable clippy (1.98) reports 34 findings that would block the Lint job the day `rust-toolchain.toml` moves. This clears them so a future toolchain bump is a one-line change.

| Lint | Count | Rewrite |
|---|---:|---|
| `manual_checked_div` | 13 | `if d > 0 { n / d } else { 0 }` → `n.checked_div(d).unwrap_or(0)` |
| `unnecessary_sort_by` | 13 | `sort_by(\|a, b\| b.k.cmp(&a.k))` → `sort_by_key(\|a\| Reverse(a.k))` (both stable sorts; order unchanged) |
| `collapsible_match` / `collapsible_if` | 6 | inner `if` folded into a match guard / let-chain (edition 2024, fine on 1.88) |
| `unneeded_wildcard_pattern`, `while_let_loop` | 2 | as suggested |

No behaviour change. 16 files, +76 / −125.

**Verification:** clippy 1.88 (CI invocation, default and all-features) clean; clippy 1.98 all-features clean; fmt clean; full suite 2450 passed / 0 failed (all features), including the TUI snapshot tests that would catch a sort-order change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dVZ9LY4MJH5iFji7kyXr1
