### PR TITLE
chore(deps): bump dirs from 6.0.0 to 7.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+checksum = "8d57d423b3c82e89b9a24ca3091fee61f456a26edbd28d26c65906f4bc1dcd8f"
 dependencies = [
  "dirs-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 indexmap = { version = "2.14", features = ["serde"] }
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
-dirs = "6.0.0"
+dirs = "7.0.0"
 unicode-width = "0.2"
 schemars = "1.2"
 


### PR DESCRIPTION
Clears the only "outdated" entry on [deps.rs](https://deps.rs/repo/github/sbom-tool/sbom-tools).

dirs 7.0.0 (released 2026-09-05) has a single breaking change: `preference_dir` on Windows now resolves to the roaming AppData folder instead of the local one. sbom-tools only calls `home_dir()` and `config_dir()`, so nothing observable changes.

- Cargo.toml `dirs = "7.0.0"`, Cargo.lock `dirs 6.0.0 → 7.0.0`; same `dirs-sys 0.5`, no new transitive crates.
- Full suite green on the pinned 1.88 toolchain (all features).
- Dependabot would have opened this as a separate major-bump PR after its five-day cooldown; this just brings it forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013dVZ9LY4MJH5iFji7kyXr1
