### PR TITLE
docs: state the JSON output contract and its limits (#362)

### DIFF
--- a/README.md
+++ b/README.md
@@ -780,6 +780,39 @@ operational error (exit `3`), before any SBOM is read, naming the formats they
 do accept (`validate --summary` is the exception — it overrides `-o` outright,
 so no format is gated).
 
+### JSON output contract
+
+Which JSON payloads are a compatibility contract, and how firm it is
+(pre-1.0):
+
+- **Contractual payloads.** The normalized SBOM, diff results, and quality
+  reports, as emitted by the C ABI (`sbom_tools_parse_sbom_*_json`,
+  `sbom_tools_diff_*`, `sbom_tools_score_*`) and by the language bindings, and
+  the `-o json` output of `diff`, `diff-multi`, `matrix`, `timeline`,
+  `validate`, and `quality`. Field names are `snake_case` with no serde
+  renames; `Option` fields serialize as `null`, except a few additive blocks
+  (e.g. `crypto_properties`, `ml_model`-adjacent extensions) that are omitted
+  when absent.
+- **`view -o json` is a projection, not the normalized model.** It emits a
+  `summary` block plus, per component, `name`, `version`, `ecosystem`,
+  `licenses`, `supplier`, `dependency_kind`, `vulnerability_count`,
+  `vulnerabilities[]`, and optional EOL fields. Domain detail such as
+  `crypto_properties`, `ml_model`, or `dataset` is **not** included; the full
+  normalized document is available only through the ABI and bindings.
+- **What is test-pinned.** The ABI snapshot tests pin the top-level keys of
+  each payload (`tests/fixtures/abi/contract_required_keys.json`) and the
+  numeric scales (`semantic_score` 0–100, similarity and deviation 0–1).
+  Nested shape is covered by behaviour tests but is not frozen by a schema.
+- **No separate schema version.** The payload shape follows the crate version.
+  Until 1.0 a breaking change may land in a minor release and is always listed
+  under **Upgrade notes** in `CHANGELOG.md`; consumers should pin the crate
+  version and read those notes on each bump.
+- **Known conflation.** In the CycloneDX parser an absent
+  `cryptoProperties.algorithmProperties.primitive` and an explicit
+  `"unknown"` both normalize to `primitive: "Unknown"`. A consumer that must
+  tell "omitted" from "declared unknown" should read the raw CycloneDX
+  document, which is the stable contract for that distinction.
+
 ## CI/CD Integration
 
 Use sbom-tools in CI pipelines to gate deployments on SBOM changes, new vulnerabilities, or quality regressions.

--- a/docs/PROJECT_BRIEF.md
+++ b/docs/PROJECT_BRIEF.md
@@ -67,6 +67,15 @@ behavior rather than implement independent parsing or analysis rules.
   `DiffResult.semantic_score` is 0-100, `MatrixResult` similarity is 0-1
   (`semantic_score / 100`), and `diff-multi` deviation is 0-1
   (`1 - similarity`).
+- The contract is pinned at the top-level keys of each payload and the
+  numeric scales; nested shape follows the crate version, and pre-1.0 a
+  breaking change may land in a minor release with an entry under **Upgrade
+  notes** in `CHANGELOG.md`. There is no separate JSON schema version.
+- `view -o json` is a curated projection (summary + per-component identity,
+  licenses, supplier, dependency kind, vulnerabilities, EOL). The full
+  normalized model, including `crypto_properties`, `ml_model`, and `dataset`,
+  is exposed only through the ABI parse functions and the bindings. See
+  "JSON output contract" in the README.
 
 ## Non-goals and ownership boundary
 


### PR DESCRIPTION
Refs #362, where a downstream consumer asked whether `view -o json` is a stable contract, whether the normalized crypto fields are guaranteed present, and whether the payload shape is versioned separately from the crate. The answers were all discoverable only from source; this writes them down.

## Changes (docs only)

**README → Output Formats → new "JSON output contract" subsection**

- Which payloads are contractual: the ABI/bindings normalized SBOM, diff, and quality payloads, and the `-o json` output of `diff`, `diff-multi`, `matrix`, `timeline`, `validate`, `quality`. `snake_case`, no serde renames, `Option` → `null` except a few additive blocks omitted when absent.
- `view -o json` is a curated projection (`summary` + per-component identity, licenses, supplier, dependency kind, vulnerabilities, EOL). No `crypto_properties` / `ml_model` / `dataset`; the full normalized model is reachable only via the ABI parse functions and the bindings.
- What is test-pinned: top-level keys (`tests/fixtures/abi/contract_required_keys.json`) and numeric scales. Nested shape is behaviour-tested, not schema-frozen.
- No separate schema version: shape follows the crate version; pre-1.0 a breaking change may land in a minor release and is listed under **Upgrade notes** in `CHANGELOG.md`.
- Known conflation: absent CycloneDX `primitive` and explicit `"unknown"` both normalize to `Unknown`; read the raw document if that distinction matters.

**docs/PROJECT_BRIEF.md → Interface contract**: two bullets summarising the pinning boundary and the `view -o json` projection, pointing at the README section.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dVZ9LY4MJH5iFji7kyXr1
